### PR TITLE
Improved Linux platform support & some tweaks/fixes

### DIFF
--- a/source/Miniscope-DAQ-QT-Software.pro
+++ b/source/Miniscope-DAQ-QT-Software.pro
@@ -74,19 +74,22 @@ HEADERS += \
 
 DISTFILES +=
 
+win32 {
+    LIBS += -L$$PWD/../../../../../../../opencv-build420/lib/Release/ -lopencv_world420
+    #LIBS += -L$$PWD/../../../../../../../opencv-build420/lib/Debug/ -lopencv_world420d
 
-LIBS += -L$$PWD/../../../../../../../opencv-build420/lib/Release/ -lopencv_world420
-#LIBS += -L$$PWD/../../../../../../../opencv-build420/lib/Debug/ -lopencv_world420d
+    #win32:CONFIG(release, debug|release): LIBS += -L$$PWD/../../../../../../../opencv-build420/install/x64/vc15/lib/ -lopencv_world420
+    ##win32:CONFIG(release, debug|release): LIBS += -L$$PWD/../../../../../../../opencv-build420/install/x64/vc15/lib/ -lopencv_videoio_ffmpeg420_64
+    #else:win32:CONFIG(debug, debug|release): LIBS += -L$$PWD/../../../../../../../opencv-build420/install/x64/vc15/lib/ -lopencv_world420d
 
-#win32:CONFIG(release, debug|release): LIBS += -L$$PWD/../../../../../../../opencv-build420/install/x64/vc15/lib/ -lopencv_world420
-##win32:CONFIG(release, debug|release): LIBS += -L$$PWD/../../../../../../../opencv-build420/install/x64/vc15/lib/ -lopencv_videoio_ffmpeg420_64
-#else:win32:CONFIG(debug, debug|release): LIBS += -L$$PWD/../../../../../../../opencv-build420/install/x64/vc15/lib/ -lopencv_world420d
+    #LIBS += -L$$PWD/../../../../../../../opencv-build420/install/x64/vc15/lib/ -lopencv_world420
 
-#LIBS += -L$$PWD/../../../../../../../opencv-build420/install/x64/vc15/lib/ -lopencv_world420
-
-INCLUDEPATH += $$PWD/../../../../../../../opencv/build/include
-#DEPENDPATH += $$PWD/../../../../../../../opencv-build420/install/include
-
+    INCLUDEPATH += $$PWD/../../../../../../../opencv/build/include
+    #DEPENDPATH += $$PWD/../../../../../../../opencv-build420/install/include
+} else {
+    CONFIG += link_pkgconfig
+    PKGCONFIG += opencv4
+}
 
 # Move user and device configs to build directory
 copydata.commands = $(COPY_DIR) \"$$shell_path($$PWD\\..\\deviceConfigs)\" \"$$shell_path($$OUT_PWD\\deviceConfigs)\"
@@ -97,4 +100,3 @@ export(copydata.commands)
 export(copydata2.commands)
 
 QMAKE_EXTRA_TARGETS += first copydata copydata2
-

--- a/source/datasaver.cpp
+++ b/source/datasaver.cpp
@@ -179,8 +179,12 @@ void DataSaver::startRunning()
 void DataSaver::startRecording()
 {
     if (baseDirectory.isEmpty()) {
-        qWarning() << "Could not start recording since the base directory is empty.";
-        return;
+        setupBaseDirectory();
+        // give up if a base directory still can not be found
+        if (baseDirectory.isEmpty()) {
+            qWarning() << "Could not start recording since the base directory is empty.";
+            return;
+        }
     }
 
     QJsonDocument jDoc;

--- a/source/datasaver.cpp
+++ b/source/datasaver.cpp
@@ -243,6 +243,8 @@ void DataSaver::startRecording()
 
 void DataSaver::stopRecording()
 {
+    if (!m_recording)
+        return;
     m_recording = false;
     QStringList keys = videoWriter.keys();
     for (int i = 0; i < keys.length(); i++) {

--- a/source/datasaver.cpp
+++ b/source/datasaver.cpp
@@ -114,6 +114,11 @@ void DataSaver::setupBaseDirectory()
 
 void DataSaver::startRunning()
 {
+    if (m_running) {
+        qCritical() << "Tried to run a DataSaver that was already running.";
+        return;
+    }
+
     m_running = true;
     int i;
     int bufPosition;

--- a/source/datasaver.cpp
+++ b/source/datasaver.cpp
@@ -19,7 +19,6 @@
 #include <QTextStream>
 #include <QVariant>
 #include <QMetaType>
-#include <QMessageBox>
 
 DataSaver::DataSaver(QObject *parent) :
     QObject(parent),

--- a/source/datasaver.cpp
+++ b/source/datasaver.cpp
@@ -19,6 +19,7 @@
 #include <QTextStream>
 #include <QVariant>
 #include <QMetaType>
+#include <QMessageBox>
 
 DataSaver::DataSaver(QObject *parent) :
     QObject(parent),
@@ -172,8 +173,12 @@ void DataSaver::startRunning()
 
 void DataSaver::startRecording()
 {
-    QJsonDocument jDoc;
+    if (baseDirectory.isEmpty()) {
+        qWarning() << "Could not start recording since the base directory is empty.";
+        return;
+    }
 
+    QJsonDocument jDoc;
     recordStartDateTime = QDateTime::currentDateTime();
     setupFilePaths();
     // TODO: Save meta data JSONs

--- a/source/main.qml
+++ b/source/main.qml
@@ -264,6 +264,7 @@ Window {
         }
 
     }
+
     Connections{
         target: backend
         onShowErrorMessage: errorMessageDialog.visible = true
@@ -272,5 +273,8 @@ Window {
         target: backend
         onShowErrorMessageCompression: errorMessageDialogCompression.visible = true
     }
+    Component.onCompleted: {
+        setX(Screen.width / 2 - width / 2);
+        setY(Screen.height / 2 - height / 2);
+    }
 }
-

--- a/source/videostreamocv.cpp
+++ b/source/videostreamocv.cpp
@@ -36,13 +36,25 @@ int VideoStreamOCV::connect2Camera(int cameraID) {
     int connectionState = 0;
     m_cameraID = cameraID;
     cam = new cv::VideoCapture;
+
+    auto apiPreference = cv::CAP_ANY;
+    QString apiName = "OTHER";
+#ifdef Q_OS_LINUX
+    apiPreference = cv::CAP_V4L2;
+    apiName = QStringLiteral("V4L");
+#elif defined(Q_OS_WINDOWS)
     // Try connecting using DShow backend
-    if (cam->open(m_cameraID, cv::CAP_DSHOW)) {
+    apiPreference = cv::CAP_DSHOW;
+    apiName = QStringLiteral("DSHOW");
+#endif
+
+    if (cam->open(m_cameraID, apiPreference)) {
+        // we got our preferred backend!
         connectionState = 1;
-        m_connectionType = "DSHOW";
+        m_connectionType = apiName;
     }
     else {
-        // connecting again using defaulk backend
+        // connecting again using default backend
         if (cam->open(m_cameraID)) {
             connectionState = 2;
             m_connectionType = "OTHER";


### PR DESCRIPTION
Hi!
Thank you for writing this software! I originally just wanted to include improved Linux support in this PR, but picked up a few other changes along the way. This PR changes the following:
 * QMake now uses [pkg-config](https://en.wikipedia.org/wiki/Pkg-config) on Linux to find OpenCV which pretty much means you'll be able to instantly build the software on Linux without any include/link path tweaking as long as OpenCV is installed
 * The main window will now be centered on screen (it bothered me to always have all windows right at the top left screen edge)
 * The V4L backend is preferred on Linux, DirectShow is preferred on Windows (based on my own experience with GStreamer on Linux not liking the older DAQ board firmware - the new one doesn't appear to have the same issue, but better be safe. Usually V4L will be picked up automatically anyway) The app also won't even try DirectShow on Linux now, as that will never be found anyway.
 * Don't try to record if the user has forgotten to set a data base directory, otherwise the software will crash or write to arbitrary places (this may have happened to me after mistyping the JSON key... ^^)
 * Various crash fixes if the user managed to request nonsensical actions via the UI

I hope you'll find this useful! Please check if the Windows build still works - as far as I know, the WIN32 condition also covers 64-bit Windows, so Windows builds should be unaffected by this change, but better be sure.
Cheers,
    Matthias

Edit: Since this application is using QML, and QML is known to be a bit cumbersome on desktops and bigger screens, it may be interesting for you to look into [Kirigami](https://kde.org/products/kirigami/) if you don't know that already and have a new project that uses QML. Kirigami is a responsive QML component framework providing basic types and shapes that integrate well with the desktop environment or mobile UI and is available on all major platforms.
