### PR TITLE
Expand v4 `led0` range to 0..255

### DIFF
--- a/deviceConfigs/videoDevices.json
+++ b/deviceConfigs/videoDevices.json
@@ -310,10 +310,10 @@
             "led0": {
                 "startValue": 0,
                 "min": 0,
-                "max": 100,
+                "max": 255,
                 "stepSize": 1,
-                "displayValueScale": -2.55,
-                "displayValueOffset": -255,
+                "displayValueScale": 1,
+                "displayValueOffset": 255,
                 "sendCommand": [
                     {
                         "protocol": "I2C",
@@ -523,10 +523,10 @@
             "led0": {
                 "startValue": 0,
                 "min": 0,
-                "max": 100,
+                "max": 255,
                 "stepSize": 1,
-                "displayValueScale": -2.55,
-                "displayValueOffset": -255,
+                "displayValueScale": 1,
+                "displayValueOffset": 255,
                 "sendCommand": [
                     {
                         "protocol": "I2C",


### PR DESCRIPTION
Related to:
- https://github.com/Aharoni-Lab/Miniscope-DAQ-QT-Software/issues/68
- https://github.com/Aharoni-Lab/Miniscope-v4/issues/37#issuecomment-1922748249

## Problem

Some lucky people have such lovely bright and clear signal that they need to make the illumination LED as dim as possible. 

The current `led0` configuration maps `0..100` -> `0..255`, which naturally reduces the number of possible brightness states from 256 to 101, the relevant line in the software is here:

https://github.com/Aharoni-Lab/Miniscope-DAQ-QT-Software/blob/0fecb97cca82c694b1b40dde03cd759e23ad3224/source/VideoSliderControl.qml#L73

So for the current settings:
- `displayValueScale`: `-2.55`
- `displayValueOffset`: `-255`

the value map created is:

<details>
<summary>Expand/collapse value map</summary>

|   input |   output |
|--------:|---------:|
|       0 |      255 |
|       1 |      252 |
|       2 |      250 |
|       3 |      247 |
|       4 |      245 |
|       5 |      242 |
|       6 |      240 |
|       7 |      237 |
|       8 |      235 |
|       9 |      232 |
|      10 |      230 |
|      11 |      227 |
|      12 |      224 |
|      13 |      222 |
|      14 |      219 |
|      15 |      217 |
|      16 |      214 |
|      17 |      212 |
|      18 |      209 |
|      19 |      207 |
|      20 |      204 |
|      21 |      201 |
|      22 |      199 |
|      23 |      196 |
|      24 |      194 |
|      25 |      191 |
|      26 |      189 |
|      27 |      186 |
|      28 |      184 |
|      29 |      181 |
|      30 |      178 |
|      31 |      176 |
|      32 |      173 |
|      33 |      171 |
|      34 |      168 |
|      35 |      166 |
|      36 |      163 |
|      37 |      161 |
|      38 |      158 |
|      39 |      156 |
|      40 |      153 |
|      41 |      150 |
|      42 |      148 |
|      43 |      145 |
|      44 |      143 |
|      45 |      140 |
|      46 |      138 |
|      47 |      135 |
|      48 |      133 |
|      49 |      130 |
|      50 |      128 |
|      51 |      125 |
|      52 |      122 |
|      53 |      120 |
|      54 |      117 |
|      55 |      115 |
|      56 |      112 |
|      57 |      110 |
|      58 |      107 |
|      59 |      105 |
|      60 |      102 |
|      61 |       99 |
|      62 |       97 |
|      63 |       94 |
|      64 |       92 |
|      65 |       89 |
|      66 |       87 |
|      67 |       84 |
|      68 |       82 |
|      69 |       79 |
|      70 |       76 |
|      71 |       74 |
|      72 |       71 |
|      73 |       69 |
|      74 |       66 |
|      75 |       64 |
|      76 |       61 |
|      77 |       59 |
|      78 |       56 |
|      79 |       54 |
|      80 |       51 |
|      81 |       48 |
|      82 |       46 |
|      83 |       43 |
|      84 |       41 |
|      85 |       38 |
|      86 |       36 |
|      87 |       33 |
|      88 |       31 |
|      89 |       28 |
|      90 |       26 |
|      91 |       23 |
|      92 |       20 |
|      93 |       18 |
|      94 |       15 |
|      95 |       13 |
|      96 |       10 |
|      97 |        8 |
|      98 |        5 |
|      99 |        3 |
|     100 |        0 |

</details>

## Fix

That seems to only really be a problem on the low end, where someone could access 2/3 and 1/3 of the current minimum brightness. 

The reason for wanting to constrain from 0..100 is to make proportions sensible - 100% brightness is more intuitive than the max being 255, but it seems like at the point that it's limiting functionality it might be worth expanding to the full range. 

This PR is just one way of doing this without needing to recompile anything. It changes the range to 0..255, the scale to 1, and the offset to `255` for a map of `(x*1)-255` 

### Other options

- make another directory `examples` with a `README.md` document in it, where we make this modified deviceConfig file an example with the full LED range and explain what it does in the README
- make the StepSize smaller, like `0.1` or something - this would keep the 0..100 range while allowing someone to access the full 0..255 output range, but imo it's somewhat undesirable because a lot of changes to float values would actually not change the output value at all, which would lead to bad intuition traps trying to micro-adjust values that aren't actually doing anything.
- make another v4 device config something like `v4_full_led0_range` - but that seems undesirable because we get into combinatorics of "for every variant we square the number of devices we have"
- ideally this would be something one could toggle in the UI, but that's about a thousand times more work than changing 4 lines in the config for now ;)

Anyway what do ya think?