### PR TITLE
Qt6 port + reproducible Windows build/installer + config & UX enhancements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,143 @@
+# Build the standalone Windows distribution and publish it as a GitHub Release.
+#
+# Triggers:
+#   * push a tag like v1.10  -> builds and creates/updates a Release with both
+#                               the installer (.exe) and the portable zip
+#   * manual "Run workflow"  -> builds and uploads both as run artifacts only
+#
+# The build mirrors the local recipe (conda env from environment.yml, MSVC, then
+# the `deploy` target which bundles every dependency into build/Release/ itself -
+# launcher + configs at the top, real exe + DLLs in bin/). One deliberate
+# difference: CI configures with the Ninja generator instead of the local
+# "Visual Studio 17 2022" generator, because the conda cmake can't discover the
+# runner's VS instance through the VS generator. CMakeLists is generator-agnostic
+# and the output tree is identical, so this is transparent to deploy/zip/installer.
+# deploy.py verifies the bundle and exits non-zero if any conda dependency is
+# missing, so a broken bundle fails the job.
+#
+# Two artifacts ship from that one bundle:
+#   * MiniscopeDAQ-<ver>-Setup.exe  - per-user Inno Setup installer (no admin;
+#     Start Menu + optional desktop shortcut + uninstaller). See installer/.
+#   * MiniscopeDAQ-<ver>-Windows-x64.zip - the same bundle, unzip-and-run.
+#
+# NOTE: not yet validated on GitHub's runners - the first tag push / manual run
+# will shake out any runner-specific issues (conda activation, solve time).
+name: Build & Release (Windows)
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write          # needed to create the Release on tag pushes
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: pwsh        # matches the local PowerShell build recipe
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up conda env (Miniforge + environment.yml)
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-version: latest
+          environment-file: environment.yml
+          activate-environment: miniscope-qt6
+          auto-activate-base: false
+
+      # Put the MSVC x64 toolchain (cl.exe + INCLUDE/LIB) on PATH for the build
+      # steps below. We build with the Ninja generator rather than the
+      # "Visual Studio 17 2022" generator because the conda-provided cmake fails
+      # to locate the runner's VS instance through the VS generator
+      # ("could not find any instance of Visual Studio"); Ninja just invokes the
+      # cl.exe this step exposes, so no VS-instance discovery is needed. The
+      # output tree (build/Release/ - launcher + configs on top, exe + DLLs in
+      # bin/) is identical to the local VS-generator build, so deploy/zip/
+      # installer downstream are unaffected. conda provides cmake + ninja.
+      - name: Set up MSVC toolchain (x64)
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      - name: Configure (CMake + Ninja + MSVC)
+        run: >
+          cmake -B build -S . -G Ninja
+          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_PREFIX_PATH="$env:CONDA_PREFIX/Library"
+          -DPython3_EXECUTABLE="$env:CONDA_PREFIX/python.exe"
+          -DUSE_PYTHON=ON
+
+      - name: Build (Release)
+        run: cmake --build build --config Release
+
+      - name: Deploy standalone bundle (into build/Release/)
+        run: cmake --build build --config Release --target deploy
+
+      - name: Package the release folder into a zip
+        run: |
+          $name = if ($env:GITHUB_REF_TYPE -eq 'tag') { "MiniscopeDAQ-$env:GITHUB_REF_NAME-Windows-x64.zip" } else { "MiniscopeDAQ-Windows-x64.zip" }
+          Compress-Archive -Path build/Release/* -DestinationPath $name -Force
+          "ZIP_NAME=$name" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "Built $name"
+
+      - name: Build installer (Inno Setup)
+        run: |
+          # The version shown in the app's Help and in "Add or Remove Programs"
+          # comes straight from the app itself (source/main.cpp:
+          # #define VERSION_NUMBER "x.y"), so the installer label always matches
+          # what the running app reports - regardless of tag vs manual trigger.
+          $m = Select-String -Path source/main.cpp -Pattern '#define\s+VERSION_NUMBER\s+"([^"]+)"'
+          if (-not $m) { throw "VERSION_NUMBER not found in source/main.cpp" }
+          $ver = $m.Matches[0].Groups[1].Value
+          "App version (from main.cpp): $ver"
+
+          # The release-artifact FILE name still tracks the git tag (or a generic
+          # name for manual runs) so each tagged release stays identifiable; only
+          # the in-installer version label is sourced from the app above.
+          if ($env:GITHUB_REF_TYPE -eq 'tag') {
+            $base = "MiniscopeDAQ-$env:GITHUB_REF_NAME-Setup"
+          } else {
+            $base = "MiniscopeDAQ-Setup"
+          }
+
+          # Locate the Inno Setup compiler: it ships on the windows runner image
+          # but isn't always on PATH; fall back to the default path, then choco.
+          $iscc = (Get-Command iscc.exe -ErrorAction SilentlyContinue).Source
+          if (-not $iscc) {
+            $default = "C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
+            if (Test-Path $default) { $iscc = $default }
+            else { choco install innosetup -y --no-progress; $iscc = $default }
+          }
+          "Using ISCC: $iscc"
+
+          $src = (Resolve-Path build/Release).Path
+          $out = (Resolve-Path .).Path
+          & $iscc "/DMyAppVersion=$ver" "/DMySourceDir=$src" "/DMyOutputDir=$out" "/DMyOutputBaseName=$base" installer/MiniscopeDAQ.iss
+          if ($LASTEXITCODE -ne 0) { throw "Inno Setup compile failed ($LASTEXITCODE)" }
+
+          "INSTALLER_NAME=$base.exe" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "Built $base.exe"
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: MiniscopeDAQ-Windows-x64
+          path: |
+            ${{ env.ZIP_NAME }}
+            ${{ env.INSTALLER_NAME }}
+          retention-days: 14
+
+      - name: Publish Release (tag pushes only)
+        if: github.ref_type == 'tag'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            ${{ env.ZIP_NAME }}
+            ${{ env.INSTALLER_NAME }}
+          generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,12 @@ Thumbs.db
 # Builds
 build-*
 
+# CMake build directory + artifacts
+/build/
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+
 # Binaries
 # --------
 *.dll

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,198 @@
+# ---------------------------------------------------------------------------
+# Miniscope-DAQ-QT-Software  -  Qt6 / CMake build
+#
+# This replaces the old qmake .pro file. It is written to be *reproducible*:
+# nothing is hard-coded to a particular machine. Point CMake at your toolchain
+# with the standard variables, e.g.:
+#
+#   cmake -B build -S . ^
+#     -DCMAKE_PREFIX_PATH="C:/Qt/6.5.3/msvc2019_64;C:/opencv/build" ^
+#     -DPython3_ROOT_DIR="C:/Python311"
+#   cmake --build build --config Release
+#
+# Toggle the DeepLabCut-Live behaviour tracker (embedded Python + numpy) with
+#   -DUSE_PYTHON=ON|OFF        (default ON)
+# ---------------------------------------------------------------------------
+cmake_minimum_required(VERSION 3.21)
+
+project(MiniscopeDAQ VERSION 2.0 LANGUAGES CXX)
+
+option(USE_PYTHON "Build the DeepLabCut-Live behaviour tracker (embedded Python)" ON)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)   # compiles source/qml.qrc automatically
+
+# --- Qt6 -------------------------------------------------------------------
+# Note the OpenGL component: in Qt6, QOpenGLShaderProgram / QOpenGLBuffer /
+# QOpenGLFramebufferObject moved out of QtGui into the separate Qt6::OpenGL
+# module. The custom renderers (videodisplay, tracedisplay, behaviortracker)
+# need it.
+find_package(Qt6 6.5 REQUIRED COMPONENTS Core Gui Qml Quick QuickControls2 Widgets OpenGL)
+qt_standard_project_setup(REQUIRES 6.5)
+
+# This project has no .ui files (the UI is all QML), so AUTOUIC is unnecessary.
+# qt_standard_project_setup() turns it on, so turn it back off here.
+set(CMAKE_AUTOUIC OFF)
+
+# --- OpenCV ----------------------------------------------------------------
+find_package(OpenCV REQUIRED)
+
+# --- Sources ---------------------------------------------------------------
+set(SOURCES
+    source/backend.cpp
+    source/behaviorcam.cpp
+    source/behaviortracker.cpp
+    source/behaviortrackerworker.cpp
+    source/controlpanel.cpp
+    source/datasaver.cpp
+    source/main.cpp
+    source/miniscope.cpp
+    source/newquickview.cpp
+    source/tracedisplay.cpp
+    source/videodevice.cpp
+    source/videodisplay.cpp
+    source/videostreamocv.cpp
+)
+
+set(HEADERS
+    source/backend.h
+    source/behaviorcam.h
+    source/behaviortracker.h
+    source/behaviortrackerworker.h
+    source/controlpanel.h
+    source/datasaver.h
+    source/miniscope.h
+    source/newquickview.h
+    source/tracedisplay.h
+    source/videodevice.h
+    source/videodisplay.h
+    source/videostreamocv.h
+)
+
+qt_add_executable(MiniscopeDAQ
+    ${SOURCES}
+    ${HEADERS}
+    source/qml.qrc
+)
+
+# conda-forge's qmlimportscanner can fail to launch (exit 0xc0000139) during
+# the automatic QML import scan that Qt runs at target finalization. That scan
+# only produces QML *plugin deployment* hints and is not needed to build or to
+# run from the conda env, so skip it.
+set_target_properties(MiniscopeDAQ PROPERTIES QT_QML_MODULE_NO_IMPORT_SCAN ON)
+
+# Windows: GUI app (no console) + application icon, replacing qmake RC_ICONS.
+if(WIN32)
+    set_target_properties(MiniscopeDAQ PROPERTIES WIN32_EXECUTABLE ON)
+
+    # Make build/<config>/ itself the portable release. The real exe (and, after
+    # the `deploy` target runs, all its DLLs / Qt plugins / QML) lives in a bin/
+    # subfolder, leaving the top of build/<config>/ for just the launcher and the
+    # configs. So the folder a user opens IS the double-clickable release - no
+    # nested dist/, no loose dev exe that fails to launch. The genexp keeps the
+    # multi-config generator from appending a second per-config subdir (so the exe
+    # lands in build/Release/bin, not build/Release/bin/Release). See
+    # tools/launcher.cpp + tools/deploy.py.
+    set(MINISCOPE_RELEASE_TOP "${CMAKE_BINARY_DIR}/$<CONFIG>")
+    set_target_properties(MiniscopeDAQ PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${MINISCOPE_RELEASE_TOP}/bin")
+    set(APP_ICON_RC "${CMAKE_CURRENT_BINARY_DIR}/appicon.rc")
+    file(WRITE "${APP_ICON_RC}"
+         "IDI_ICON1 ICON \"${CMAKE_CURRENT_SOURCE_DIR}/source/miniscope_icon.ico\"\n")
+    target_sources(MiniscopeDAQ PRIVATE "${APP_ICON_RC}")
+
+    # Tiny launcher that becomes dist/MiniscopeDAQ.exe: it keeps the top of the
+    # distribution to a single loose file (the executable) and runs
+    # bin/MiniscopeDAQ.exe with the working dir set to the top, so the DLL clutter
+    # hides in bin/ while the configs stay visible at the top (see
+    # tools/launcher.cpp + tools/deploy.py). Built into a side folder, NOT
+    # build/Release, so the build output dir stays uncluttered; deploy.py picks it
+    # up via its CMake target-file path.
+    add_executable(MiniscopeLauncher WIN32 tools/launcher.cpp "${APP_ICON_RC}")
+    set_target_properties(MiniscopeLauncher PROPERTIES
+        OUTPUT_NAME "MiniscopeDAQ-launcher"
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/launcher")
+
+    # DirectShow video-device enumeration (backEnd::scanVideoDevices): strmiids
+    # provides the CLSID/IID symbols, ole32/oleaut32 the COM + VARIANT helpers.
+    target_link_libraries(MiniscopeDAQ PRIVATE strmiids ole32 oleaut32)
+else()
+    # No bin/ split off-Windows (no launcher/deploy target there yet): the configs
+    # sit next to the exe, exactly as before.
+    set(MINISCOPE_RELEASE_TOP "$<TARGET_FILE_DIR:MiniscopeDAQ>")
+endif()
+
+target_include_directories(MiniscopeDAQ PRIVATE
+    source
+    ${OpenCV_INCLUDE_DIRS}
+)
+
+target_link_libraries(MiniscopeDAQ PRIVATE
+    Qt6::Core
+    Qt6::Gui
+    Qt6::Qml
+    Qt6::Quick
+    Qt6::QuickControls2
+    Qt6::Widgets
+    Qt6::OpenGL
+    ${OpenCV_LIBS}
+)
+
+# --- Embedded Python (DeepLabCut-Live) -------------------------------------
+if(USE_PYTHON)
+    # Use a maintained interpreter (3.11/3.12). Python 3.7 used by the old
+    # build is end-of-life. Override discovery with -DPython3_ROOT_DIR=...
+    find_package(Python3 REQUIRED COMPONENTS Development NumPy)
+    target_compile_definitions(MiniscopeDAQ PRIVATE USE_PYTHON)
+    target_link_libraries(MiniscopeDAQ PRIVATE Python3::Python Python3::NumPy)
+endif()
+
+# Note: there used to be a second "MiniscopeDAQ-launch.bat" launcher here that
+# just put the conda env on PATH and started the dev exe. It was superseded by
+# the standalone `deploy` target below (which bundles every dependency, so the
+# result needs no conda env at all) and only cluttered build/Release with an
+# extra artifact that confused users, so it was removed. To run the dev build
+# in place, launch from an activated conda env.
+
+# --- Standalone deployment target ------------------------------------------
+# Turn build/<config>/ itself into a clean, standalone release that runs by
+# double-click with NO conda env on PATH and can be copied to any Windows PC. The
+# configs are already at the top (POST_BUILD step above) and the real exe is
+# already built into bin/, so deploy just bundles the DLLs into bin/ and drops the
+# launcher on top (see deploy.py):
+#     build/<config>/MiniscopeDAQ.exe                  <- launcher (the only loose file)
+#     build/<config>/deviceConfigs|userConfigs|Scripts <- configs, visible at the top
+#     build/<config>/bin/                              <- real exe + all DLLs + plugins + qml
+# Run after building:
+#     cmake --build build --config Release --target deploy
+# Requires: run from the activated conda env, and `pip install pefile`.
+# IMPORTANT: the env must use the OpenBLAS BLAS variant, not MKL (MKL is 565 MB
+# of dynamically-loaded kernels that can't be bundled). Switch once with:
+#     conda install "libblas=*=*openblas"
+if(WIN32 AND DEFINED ENV{CONDA_PREFIX})
+    add_custom_target(deploy
+        COMMAND python "${CMAKE_CURRENT_SOURCE_DIR}/tools/deploy.py"
+                "$<TARGET_FILE:MiniscopeDAQ>" "$ENV{CONDA_PREFIX}"
+                "$<TARGET_FILE:MiniscopeLauncher>"
+        DEPENDS MiniscopeDAQ MiniscopeLauncher
+        USES_TERMINAL
+        VERBATIM
+        COMMENT "Bundling dependencies into build/<config>/ (launcher + configs at top, real exe + DLLs in bin/)")
+endif()
+
+# --- Runtime data ----------------------------------------------------------
+# Copy the JSON device/user configs and helper scripts to the top of the release
+# folder - a SINGLE copy, no duplication - where the app finds ./deviceConfigs etc.
+# via its working directory. On Windows that top is build/<config>/ (the exe itself
+# lives in build/<config>/bin/); elsewhere it is the exe's own directory.
+foreach(data_dir deviceConfigs userConfigs Scripts)
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${data_dir}")
+        add_custom_command(TARGET MiniscopeDAQ POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_directory
+                "${CMAKE_CURRENT_SOURCE_DIR}/${data_dir}"
+                "${MINISCOPE_RELEASE_TOP}/${data_dir}"
+            COMMENT "Copying ${data_dir} to the release top")
+    endif()
+endforeach()

--- a/README.md
+++ b/README.md
@@ -26,3 +26,12 @@ This backwards compatible Miniscope DAQ software is an upgrade and replacement t
 **All information can be found on the [Miniscope DAQ Software Wiki page](https://github.com/Aharoni-Lab/Miniscope-DAQ-QT-Software/wiki).**
 
 Along with this repository holding the software's source code, you can get built release versions of the software on the [Releases Page](https://github.com/Aharoni-Lab/Miniscope-DAQ-QT-Software/releases).
+
+## Installation (Windows)
+
+Each release on the [Releases Page](https://github.com/Aharoni-Lab/Miniscope-DAQ-QT-Software/releases) ships in two forms — pick whichever suits you:
+
+- **Installer — `MiniscopeDAQ-<version>-Setup.exe`** (recommended). A standard Windows setup wizard. It installs per-user (no administrator rights required), adds a Start Menu shortcut (and an optional desktop shortcut), and registers an entry under *Add or Remove Programs* so it can be uninstalled cleanly.
+- **Portable zip — `MiniscopeDAQ-<version>-Windows-x64.zip`**. Unzip it anywhere and double-click `MiniscopeDAQ.exe` — nothing is installed, and you can remove it just by deleting the folder. Handy when you can't run an installer or want to carry it on a USB drive.
+
+Both are fully self-contained: all dependencies (Qt, OpenCV, Python, …) are bundled, so no separate installation is needed.

--- a/deviceConfigs/userConfigProps.json
+++ b/deviceConfigs/userConfigProps.json
@@ -217,6 +217,10 @@
                     "type": "String",
                     "tips": "Imaging data is save in .avi file format. You can choose what type of video compression to apply when saving data. We suggest using a lossless compression CODEC for Miniscope data. This would be either GREY or FFV1. GREY does no compression. FFV1 losslessly compresses the data but can be CPU intensive. We generally use FFV1 is our computer can keep up with it. If you notice the frame buffer filling up completely while recording you should switch to GREY."
                 },
+                "lut": {
+                    "type": "String",
+                    "tips": "Optional display colormap (LUT) for the live Miniscope video. Choose None (grayscale), Green (GCaMP/GFP, ~530 nm), Red (red indicators such as jRGECO/RCaMP/tdTomato), or Inferno. This is DISPLAY ONLY - it does not affect the recorded data, which is always saved in grayscale. The 'Apply LUT' switch on the device window toggles it on/off at runtime."
+                },
                 "framesPerFile": {
                     "type": "Integer",
                     "tips": "We generally set this to 1000. It defines how large each .avi file will be in your recording."

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,37 @@
+# Reproducible build environment for Miniscope-DAQ-QT-Software (Qt6 / Windows).
+#
+# Create it once, then build per the CMake instructions in CMakeLists.txt:
+#     conda env create -f environment.yml
+#     conda activate miniscope-qt6
+#     cmake -B build -S . -G "Visual Studio 17 2022" -A x64 ^
+#         -DCMAKE_PREFIX_PATH="%CONDA_PREFIX%/Library" ^
+#         -DPython3_EXECUTABLE="%CONDA_PREFIX%/python.exe" -DUSE_PYTHON=ON
+#     cmake --build build --config Release
+#     cmake --build build --config Release --target deploy   # -> build/Release/
+#
+# To update an existing env after editing this file:
+#     conda env update -f environment.yml --prune
+#
+# IMPORTANT - BLAS provider MUST be OpenBLAS, not MKL.
+# OpenCV's LAPACK/BLAS under MKL pulls mkl_rt plus ~565 MB of dynamically-loaded
+# kernels that tools/deploy.py cannot see (and so cannot bundle), which makes the
+# standalone dist/ fail on a machine without MKL. The `libblas=*=*openblas` pin
+# below forces the small, bundleable OpenBLAS variant. Do not remove it.
+#
+# Versions are pinned to major.minor for a reproducible-yet-maintainable build.
+# For byte-for-byte reproducibility (identical DLL set every time), generate a
+# lock file with conda-lock and install from that instead.
+name: miniscope-qt6
+channels:
+  - conda-forge
+dependencies:
+  - python=3.12
+  - qt6-main=6.11
+  - libopencv=4.13
+  - numpy=2.4
+  - cmake
+  - ninja
+  - "libblas=*=*openblas"   # force OpenBLAS, never MKL (see note above)
+  - pip
+  - pip:
+      - pefile              # deploy.py walks the PE import table to find DLL deps

--- a/installer/MiniscopeDAQ.iss
+++ b/installer/MiniscopeDAQ.iss
@@ -1,0 +1,98 @@
+; ---------------------------------------------------------------------------
+; Inno Setup script for Miniscope DAQ
+;
+; Wraps the standalone bundle produced by the CMake `deploy` target
+; (build/Release/ - launcher + configs at the top, real exe + DLLs in bin/)
+; into a familiar Setup.exe: per-user install (NO admin rights), Start Menu
+; shortcut, optional desktop shortcut, and an entry in "Add or Remove Programs"
+; with a working uninstaller.
+;
+; Per-user is deliberate: the launcher writes ./userConfigs relative to the
+; install dir, so the app must land somewhere the user can write to. {autopf}
+; with PrivilegesRequired=lowest resolves to %LocalAppData%\Programs, which is
+; user-writable and needs no elevation.
+;
+; Build locally (after `cmake --build build --config Release --target deploy`):
+;   iscc installer\MiniscopeDAQ.iss
+;
+; CI overrides version / source / output name from the command line, e.g.:
+;   iscc /DMyAppVersion=1.10 /DMySourceDir=C:\...\build\Release ^
+;        /DMyOutputDir=C:\...\artifacts /DMyOutputBaseName=MiniscopeDAQ-v1.10-Setup ^
+;        installer\MiniscopeDAQ.iss
+; ---------------------------------------------------------------------------
+
+#define MyAppName "Miniscope DAQ"
+#define MyAppPublisher "Aharoni Lab"
+#define MyAppExeName "MiniscopeDAQ.exe"
+#define MyAppURL "https://github.com/Aharoni-Lab/Miniscope-DAQ-QT-Software"
+
+; --- Overridable from the iscc command line (sensible local defaults) -------
+#ifndef MyAppVersion
+  #define MyAppVersion "dev"
+#endif
+#ifndef MySourceDir
+  #define MySourceDir "..\build\Release"
+#endif
+#ifndef MyOutputDir
+  #define MyOutputDir "..\build\installer"
+#endif
+#ifndef MyOutputBaseName
+  #define MyOutputBaseName "MiniscopeDAQ-" + MyAppVersion + "-Setup"
+#endif
+
+[Setup]
+; A stable AppId ties every version to the same uninstall entry, so a new
+; release upgrades the previous install in place instead of stacking copies.
+; Never change this GUID once shipped.
+AppId={{B7E6B2D4-3F8A-4C21-9E5D-2A1F6C9B4E70}
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+; Controls the wizard caption AND the "Add or Remove Programs" display name.
+; Without this, Inno shows "<AppName> version <AppVersion>"; set it explicitly
+; for a clean "Miniscope DAQ 1.2" that matches the version shown in the app's
+; Help (sourced from source/main.cpp VERSION_NUMBER - see the CI step).
+AppVerName={#MyAppName} {#MyAppVersion}
+AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppURL}
+AppSupportURL={#MyAppURL}
+DefaultDirName={autopf}\MiniscopeDAQ
+DefaultGroupName={#MyAppName}
+DisableProgramGroupPage=yes
+; Per-user install: no UAC elevation, lands under %LocalAppData%\Programs.
+PrivilegesRequired=lowest
+ArchitecturesAllowed=x64
+ArchitecturesInstallIn64BitMode=x64
+OutputDir={#MyOutputDir}
+OutputBaseFilename={#MyOutputBaseName}
+SetupIconFile=..\source\miniscope_icon.ico
+UninstallDisplayIcon={app}\{#MyAppExeName}
+; Tuck the uninstaller (unins000.exe + unins000.dat) into bin/ rather than the
+; top level. Inno hardcodes those file names and the .dat is required by the
+; uninstaller, so they can't be renamed or removed - but bin/ is where this
+; project already hides its DLL/plugin clutter, leaving the top level clean
+; (launcher + configs + bin/). Users uninstall via the Start Menu shortcut or
+; Add/Remove Programs, both labelled "Uninstall", never "unins000".
+UninstallFilesDir={app}\bin
+Compression=lzma2
+SolidCompression=yes
+WizardStyle=modern
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+
+[Files]
+; Take the whole deployed bundle verbatim: launcher + configs at the top, real
+; exe + DLLs + Qt plugins + QML under bin/. The bundle is already self-contained
+; (no conda env required), so a recursive copy is all the installer does.
+Source: "{#MySourceDir}\*"; DestDir: "{app}"; Flags: recursesubdirs createallsubdirs ignoreversion
+
+[Icons]
+Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
+Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#MyAppName}}"; Flags: nowait postinstall skipifsilent

--- a/source/AddDeviceDialog.qml
+++ b/source/AddDeviceDialog.qml
@@ -1,0 +1,122 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+// Modal dialog for the user-config generator's "Add Device" action. The user
+// picks a category (Miniscope vs Camera), a device type from the catalog
+// (backend.deviceTypes()), a deviceID, and a name. The deviceID dropdown only
+// offers IDs not already used by another device (backend.availableDeviceIDs()),
+// each labelled with the connected-device name when known, so two devices can't
+// share an ID. A full scan of connected devices is also shown as a hint. On OK
+// the chosen values are exposed via the category / deviceType / deviceID /
+// deviceName properties and the built-in accepted() signal fires; main.qml
+// forwards them to backend.addDevice().
+Dialog {
+    id: control
+    title: "Add a device"
+    modal: true
+    parent: Overlay.overlay
+    anchors.centerIn: parent
+    width: 480
+    standardButtons: Dialog.Ok | Dialog.Cancel
+    closePolicy: Popup.CloseOnEscape
+
+    // Results read by the caller (main.qml) on accept. deviceID is the leading
+    // integer of the dropdown label (e.g. "0  (Asus Webcam)" -> 0).
+    property string category:   catCombo.currentText === "Miniscope" ? "miniscopes" : "cameras"
+    property string deviceType: typeCombo.currentText
+    property int    deviceID:   idCombo.currentText.length > 0 ? parseInt(idCombo.currentText) : 0
+    property string deviceName: nameField.text.trim()
+    property string detectedDevices: ""
+
+    // Reset the fields and refresh the live device info each time it opens.
+    onAboutToShow: {
+        catCombo.currentIndex = 0;
+        typeCombo.currentIndex = 0;
+        nameField.text = catCombo.currentText === "Miniscope" ? "My Miniscope" : "My Camera";
+        idCombo.model = backend.availableDeviceIDs();   // unused IDs only
+        idCombo.currentIndex = 0;
+        detectedDevices = backend.scanVideoDevices();
+    }
+
+    // Keep OK disabled until a name is entered (backend.addDevice also guards).
+    Component.onCompleted: {
+        var ok = control.standardButton(Dialog.Ok);
+        if (ok)
+            ok.enabled = Qt.binding(function () { return nameField.text.trim().length > 0; });
+    }
+
+    GridLayout {
+        columns: 2
+        columnSpacing: 10
+        rowSpacing: 12
+        width: parent.width
+
+        Label { text: "Category"; font.pointSize: 12 }
+        ComboBox {
+            id: catCombo
+            Layout.fillWidth: true
+            font.pointSize: 12
+            model: [ "Miniscope", "Camera" ]
+            // Refresh the suggested name to match the category unless the user
+            // already typed their own.
+            onActivated: {
+                if (nameField.text === "My Miniscope" || nameField.text === "My Camera"
+                        || nameField.text.trim() === "")
+                    nameField.text = currentText === "Miniscope" ? "My Miniscope" : "My Camera";
+            }
+        }
+
+        Label { text: "Device type"; font.pointSize: 12 }
+        ComboBox {
+            id: typeCombo
+            Layout.fillWidth: true
+            font.pointSize: 12
+            // All supported types from deviceConfigs/videoDevices.json; the user
+            // picks the category explicitly above.
+            model: backend.deviceTypes()
+        }
+
+        Label { text: "Device ID"; font.pointSize: 12 }
+        ComboBox {
+            id: idCombo
+            Layout.fillWidth: true
+            font.pointSize: 12
+            // Populated in onAboutToShow with only the unused IDs.
+        }
+
+        Label { text: "Name"; font.pointSize: 12 }
+        TextField {
+            id: nameField
+            Layout.fillWidth: true
+            font.pointSize: 12
+            selectByMouse: true
+            placeholderText: "e.g. My V4 Miniscope"
+        }
+
+        // Full connected-device scan (incl. already-used IDs), spanning both columns.
+        Label {
+            Layout.columnSpan: 2
+            Layout.topMargin: 6
+            text: "Connected devices:"
+            font.pointSize: 11
+            font.bold: true
+        }
+        Frame {
+            Layout.columnSpan: 2
+            Layout.fillWidth: true
+            Layout.preferredHeight: 120
+            ScrollView {
+                anchors.fill: parent
+                clip: true
+                TextArea {
+                    readOnly: true
+                    wrapMode: TextArea.WordWrap
+                    font.pointSize: 10
+                    text: control.detectedDevices === "" ? "(no devices detected)"
+                                                         : control.detectedDevices
+                }
+            }
+        }
+    }
+}

--- a/source/ControlPanel.qml
+++ b/source/ControlPanel.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.0
+import QtQuick          // Qt6: unversioned so RegularExpressionValidator (QtQuick 2.14+) resolves
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
 
@@ -206,7 +206,7 @@ Item {
                                 }
                                 TextField {
                                     property var validNumber : DoubleValidator { bottom:0;}
-                                    property var validAll : RegExpValidator{}
+                                    property var validAll : RegularExpressionValidator{}  // Qt6: RegExpValidator removed
                                     width: parent.width - 10
                                     height:30
                                     text: root.ucValues[index]
@@ -318,7 +318,8 @@ Item {
     }
     Connections{
         target: root
-        onCurrentRecordTimeChanged: {
+        // Qt6: Connections requires function syntax instead of onSignal: ...
+        function onCurrentRecordTimeChanged() {
             if ((root.currentRecordTime >= root.ucRecordLength) && root.ucRecordLength > 0) {
                 bStop.enabled = false;
                 bRecord.enabled = true;

--- a/source/Miniscope_V3.qml
+++ b/source/Miniscope_V3.qml
@@ -204,23 +204,23 @@ Item {
 
     Connections{
         target: led0
-        onValueChangedSignal: vidPropChangedSignal(led0.objectName, displayValue, i2cValue, i2cValue2)
+        function onValueChangedSignal(displayValue, i2cValue, i2cValue2) { vidPropChangedSignal(led0.objectName, displayValue, i2cValue, i2cValue2) }
     }
     Connections{
         target: gain
-        onValueChangedSignal: vidPropChangedSignal(gain.objectName, displayValue, i2cValue, i2cValue2)
+        function onValueChangedSignal(displayValue, i2cValue, i2cValue2) { vidPropChangedSignal(gain.objectName, displayValue, i2cValue, i2cValue2) }
     }
     Connections{
         target: frameRate
-        onValueChangedSignal: vidPropChangedSignal(frameRate.objectName, displayValue, i2cValue, i2cValue2)
+        function onValueChangedSignal(displayValue, i2cValue, i2cValue2) { vidPropChangedSignal(frameRate.objectName, displayValue, i2cValue, i2cValue2) }
     }
     Connections{
         target: alpha
-        onValueChangedSignal: vidPropChangedSignal(alpha.objectName, displayValue, i2cValue, i2cValue2)
+        function onValueChangedSignal(displayValue, i2cValue, i2cValue2) { vidPropChangedSignal(alpha.objectName, displayValue, i2cValue, i2cValue2) }
     }
     Connections{
         target: beta
-        onValueChangedSignal: vidPropChangedSignal(beta.objectName, displayValue, i2cValue, i2cValue2)
+        function onValueChangedSignal(displayValue, i2cValue, i2cValue2) { vidPropChangedSignal(beta.objectName, displayValue, i2cValue, i2cValue2) }
     }
 
     states: [

--- a/source/Miniscope_V4.qml
+++ b/source/Miniscope_V4.qml
@@ -210,23 +210,23 @@ Item {
 
     Connections{
         target: led0
-        onValueChangedSignal: vidPropChangedSignal(led0.objectName, displayValue, i2cValue)
+        function onValueChangedSignal(displayValue, i2cValue) { vidPropChangedSignal(led0.objectName, displayValue, i2cValue) }
     }
     Connections{
         target: ewl
-        onValueChangedSignal: vidPropChangedSignal(ewl.objectName, displayValue, i2cValue)
+        function onValueChangedSignal(displayValue, i2cValue) { vidPropChangedSignal(ewl.objectName, displayValue, i2cValue) }
     }
     Connections{
         target: gain
-        onValueChangedSignal: vidPropChangedSignal(gain.objectName, displayValue, i2cValue)
+        function onValueChangedSignal(displayValue, i2cValue) { vidPropChangedSignal(gain.objectName, displayValue, i2cValue) }
     }
     Connections{
         target: alpha
-        onValueChangedSignal: vidPropChangedSignal(alpha.objectName, displayValue, i2cValue)
+        function onValueChangedSignal(displayValue, i2cValue) { vidPropChangedSignal(alpha.objectName, displayValue, i2cValue) }
     }
     Connections{
         target: beta
-        onValueChangedSignal: vidPropChangedSignal(beta.objectName, displayValue, i2cValue)
+        function onValueChangedSignal(displayValue, i2cValue) { vidPropChangedSignal(beta.objectName, displayValue, i2cValue) }
     }
 
     states: [

--- a/source/Miniscope_V4_BNO.qml
+++ b/source/Miniscope_V4_BNO.qml
@@ -15,6 +15,7 @@ Item {
     signal takeScreenShotSignal()
     signal dFFSwitchChanged(bool value)
     signal saturationSwitchChanged(bool value)
+    signal lutSwitchChanged(bool value)
 
     signal setRoiClicked()
     signal addTraceRoiClicked()
@@ -203,6 +204,19 @@ Item {
             }
 
             Switch {
+                id: lutSwitch
+                objectName: "lutSwitch"
+                text: qsTr("Apply LUT")
+                hoverEnabled: false
+
+                font.bold: true
+                font.family: "Arial"
+                Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
+                Layout.column: 1
+                Layout.row: 0
+            }
+
+            Switch {
                 id: saturationSwitch
                 objectName: "saturationSwitch"
                 text: qsTr("Show Saturation")
@@ -297,6 +311,9 @@ Item {
         spacing: 0
         anchors.verticalCenter: parent.verticalCenter
 
+        // "Add Neuron ROI": arms ROI-selection mode so the next click/drag on the
+        // video defines a neuron trace. Safe now that VideoDisplay initializes its
+        // selection flag to false (a plain click does nothing until this is clicked).
         RoundButton {
             id: addTraceRoi
             objectName: "addTraceRoi"
@@ -413,39 +430,43 @@ Item {
 
     Connections{
         target: led0
-        onValueChangedSignal: vidPropChangedSignal(led0.objectName, displayValue, i2cValue, i2cValue2)
+        function onValueChangedSignal(displayValue, i2cValue, i2cValue2) { vidPropChangedSignal(led0.objectName, displayValue, i2cValue, i2cValue2) }
     }
     Connections{
         target: led1
-        onValueChangedSignal: vidPropChangedSignal(led1.objectName, displayValue, i2cValue, i2cValue2)
+        function onValueChangedSignal(displayValue, i2cValue, i2cValue2) { vidPropChangedSignal(led1.objectName, displayValue, i2cValue, i2cValue2) }
     }
     Connections{
         target: ewl
-        onValueChangedSignal: vidPropChangedSignal(ewl.objectName, displayValue, i2cValue, i2cValue2)
+        function onValueChangedSignal(displayValue, i2cValue, i2cValue2) { vidPropChangedSignal(ewl.objectName, displayValue, i2cValue, i2cValue2) }
     }
     Connections{
         target: gain
-        onValueChangedSignal: vidPropChangedSignal(gain.objectName, displayValue, i2cValue, i2cValue2)
+        function onValueChangedSignal(displayValue, i2cValue, i2cValue2) { vidPropChangedSignal(gain.objectName, displayValue, i2cValue, i2cValue2) }
     }
     Connections{
         target: frameRate
-        onValueChangedSignal: vidPropChangedSignal(frameRate.objectName, displayValue, i2cValue, i2cValue2)
+        function onValueChangedSignal(displayValue, i2cValue, i2cValue2) { vidPropChangedSignal(frameRate.objectName, displayValue, i2cValue, i2cValue2) }
     }
     Connections{
         target: alpha
-        onValueChangedSignal: vidPropChangedSignal(alpha.objectName, displayValue, i2cValue, i2cValue2)
+        function onValueChangedSignal(displayValue, i2cValue, i2cValue2) { vidPropChangedSignal(alpha.objectName, displayValue, i2cValue, i2cValue2) }
     }
     Connections{
         target: beta
-        onValueChangedSignal: vidPropChangedSignal(beta.objectName, displayValue, i2cValue, i2cValue2)
+        function onValueChangedSignal(displayValue, i2cValue, i2cValue2) { vidPropChangedSignal(beta.objectName, displayValue, i2cValue, i2cValue2) }
     }
     Connections{
         target: dFFSwitch
-        onClicked: dFFSwitchChanged(dFFSwitch.checked)
+        function onClicked() { dFFSwitchChanged(dFFSwitch.checked) }
     }
     Connections{
         target: saturationSwitch
-        onClicked: saturationSwitchChanged(saturationSwitch.checked)
+        function onClicked() { saturationSwitchChanged(saturationSwitch.checked) }
+    }
+    Connections{
+        target: lutSwitch
+        function onClicked() { lutSwitchChanged(lutSwitch.checked) }
     }
 
     states: [

--- a/source/TreeViewerJSON.qml
+++ b/source/TreeViewerJSON.qml
@@ -1,233 +1,243 @@
-import QtQuick 2.0
-import QtQuick.Controls 1.4
-    import QtQuick.Controls 2.12 as QTQC2
-import QtQuick.Layouts 1.3
-import QtQuick.Controls.Styles 1.4
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Dialogs
 
+// ---------------------------------------------------------------------------
+// User-config tree editor - Qt6 port.
+//
+// The original used Qt Quick Controls 1 (TreeView + TableViewColumn +
+// Controls.Styles), all removed in Qt6. The backend still exposes the same
+// QStandardItemModel (backend.jsonTreeModel); its column-0 index carries every
+// field as a role - key / value / type / tips (the old design where each
+// TableViewColumn just picked a different role of the same item). So this is a
+// single logical column whose delegate lays out the row by hand:
+//
+//     [indent][expand arrow][key][value editor][type]
+//
+// NOTE: the Qt6 TreeView *attached* properties (TreeView.depth / hasChildren /
+// expanded) come back undefined in this build, so we instead use the TreeView
+// *methods* depth(row) / isExpanded(row) / toggleExpanded(row), and derive
+// "has children" from the node type (Object/Array are the expandable parents).
+// expandTick is bumped on expand/collapse so the isExpanded() bindings (which
+// call a non-reactive method) re-evaluate.
+//
+// Bool values get a Switch, everything else a validated TextField. Edits are
+// written back with backend.treeViewTextChanged(<modelIndex>, text); focusing a
+// field publishes its "tips" to root.toolTipText (shown by the pane in
+// main.qml).
+// ---------------------------------------------------------------------------
 TreeView {
-    property string toolTipText
-    id:root
-    rowDelegate: Rectangle {
-            width: parent.width
-            height: 25
+    id: root
+    property string toolTipText: ""
+    property int expandTick: 0          // bump to re-evaluate isExpanded() bindings
+    property var browseTarget: null     // QModelIndex currently being set via a dialog
 
-        }
+    clip: true
+    boundsBehavior: Flickable.StopAtBounds
 
-    TableViewColumn {
-        title: "Key"
-        role: "key"
-        width: 200
+    // Folder / file pickers for DirPath / FilePath entries, so the user can
+    // browse to a location instead of typing it. The browse button stashes the
+    // row's QModelIndex in browseTarget; on accept we write the chosen path back
+    // through the same path as a manual edit.
+    FolderDialog {
+        id: folderDlg
+        title: "Select a folder"
+        onAccepted: if (root.browseTarget)
+            backend.treeViewTextChanged(root.browseTarget, backend.urlToLocalFile(selectedFolder))
+    }
+    FileDialog {
+        id: fileDlg
+        title: "Select a file"
+        onAccepted: if (root.browseTarget)
+            backend.treeViewTextChanged(root.browseTarget, backend.urlToLocalFile(selectedFile))
+    }
 
-        delegate: Loader {
-            property string modelType: model.type
-            property string modelTips: model.tips
+    onExpanded: root.expandTick++       // TreeView signal: a row was expanded
+    onCollapsed: root.expandTick++
+
+    // All data lives on column 0; the model's sibling columns 1 & 2 are empty
+    // (legacy role-per-column design), so give column 0 the full content width
+    // and collapse the others to zero.
+    columnWidthProvider: function (column) { return column === 0 ? Math.max(root.width, 780) : 0 }
+    onWidthChanged: Qt.callLater(root.forceLayout)
+
+    ScrollBar.vertical: ScrollBar { policy: ScrollBar.AsNeeded }
+    ScrollBar.horizontal: ScrollBar { policy: ScrollBar.AsNeeded }
+
+    // Background colour by data type (matches the original editor).
+    function typeColor(t) {
+        if (t === "Number" || t === "Integer" || t === "Double") return "#cfe2f3";
+        if (t === "String") return "#d9d2e9";
+        if (t === "DirPath" || t === "FilePath") return "#ead1dc";
+        return "#f3f3f3";
+    }
+    // Object / Array(...) nodes are the expandable parents in this model.
+    function isParent(t) { return t === "Object" || (t !== undefined && t.indexOf("Array") === 0); }
+
+    delegate: Item {
+        id: cell
+        required property var model
+        required property int row
+        required property int column
+
+        readonly property bool hasKids:    root.isParent(model.type)
+        readonly property int  depthLevel: root.depth(cell.row)
+        readonly property bool nodeOpen:   { root.expandTick; return root.isExpanded(cell.row); }
+
+        implicitWidth: line.implicitWidth
+        implicitHeight: 26
+        visible: column === 0          // columns 1 & 2 carry no data
+
+        Row {
+            id: line
+            height: parent.height
+
+            // indentation by tree depth
+            Item { width: cell.depthLevel * 18; height: 1 }
+
+            // expand / collapse control
             Rectangle {
-                id: rectangle
-                width: parent.width
-                height: parent.height
-
-                color: {
-                    if (modelType === "Number") {"#cfe2f3"}
-                    else if (modelType === "Integer") {"#cfe2f3"}
-                    else if (modelType === "Double") {"#cfe2f3"}
-                    else if (modelType === "String") {"#d9d2e9"}
-                    else if (modelType === "DirPath") {"#ead1dc"}
-                    else if (modelType === "FilePath") {"#ead1dc"}
-                    else {"#f3f3f3"}
-                }
-
-                border.color: "black"
-                border.width: 1
-                anchors.fill: parent
+                width: 22; height: cell.height
+                color: "transparent"
                 Text {
-                    text: model.key
-                    anchors.left: parent.left
-                    anchors.leftMargin: 3
-                    font.pointSize: 10
-
-//                    color:  if (model.type === "Number") {"black"} else {"black"}
+                    anchors.centerIn: parent
+                    visible: cell.hasKids
+                    text: cell.nodeOpen ? "▾" : "▸"   // down / right triangle
+                    font.pointSize: 11
+                    color: "#333333"
                 }
                 MouseArea {
                     anchors.fill: parent
-                    onClicked: {
-                            root.toolTipText = modelTips;
-
-                    }
+                    enabled: cell.hasKids
+                    onClicked: root.toggleExpanded(cell.row)
                 }
             }
-        }
-    }
 
-    TableViewColumn {
-        title: "Value"
-        role: "value"
-        width: 400
-        delegate: Loader {
-            property string modelValue: model.value
-            property string modelType: model.type
-            property string modelTips: model.tips
-            sourceComponent:
-            {
-                if (model.type === "Bool") {checkBoxDelegate}
-                else {textFieldDelegate}
-            }
-
-//        delegate: Loader {
-//            property var modelTwo: model.value
-//            sourceComponent: stringDelegate
-//            function updateValue(value) {
-//                model.value = value;
-//            }
-        }
-    }
-
-    TableViewColumn {
-        title: "Type"
-        role: "type"
-        width: 90
-        delegate: Loader {
-            property string modelType: model.type
+            // key
             Rectangle {
-                width: parent.width
-                height: parent.height
-                color: {
-                    if (modelType === "Number") {"#cfe2f3"}
-                    else if (modelType === "Integer") {"#cfe2f3"}
-                    else if (modelType === "Double") {"#cfe2f3"}
-                    else if (modelType === "String") {"#d9d2e9"}
-                    else if (modelType === "DirPath") {"#ead1dc"}
-                    else if (modelType === "FilePath") {"#ead1dc"}
-                    else {"#f3f3f3"}
-                }
-
-                border.color: "black"
-                border.width: 1
-//                anchors.fill: parent
+                width: 180; height: cell.height
+                color: root.typeColor(cell.model.type)
+                border.color: "black"; border.width: 1
                 Text {
-                    text: model.type
-                    anchors.left: parent.left
-                    anchors.leftMargin: 3
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.left: parent.left; anchors.leftMargin: 4
+                    text: cell.model.key === undefined ? "" : cell.model.key
                     font.pointSize: 10
-//                    color:  if (model.type === "Number") {"black"} else {"black"}
                 }
-            }
-        }
-    }
-
-
-    Component {
-        id: checkBoxDelegate
-        QTQC2.Switch {
-            width: 10
-            height: 10
-            checked: {
-                if (modelValue === "true") {true}
-                else {false}
-            }
-            onClicked: {
-                if (checked)
-                    backend.treeViewTextChanged(currentIndex, "true");
-                else
-                    backend.treeViewTextChanged(currentIndex, "false");
-            }
-            onFocusChanged: {
-                if (focus) {
-                    root.toolTipText = modelTips;
-                }
-            }
-        }
-    }
-
-    Component {
-        id: textFieldDelegate
-        QTQC2.TextField {
-            text: modelValue
-            enabled: {
-                if (modelType === "Object" || modelType === "Array") {false}
-                else {true}
+                TapHandler { onTapped: root.toolTipText = cell.model.tips }
             }
 
-            anchors.fill: parent
-            font.pointSize: 10
-            height: 25
+            // value editor: Switch for Bool, validated TextField otherwise,
+            // plus a Browse button for DirPath / FilePath entries.
+            Item {
+                id: valueCell
+                width: 360; height: cell.height
+                readonly property bool isPath: cell.model.type === "DirPath" || cell.model.type === "FilePath"
+                // The compression value is a video codec: offer the host-supported
+                // codecs as a dropdown instead of a free-text field.
+                readonly property bool isCompression: cell.model.key === "compression" && !cell.hasKids
+                // The lut value is a display colormap: offer the available LUTs.
+                readonly property bool isLut: cell.model.key === "lut" && !cell.hasKids
+                // Either of the above renders a dropdown instead of a text field.
+                readonly property bool isChoice: isCompression || isLut
 
-            selectByMouse: true
-//            canPaste: true
+                IntValidator    { id: intV; bottom: 0 }
+                DoubleValidator { id: dblV; bottom: 0 }
 
-            background:
-                Rectangle {
-                    anchors.fill: parent
-                    border.color: "black"
-                    border.width: 1
-                    color: {
-
-                        if (modelType === "Number") {"#cfe2f3"}
-                        else if (modelType === "Integer") {"#cfe2f3"}
-                        else if (modelType === "Double") {"#cfe2f3"}
-                        else if (modelType === "String") {"#d9d2e9"}
-                        else if (modelType === "DirPath") {"#ead1dc"}
-                        else if (modelType === "FilePath") {"#ead1dc"}
-                        else {"#f3f3f3"}
-
-//                        if (modelType === "Number") {"#cfe2f3"}
-//                        else if (modelType === "String") {"#d9d2e9"}
-//                        else if (modelType === "Bool") {"#ead1dc"}
-//                        else {"#f3f3f3"}
+                TextField {
+                    id: tf
+                    anchors.left: parent.left
+                    anchors.right: valueCell.isPath ? browseBtn.left : parent.right
+                    anchors.top: parent.top
+                    anchors.bottom: parent.bottom
+                    visible: cell.model.type !== "Bool" && !valueCell.isChoice
+                    enabled: cell.model.type !== "Object" && cell.model.type !== "Array"
+                    text: cell.model.value === undefined ? "" : cell.model.value
+                    font.pointSize: 10
+                    selectByMouse: true
+                    color: "black"
+                    validator: cell.model.type === "Integer" ? intV
+                             : (cell.model.type === "Number" || cell.model.type === "Double") ? dblV
+                             : null
+                    background: Rectangle {
+                        border.color: "black"; border.width: 1
+                        color: root.typeColor(cell.model.type)
+                    }
+                    onActiveFocusChanged: if (activeFocus) root.toolTipText = cell.model.tips
+                    onTextEdited: color = "red"          // unsaved edit
+                    onEditingFinished: {
+                        color = "green";                 // committed
+                        backend.treeViewTextChanged(root.index(cell.row, 0), text);
                     }
                 }
-            property var validInt : IntValidator { bottom:0;}
-            property var validDouble : DoubleValidator { bottom:0;}
-            property var validPath : RegExpValidator{regExp: /^[^\\]+$/}
-            property var validAll : RegExpValidator{}
 
-            validator: {
+                Button {
+                    id: browseBtn
+                    visible: valueCell.isPath
+                    anchors.right: parent.right
+                    anchors.top: parent.top
+                    anchors.bottom: parent.bottom
+                    width: visible ? 34 : 0
+                    text: "…"
+                    font.pointSize: 11
+                    ToolTip.visible: hovered
+                    ToolTip.text: cell.model.type === "DirPath" ? "Browse for a folder" : "Browse for a file"
+                    onClicked: {
+                        root.browseTarget = root.index(cell.row, 0);
+                        if (cell.model.type === "DirPath")
+                            folderDlg.open();
+                        else
+                            fileDlg.open();
+                    }
+                }
 
-                if (modelType === "Number") {validDouble}
-                else if (modelType === "Integer") {validInt}
-                else if (modelType === "Double") {validDouble}
-                else if (modelType === "String") {validAll}
-                else if (modelType === "DirPath") {validAll}
-                else if (modelType === "FilePath") {validAll}
-                else {validAll}
-            }
-            onFocusChanged: {
-                if (focus) {
-                    root.toolTipText = modelTips;
+                Switch {
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.left: parent.left
+                    visible: cell.model.type === "Bool"
+                    checked: cell.model.value === true || cell.model.value === "true"
+                    onToggled: backend.treeViewTextChanged(root.index(cell.row, 0), checked ? "true" : "false")
+                    onActiveFocusChanged: if (activeFocus) root.toolTipText = cell.model.tips
+                }
+
+                ComboBox {
+                    id: choiceBox
+                    visible: valueCell.isChoice
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.top: parent.top
+                    anchors.bottom: parent.bottom
+                    font.pointSize: 10
+                    // Options: codecs for "compression", colormaps for "lut".
+                    readonly property var choices: valueCell.isLut ? backend.availableLUTs
+                                                                    : backend.availableCodecs
+                    // Current stored value; coerce to string in case the model hands
+                    // back a non-string.
+                    readonly property string curVal: cell.model.value === undefined ? "" : "" + cell.model.value
+                    // Keep an existing-but-unlisted value visible so the user can change it.
+                    model: {
+                        var list = choiceBox.choices.slice();
+                        if (curVal !== "" && list.indexOf(curVal) === -1)
+                            list.unshift(curVal);
+                        return list;
+                    }
+                    currentIndex: Math.max(0, model.indexOf(curVal))
+                    onActivated: backend.treeViewTextChanged(root.index(cell.row, 0), currentText)
+                    onActiveFocusChanged: if (activeFocus) root.toolTipText = cell.model.tips
                 }
             }
 
-            onTextChanged: {
-                if (focus)
-                    color = "red"
-            }
-
-            onEditingFinished: {
-                color = "green"
-                backend.treeViewTextChanged(currentIndex, text);
-            }
-
-        }
-
-    }
-
-//    Component {
-//        id: stringDelegate
-//        TextEdit {
-//            text: modelTwo
-//            font.family: Arial
-//            font.pointSize: 12
-//            onTextChanged: updateValue(text)
-//        }
-//    }
-
-    DropArea {
-        id: drop
-        anchors.fill: parent
-        onDropped: {
-            // Send file name to c++ backend
-            if (drop.hasUrls) {
-                backend.userConfigFileName = drop.urls[0];
-
+            // type
+            Rectangle {
+                width: 90; height: cell.height
+                color: root.typeColor(cell.model.type)
+                border.color: "black"; border.width: 1
+                Text {
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.left: parent.left; anchors.leftMargin: 4
+                    text: cell.model.type === undefined ? "" : cell.model.type
+                    font.pointSize: 10
+                }
             }
         }
     }

--- a/source/VideoSpinBoxControl.qml
+++ b/source/VideoSpinBoxControl.qml
@@ -1,7 +1,8 @@
 import QtQuick 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
-import QtQuick.Controls.Styles 1.4
+// Qt6: removed unused 'import QtQuick.Controls.Styles 1.4' (module removed in Qt6;
+// nothing in this file used a Controls-1 *Style type).
 
 Item {
     id:root

--- a/source/backend.cpp
+++ b/source/backend.cpp
@@ -10,6 +10,7 @@
 #include <QObject>
 #include <QVariant>
 #include <QDir>
+#include <QFile>
 #include <QVector>
 #include <QUrl>
 #include <QString>
@@ -35,9 +36,16 @@
  #include <libusb.h>
 #endif
 
+#ifdef Q_OS_WINDOWS
+// DirectShow video-device enumeration for scanVideoDevices().
+#define NOMINMAX
+#include <dshow.h>
+#endif
+
 backEnd::backEnd(QObject *parent) :
     QObject(parent),
     m_versionNumber(""),
+    m_buildInfo(""),
     m_userConfigFileName(""),
     m_userConfigOK(false),
     traceDisplay(nullptr),
@@ -94,6 +102,7 @@ backEnd::backEnd(QObject *parent) :
         file.close();
         QJsonDocument d = QJsonDocument::fromJson(jsonFile.toUtf8());
         jObj = d.object();
+        m_deviceCatalog = jObj;   // retained for the user-config generator (Add Device)
         supportedDevices = jObj.keys();
     }
 
@@ -514,6 +523,329 @@ void backEnd::saveConfigObject()
     file.close();
 }
 
+void backEnd::saveConfigObjectAs(const QString &filePath)
+{
+    generateUserConfigFromModel();
+    QJsonDocument d;
+    d.setObject(m_userConfig);
+    QFile file(filePath);
+    if (file.open(QFile::WriteOnly | QFile::Text | QFile::Truncate)) {
+        file.write(d.toJson());
+        file.close();
+        sendMessage("User config saved to " + filePath);
+    }
+    else {
+        sendMessage("ERROR: could not save user config to " + filePath);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// User-config generator
+//
+// Lets the user build a valid user config in-app without starting from an example
+// file. newUserConfig() synthesizes a complete default skeleton straight from the
+// schema (deviceConfigs/userConfigProps.json); addDevice() inserts a device built
+// from the matching schema template, enriched with sensible starting values pulled
+// from the device catalog (deviceConfigs/videoDevices.json). Both then rebuild the
+// tree model and re-run the validity check (which enables Save / Run). All of the
+// existing editor, serialization and save machinery is reused unchanged.
+// ---------------------------------------------------------------------------
+
+QJsonValue backEnd::defaultForType(const QString &type)
+{
+    if (type == "Bool")
+        return false;
+    if (type == "Integer" || type == "Number" || type == "Double")
+        return 0;
+    if (type.startsWith("Array"))
+        return QJsonArray();
+    // String, DirPath, FilePath, MiniscopeDeviceType, CameraDeviceType, ...
+    return QString("");
+}
+
+QJsonValue backEnd::defaultFromProps(const QJsonValue &propNode)
+{
+    const QJsonObject obj = propNode.toObject();
+
+    // Leaf node: { "type": "<string>", "tips": "..." }. A branch node's "type"
+    // child (e.g. behaviorTracker.type) is itself an object, so testing that the
+    // "type" value is a string reliably tells leaves from branches.
+    if (obj.value("type").isString())
+        return defaultForType(obj.value("type").toString());
+
+    // Branch node: recurse into each sub-property (skipping COMMENT keys).
+    QJsonObject out;
+    const QStringList keys = obj.keys();
+    for (const QString &k : keys) {
+        if (k.contains("COMMENT"))
+            continue;
+        out[k] = defaultFromProps(obj.value(k));
+    }
+    return out;
+}
+
+void backEnd::newUserConfig()
+{
+    QJsonObject cfg;
+    const QStringList keys = m_configProps.keys();
+    for (const QString &k : keys) {
+        if (k.contains("COMMENT"))
+            continue;
+        cfg[k] = defaultFromProps(m_configProps.value(k));
+    }
+
+    // Seed sensible, non-empty defaults so a fresh config is immediately usable
+    // instead of being full of blanks/zeros the user has to fill in.
+    cfg["researcherName"] = "Researcher";
+    cfg["experimentName"] = "Experiment";
+    cfg["animalName"]     = "Animal";
+    // Default the data directory to a "Data" folder next to the running app (the
+    // working directory, where ./deviceConfigs etc. are read from).
+    cfg["dataDirectory"] = QDir::currentPath() + "/Data";
+
+    cfg["directoryStructure"] = QJsonArray{ "researcherName", "experimentName",
+                                            "animalName", "date", "time" };
+
+    QJsonObject devices;
+    devices["miniscopes"] = QJsonObject();
+    devices["cameras"]    = QJsonObject();
+    cfg["devices"] = devices;
+
+    // Trace display: on by default with a real window size, so it actually appears
+    // (a 0x0 window never shows). "type" has a single valid value.
+    if (cfg.contains("traceDisplay")) {
+        QJsonObject td = cfg["traceDisplay"].toObject();
+        td["enabled"]      = true;
+        td["type"]         = "scrolling";
+        td["windowX"]      = 100;
+        td["windowY"]      = 100;
+        td["windowWidth"]  = 600;
+        td["windowHeight"] = 800;
+        cfg["traceDisplay"] = td;
+    }
+
+    // Behavior tracker stays off (it needs an external Python/DLC-Live setup), but
+    // give it sane non-zero values so the section isn't all blanks/zeros if enabled.
+    if (cfg.contains("behaviorTracker")) {
+        QJsonObject bt = cfg["behaviorTracker"].toObject();
+        bt["type"]           = "DeepLabCut-Live";
+        bt["resize"]         = 0.5;
+        bt["pCutoffDisplay"] = 0.3;
+        bt["windowX"]        = 200;
+        bt["windowY"]        = 100;
+        bt["windowScale"]    = 0.75;
+        QJsonObject op = bt["occupancyPlot"].toObject();
+        op["numBinsX"] = 100;
+        op["numBinsY"] = 100;
+        bt["occupancyPlot"] = op;
+        QJsonObject po = bt["poseOverlay"].toObject();
+        po["numOfPastPoses"] = 6;
+        po["markerSize"]     = 20;
+        bt["poseOverlay"] = po;
+        cfg["behaviorTracker"] = bt;
+    }
+
+    m_userConfig = cfg;
+    m_userConfigFileName.clear();   // brand-new config: unseed the Save-As dialog
+
+    constructJsonTreeModel();
+    checkUserConfigForIssues();     // emits userConfigOKChanged() -> enables Save/Run
+}
+
+void backEnd::enrichDeviceDefaults(QJsonObject &device, const QString &category,
+                                   const QString &deviceType)
+{
+    device["deviceType"]     = deviceType;
+    device["deviceID"]       = 0;
+    device["showSaturation"] = true;
+    device["framesPerFile"]  = 1000;
+    device["windowScale"]    = 0.75;
+    device["windowX"]        = 100;
+    device["windowY"]        = 100;
+
+    const QJsonObject cat = m_deviceCatalog.value(deviceType).toObject();
+
+    // ROI defaults to the device's native resolution.
+    if (device.contains("ROI")) {
+        QJsonObject roi = device["ROI"].toObject();
+        roi["leftEdge"] = 0;
+        roi["topEdge"]  = 0;
+        if (cat.contains("width"))  roi["width"]  = cat.value("width");
+        if (cat.contains("height")) roi["height"] = cat.value("height");
+        device["ROI"] = roi;
+    }
+
+    // Control settings (gain / frameRate / led0 / ewl): use the catalog's
+    // startValue for whichever ones this device template actually has.
+    const QJsonObject controls = cat.value("controlSettings").toObject();
+    const QStringList controlKeys = { "gain", "frameRate", "led0", "ewl" };
+    for (const QString &ck : controlKeys) {
+        if (device.contains(ck) && controls.contains(ck)) {
+            const QJsonValue sv = controls.value(ck).toObject().value("startValue");
+            if (!sv.isUndefined())
+                device[ck] = sv;
+        }
+    }
+
+    // Head orientation follows the catalog flag; default the plotted axes.
+    if (device.contains("headOrientation")) {
+        QJsonObject ho = device["headOrientation"].toObject();
+        ho["enabled"]       = cat.value("headOrientation").toBool(false);
+        ho["filterBadData"] = false;
+        ho["plotTrace"]     = QJsonArray{ "roll", "pitch", "yaw" };
+        device["headOrientation"] = ho;
+    }
+
+    // Display LUT is grayscale by default (miniscope only).
+    if (device.contains("lut"))
+        device["lut"] = "None";
+
+    // Compression: pick a host-supported codec, preferring a sensible default per
+    // device class, then any available, then GREY as a last resort.
+    if (device.contains("compression")) {
+        const QString preferred = (category == "miniscopes") ? "FFV1" : "MJPG";
+        QString codec;
+        if (m_availableCodec.contains(preferred))
+            codec = preferred;
+        else if (!m_availableCodec.isEmpty())
+            codec = m_availableCodec.first();
+        else
+            codec = "GREY";
+        device["compression"] = codec;
+    }
+}
+
+void backEnd::addDevice(const QString &category, const QString &deviceType,
+                        const QString &deviceName, int deviceID)
+{
+    if (deviceName.trimmed().isEmpty() || deviceType.isEmpty())
+        return;
+    if (category != "miniscopes" && category != "cameras")
+        return;
+
+    // Capture any edits already made in the tree before we rebuild it.
+    generateUserConfigFromModel();
+
+    QJsonObject devices = m_userConfig.value("devices").toObject();
+    QJsonObject section = devices.value(category).toObject();
+    if (section.contains(deviceName))
+        return;   // names are kept unique within a category
+
+    // Build the device from its schema template, then fill catalog-derived defaults.
+    const QString templateKey = (category == "miniscopes") ? "miniscopeDeviceName"
+                                                           : "cameraDeviceName";
+    const QJsonValue tmpl = m_configProps.value("devices").toObject()
+                                .value(category).toObject().value(templateKey);
+    QJsonObject device = defaultFromProps(tmpl).toObject();
+    enrichDeviceDefaults(device, category, deviceType);
+    device["deviceID"] = deviceID;   // user-chosen ID from the Add-Device dialog
+
+    section[deviceName]     = device;
+    devices[category]       = section;
+    m_userConfig["devices"] = devices;
+
+    constructJsonTreeModel();
+    checkUserConfigForIssues();
+}
+
+QStringList backEnd::enumerateVideoDevices()
+{
+    QStringList names;
+#ifdef Q_OS_WINDOWS
+    // Enumerate DirectShow video input devices. Their order matches the index
+    // OpenCV's CAP_DSHOW backend uses, so the position == the config deviceID.
+    const HRESULT hrInit = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+    const bool balanceUninit = SUCCEEDED(hrInit); // S_OK or S_FALSE (already init)
+
+    ICreateDevEnum *devEnum = nullptr;
+    HRESULT hr = CoCreateInstance(CLSID_SystemDeviceEnum, nullptr, CLSCTX_INPROC_SERVER,
+                                  IID_PPV_ARGS(&devEnum));
+    if (SUCCEEDED(hr) && devEnum) {
+        IEnumMoniker *enumMon = nullptr;
+        hr = devEnum->CreateClassEnumerator(CLSID_VideoInputDeviceCategory, &enumMon, 0);
+        if (hr == S_OK && enumMon) { // S_FALSE => no devices in this category
+            IMoniker *moniker = nullptr;
+            while (enumMon->Next(1, &moniker, nullptr) == S_OK) {
+                IPropertyBag *propBag = nullptr;
+                QString name;
+                if (SUCCEEDED(moniker->BindToStorage(nullptr, nullptr, IID_PPV_ARGS(&propBag)))) {
+                    VARIANT var;
+                    VariantInit(&var);
+                    if (SUCCEEDED(propBag->Read(L"FriendlyName", &var, nullptr)) && var.bstrVal)
+                        name = QString::fromWCharArray(var.bstrVal);
+                    VariantClear(&var);
+                    propBag->Release();
+                }
+                names << name;            // index in this list == deviceID
+                moniker->Release();
+            }
+            enumMon->Release();
+        }
+        devEnum->Release();
+    }
+    if (balanceUninit)
+        CoUninitialize();
+#endif
+    return names;
+}
+
+QString backEnd::scanVideoDevices()
+{
+#ifndef Q_OS_WINDOWS
+    return QStringLiteral("Device scan is only available on Windows.");
+#else
+    const QStringList names = enumerateVideoDevices();
+    if (names.isEmpty())
+        return QStringLiteral("No video devices detected.");
+    QStringList lines;
+    for (int i = 0; i < names.size(); i++)
+        lines << QString("    deviceID %1:  %2")
+                     .arg(i)
+                     .arg(names[i].isEmpty() ? QStringLiteral("(unknown)") : names[i]);
+    return QStringLiteral("Detected video devices:\n") + lines.join("\n")
+           + QStringLiteral("\n\nUse these deviceID numbers in your user config. "
+                            "Note: a Miniscope might appear under a generic name "
+                            "(e.g. \"USB Video Device\").");
+#endif
+}
+
+QStringList backEnd::availableDeviceIDs()
+{
+    // Capture any edits made in the tree so the used-ID set reflects the live config.
+    generateUserConfigFromModel();
+
+    // IDs already assigned to a device in the config.
+    QList<int> used;
+    const QJsonObject devs = m_userConfig.value("devices").toObject();
+    const QStringList cats = { QStringLiteral("miniscopes"), QStringLiteral("cameras") };
+    for (const QString &cat : cats) {
+        const QJsonObject section = devs.value(cat).toObject();
+        const QStringList devNames = section.keys();
+        for (const QString &n : devNames)
+            used << section.value(n).toObject().value("deviceID").toInt();
+    }
+
+    // One entry per connected device (fall back to 0..15 if none detected), and
+    // always at least one ID past the highest used so the list is never empty.
+    const QStringList names = enumerateVideoDevices();
+    int maxIDs = names.isEmpty() ? 16 : names.size();
+    int highestUsed = -1;
+    for (int u : used)
+        highestUsed = qMax(highestUsed, u);
+    maxIDs = qMax(maxIDs, highestUsed + 2);
+
+    QStringList out;
+    for (int id = 0; id < maxIDs; id++) {
+        if (used.contains(id))
+            continue;
+        if (id < names.size() && !names[id].isEmpty())
+            out << QString("%1  (%2)").arg(id).arg(names[id]);   // e.g. "0  (Asus Webcam)"
+        else
+            out << QString::number(id);
+    }
+    return out;
+}
+
 void backEnd::loadUserConfigFile()
 {
     int count;
@@ -629,7 +961,9 @@ void backEnd::connectSnS()
     QObject::connect((controlPanel), SIGNAL( sendNote(QString) ), dataSaver, SLOT ( takeNote(QString) ));
     QObject::connect(this, SIGNAL( closeAll()), controlPanel, SLOT (close()));
 
-
+    // Trace window is optional; only tear it down on exit if it was created.
+    if (traceDisplay)
+        QObject::connect(this, SIGNAL( closeAll()), traceDisplay, SLOT (close()));
 
     QObject::connect(dataSaver, SIGNAL(sendMessage(QString)), controlPanel, SLOT( receiveMessage(QString)));
 
@@ -714,12 +1048,15 @@ void backEnd::setupDataSaver()
 
 void backEnd::testCodecSupport()
 {
-    // This function will test which codecs are supported on host's machine
+    // This function will test which codecs are supported on host's machine.
+    // Probe into a temp file (then delete it) so codec detection never leaves a
+    // stray "test.avi" behind in the working directory / distribution folder.
     cv::VideoWriter testVid;
-//    testVid.open("test.avi", -1,20, cv::Size(640, 480), true);
+    const QString probePath = QDir(QDir::tempPath()).filePath("miniscope_codec_probe.avi");
+    const std::string probe = probePath.toStdString();
     QVector<QString> possibleCodec({"DIB ", "MJPG", "MJ2C", "XVID", "FFV1", "DX50", "FLV1", "H264", "I420","MPEG","mp4v", "0000", "LAGS", "ASV1", "GREY"});
     for (int i = 0; i < possibleCodec.length(); i++) {
-        testVid.open("test.avi", cv::VideoWriter::fourcc(possibleCodec[i].toStdString()[0],possibleCodec[i].toStdString()[1],possibleCodec[i].toStdString()[2],possibleCodec[i].toStdString()[3]),
+        testVid.open(probe, cv::VideoWriter::fourcc(possibleCodec[i].toStdString()[0],possibleCodec[i].toStdString()[1],possibleCodec[i].toStdString()[2],possibleCodec[i].toStdString()[3]),
                 20, cv::Size(640, 480), true);
         if (testVid.isOpened()) {
             m_availableCodec.append(possibleCodec[i]);
@@ -729,11 +1066,20 @@ void backEnd::testCodecSupport()
         else
             unAvailableCodec.append(possibleCodec[i]);
     }
-
+    QFile::remove(probePath);   // remove the throwaway probe file
 }
 
 bool backEnd::checkUserConfigForIssues()
 {
+    // Track whether the config has any devices (the Run button is gated on this).
+    const QJsonObject devs = m_userConfig.value("devices").toObject();
+    const bool has = (devs.value("miniscopes").toObject().size()
+                      + devs.value("cameras").toObject().size()) > 0;
+    if (has != m_hasDevices) {
+        m_hasDevices = has;
+        emit hasDevicesChanged();
+    }
+
     if (checkForUniqueDeviceNames() == false) {
         // Need to tell user that user config has error(s)
         setUserConfigOK(false);
@@ -937,7 +1283,11 @@ void backEnd::constructUserConfigGUI()
 
         // Connect send and receive message to textbox in controlPanel
         QObject::connect(miniscope.last(), SIGNAL(sendMessage(QString)), controlPanel, SLOT( receiveMessage(QString)));
-        QObject::connect(miniscope.last(), &Miniscope::addTraceDisplay, traceDisplay, &TraceDisplayBackend::addNewTrace);
+        // Qt6: connecting to a null receiver dereferences it (r->d_func() reads
+        // offset 8 of nullptr) and crashes. traceDisplay is null unless a trace
+        // display is configured + enabled, so guard the connection.
+        if (traceDisplay)
+            QObject::connect(miniscope.last(), &Miniscope::addTraceDisplay, traceDisplay, &TraceDisplayBackend::addNewTrace);
         if (miniscope.last()->getErrors() != 0) {
             // Errors have occured in creating this object
             sendMessage("ERROR: " + miniscope.last()->getDeviceName() + " has error: " + QString::number(miniscope.last()->getErrors()));
@@ -976,14 +1326,15 @@ void backEnd::constructUserConfigGUI()
 
     // Make behavior tracker interface
     if (!ucBehaviorTracker.isEmpty()) {
-        if (ucBehaviorTracker["enabled"].toBool(true)) {
+        if (ucBehaviorTracker["enabled"].toBool(true) && !behavCam.isEmpty()) {
             // Behav tracker currently is hardcoded to use first behavior camera
             QSize camRes = behavCam.first()->getResolution();
 
             behavTracker = new BehaviorTracker(NULL, m_userConfig, m_softwareStartTime);
 
             QObject::connect(behavTracker, SIGNAL(sendMessage(QString)), controlPanel, SLOT( receiveMessage(QString)));
-            QObject::connect(behavTracker, &BehaviorTracker::addTraceDisplay, traceDisplay, &TraceDisplayBackend::addNewTrace);
+            if (traceDisplay)  // Qt6: avoid connecting to a null receiver (crash)
+                QObject::connect(behavTracker, &BehaviorTracker::addTraceDisplay, traceDisplay, &TraceDisplayBackend::addNewTrace);
             behavTracker->createView(camRes);
             setupBehaviorTracker();
         }

--- a/source/backend.h
+++ b/source/backend.h
@@ -4,8 +4,11 @@
 #include <QObject>
 #include <QJsonObject>
 #include <QJsonArray>
+#include <QJsonValue>
 #include <QThread>
 #include <QString>
+#include <QStringList>
+#include <QUrl>
 #include <QStandardItemModel>
 #include <QStandardItem>
 
@@ -24,8 +27,12 @@ class backEnd : public QObject
     Q_PROPERTY(QString userConfigFileName READ userConfigFileName WRITE setUserConfigFileName NOTIFY userConfigFileNameChanged)
     Q_PROPERTY(QString userConfigDisplay READ userConfigDisplay WRITE setUserConfigDisplay NOTIFY userConfigDisplayChanged)
     Q_PROPERTY(bool userConfigOK READ userConfigOK WRITE setUserConfigOK NOTIFY userConfigOKChanged)
+    Q_PROPERTY(bool hasDevices READ hasDevices NOTIFY hasDevicesChanged)
     Q_PROPERTY(QString availableCodecList READ availableCodecList WRITE setAvailableCodecList NOTIFY availableCodecListChanged)
+    Q_PROPERTY(QStringList availableCodecs READ availableCodecs CONSTANT)
+    Q_PROPERTY(QStringList availableLUTs READ availableLUTs CONSTANT)
     Q_PROPERTY(QString versionNumber READ versionNumber WRITE setVersionNumber NOTIFY versionNumberChanged)
+    Q_PROPERTY(QString buildInfo READ buildInfo WRITE setBuildInfo NOTIFY buildInfoChanged)
 
     Q_PROPERTY(QStandardItemModel* jsonTreeModel READ jsonTreeModel WRITE setJsonTreeModel NOTIFY jsonTreeModelChanged)
 
@@ -38,26 +45,67 @@ public:
     bool userConfigOK() {return m_userConfigOK;}
     void setUserConfigOK(bool userConfigOK) {m_userConfigOK = userConfigOK;}
 
+    // True when the config has at least one device (miniscope or camera). The Run
+    // button is gated on this so you can't run a config with nothing to record.
+    bool hasDevices() const { return m_hasDevices; }
+
     QString userConfigDisplay(){ return m_userConfigDisplay; }
     void setUserConfigDisplay(const QString &input);
 
     QString availableCodecList(){ return m_availableCodecList; }
     void setAvailableCodecList(const QString &input);
 
+    // List of host-supported codecs, for the compression dropdown in the tree editor.
+    QStringList availableCodecs() const { return QStringList(m_availableCodec.begin(), m_availableCodec.end()); }
+
+    // Display LUTs (colormaps) offered in the tree editor's "lut" dropdown. Must
+    // stay in sync with the lutMode mapping in VideoDevice::createView and the
+    // shader. "None" = grayscale.
+    QStringList availableLUTs() const { return {"None", "Green", "Red", "Inferno"}; }
+
     QString versionNumber() { return m_versionNumber; }
-    void setVersionNumber(const QString &input) { m_versionNumber = input; }
+    void setVersionNumber(const QString &input) { m_versionNumber = input; emit versionNumberChanged(); }
+
+    QString buildInfo() { return m_buildInfo; }
+    void setBuildInfo(const QString &input) { m_buildInfo = input; emit buildInfoChanged(); }
 
     QStandardItemModel* jsonTreeModel() { return m_jsonTreeModel; }
     void setJsonTreeModel(QStandardItemModel* model) { m_jsonTreeModel = model; }
 
     void constructJsonTreeModel();
     Q_INVOKABLE void treeViewTextChanged(const QModelIndex &index, QString text);
+    // Convert a file:// URL from a QML folder/file dialog to a native path, so
+    // the path-browse buttons in the config tree editor can store a plain path.
+    Q_INVOKABLE QString urlToLocalFile(const QUrl &url) const { return url.toLocalFile(); }
+    // Inverse of urlToLocalFile: build a file:// URL to seed the Save-As dialog.
+    Q_INVOKABLE QUrl localFileToUrl(const QString &path) const { return QUrl::fromLocalFile(path); }
     QStandardItem *handleJsonObject(QStandardItem* parent, QJsonObject obj, QJsonObject objProps);
     QStandardItem *handleJsonArray(QStandardItem* parent, QJsonArray arry, QString type);
     void generateUserConfigFromModel();
     QJsonObject getObjectFromModel(QModelIndex index);
     QJsonArray getArrayFromModel(QModelIndex index);
     Q_INVOKABLE void saveConfigObject();
+    // Save the (edited) user config to a user-chosen path from the Save-As dialog.
+    Q_INVOKABLE void saveConfigObjectAs(const QString &filePath);
+    // Enumerate connected video devices as "deviceID N: <name>" lines so the user
+    // can see which deviceID maps to which camera. Windows (DirectShow) only.
+    Q_INVOKABLE QString scanVideoDevices();
+
+    // --- User-config generator -----------------------------------------------
+    // Device types available to add (keys of deviceConfigs/videoDevices.json), for
+    // the Add-Device dialog's dropdown.
+    Q_INVOKABLE QStringList deviceTypes() const { return m_deviceCatalog.keys(); }
+    // Device IDs not already used by another device in the config, each labelled with
+    // the connected-device name when known. Drives the Add-Device dialog's ID
+    // dropdown so two devices can't be assigned the same deviceID.
+    Q_INVOKABLE QStringList availableDeviceIDs();
+    // Seed a fresh, valid user config from the schema (no example file needed) and
+    // show it in the tree editor.
+    Q_INVOKABLE void newUserConfig();
+    // Add a device of the given catalog type under devices.<category> (category is
+    // "miniscopes" or "cameras"), with sensible catalog-derived defaults, then
+    // rebuild the tree. Names must be non-empty and unique within their category.
+    Q_INVOKABLE void addDevice(const QString &category, const QString &deviceType, const QString &deviceName, int deviceID);
 
 
     void loadUserConfigFile();
@@ -77,8 +125,10 @@ signals:
     void userConfigFileNameChanged();
     void userConfigDisplayChanged();
     void userConfigOKChanged();
+    void hasDevicesChanged();
     void availableCodecListChanged();
     void versionNumberChanged();
+    void buildInfoChanged();
     void jsonTreeModelChanged();
 
     void closeAll();
@@ -101,12 +151,27 @@ private:
 
     void testCodecSupport();
 
+    // User-config generator helpers. defaultFromProps walks a userConfigProps.json
+    // node and returns a default value matching its declared types; defaultForType
+    // maps a single type string to its zero value; enrichDeviceDefaults fills a
+    // freshly-templated device with sensible, catalog-derived starting values.
+    QJsonValue defaultFromProps(const QJsonValue &propNode);
+    QJsonValue defaultForType(const QString &type);
+    void enrichDeviceDefaults(QJsonObject &device, const QString &category, const QString &deviceType);
+
+    // Connected video-device names indexed by deviceID (DirectShow order, which
+    // matches OpenCV's CAP_DSHOW index). Empty off-Windows or when none are found.
+    QStringList enumerateVideoDevices();
+
     QString m_versionNumber;
+    QString m_buildInfo;
     QString m_userConfigFileName;
     QString m_userConfigDisplay;
     bool m_userConfigOK;
+    bool m_hasDevices = false;
     QJsonObject m_userConfig;
     QJsonObject m_configProps;
+    QJsonObject m_deviceCatalog;   // deviceConfigs/videoDevices.json (device types + defaults)
 
     // Break down of different types in user config file
     // 'uc' stands for userConfig

--- a/source/behaviorCam.qml
+++ b/source/behaviorCam.qml
@@ -23,6 +23,9 @@ Item {
     signal calibrateCameraQuit()
 
     signal saturationSwitchChanged(bool value)
+    // Declared (no UI switch) so the shared VideoDevice lutSwitchChanged connect
+    // resolves cleanly; the green LUT toggle lives on the Miniscope window only.
+    signal lutSwitchChanged(bool value)
 
     Keys.onPressed: {
         if (event.key === Qt.Key_H) {
@@ -423,27 +426,27 @@ Item {
 
     Connections{
         target: led0
-        onValueChangedSignal: vidPropChangedSignal(led0.objectName, displayValue, i2cValue, i2cValue2)
+        function onValueChangedSignal(displayValue, i2cValue, i2cValue2) { vidPropChangedSignal(led0.objectName, displayValue, i2cValue, i2cValue2) }
     }
     Connections{
         target: gain
-        onValueChangedSignal: vidPropChangedSignal(gain.objectName, displayValue, i2cValue, i2cValue2)
+        function onValueChangedSignal(displayValue, i2cValue, i2cValue2) { vidPropChangedSignal(gain.objectName, displayValue, i2cValue, i2cValue2) }
     }
     Connections{
         target: frameRate
-        onValueChangedSignal: vidPropChangedSignal(frameRate.objectName, displayValue, i2cValue, i2cValue2)
+        function onValueChangedSignal(displayValue, i2cValue, i2cValue2) { vidPropChangedSignal(frameRate.objectName, displayValue, i2cValue, i2cValue2) }
     }
     Connections{
         target: alpha
-        onValueChangedSignal: vidPropChangedSignal(alpha.objectName, displayValue, i2cValue, i2cValue2)
+        function onValueChangedSignal(displayValue, i2cValue, i2cValue2) { vidPropChangedSignal(alpha.objectName, displayValue, i2cValue, i2cValue2) }
     }
     Connections{
         target: beta
-        onValueChangedSignal: vidPropChangedSignal(beta.objectName, displayValue, i2cValue, i2cValue2)
+        function onValueChangedSignal(displayValue, i2cValue, i2cValue2) { vidPropChangedSignal(beta.objectName, displayValue, i2cValue, i2cValue2) }
     }
     Connections{
         target: saturationSwitch
-        onClicked: saturationSwitchChanged(saturationSwitch.checked)
+        function onClicked() { saturationSwitchChanged(saturationSwitch.checked) }
     }
 
 

--- a/source/behaviortracker.cpp
+++ b/source/behaviortracker.cpp
@@ -6,11 +6,11 @@
 #include <opencv2/opencv.hpp>
 
 #include <QtQuick/QQuickItem>
-#include <QtGui/QOpenGLShaderProgram>
+#include <QtOpenGL/QOpenGLShaderProgram>     // Qt6: moved from QtGui to Qt6::OpenGL
 #include <QtGui/QOpenGLFunctions>
-#include <QtGui/QOpenGLTexture>
-#include <QtGui/QOpenGLBuffer>
-#include <QtGui/QOpenGLFramebufferObject>
+#include <QtOpenGL/QOpenGLTexture>   // Qt6: moved from QtGui to Qt6::OpenGL
+#include <QtOpenGL/QOpenGLBuffer>            // Qt6: moved from QtGui to Qt6::OpenGL
+#include <QtOpenGL/QOpenGLFramebufferObject> // Qt6: moved from QtGui to Qt6::OpenGL
 
 #include <QJsonObject>
 #include <QDebug>
@@ -64,7 +64,8 @@ BehaviorTracker::BehaviorTracker(QObject *parent, QJsonObject userConfig, qint64
 
 int BehaviorTracker::initNumpy()
 {
-    import_array1(-1);
+    import_array1(-1); // expands to `return -1` on failure; fall through = success
+    return 0;
 }
 
 void BehaviorTracker::parseUserConfigTracker()
@@ -216,8 +217,17 @@ void BehaviorTracker::createView(QSize resolution)
     view->setX(btConfig["windowX"].toInt(1));
     view->setY(btConfig["windowY"].toInt(1));
 
+    // Let the tracker display scale with the window, locked to the camera's
+    // aspect ratio.
+    view->setResizeMode(QQuickView::SizeRootObjectToView);
+    view->setMinimumSize(QSize(view->width() / 2, view->height() / 2));
+    view->setLockedAspectRatio((qreal)view->width() / (qreal)view->height());
+
 #ifdef Q_OS_WINDOWS
-    view->setFlags(Qt::Window | Qt::MSWindowsFixedSizeDialogHint | Qt::WindowTitleHint);
+    // Resizable (border drag) + minimizable; no maximize since that would break
+    // the locked aspect ratio.
+    view->setFlags(Qt::Window | Qt::WindowTitleHint | Qt::WindowSystemMenuHint
+                   | Qt::WindowMinimizeButtonHint);
 #endif
 
 
@@ -808,6 +818,9 @@ void TrackerDisplayRenderer::drawTrackerOverlay (QString type) {
 
 void TrackerDisplayRenderer::paint()
 {
+    // Qt6: bracket all raw OpenGL with begin/endExternalCommands (replaces resetOpenGLState).
+    m_window->beginExternalCommands();
+
     glViewport(0, 0, m_viewportSize.width(), m_viewportSize.height());
     glDisable(GL_DEPTH_TEST);
 
@@ -838,9 +851,8 @@ void TrackerDisplayRenderer::paint()
         draw2DHist();
     }
 
-    // Not strictly needed for this example, but generally useful for when
-    // mixing with raw OpenGL.
-    m_window->resetOpenGLState();
+    // Qt6: replaces the removed m_window->resetOpenGLState().
+    m_window->endExternalCommands();
 }
 
 TrackerDisplay::TrackerDisplay():
@@ -926,11 +938,8 @@ void TrackerDisplay::handleWindowChanged(QQuickWindow *win)
     if (win) {
         connect(win, &QQuickWindow::beforeSynchronizing, this, &TrackerDisplay::sync, Qt::DirectConnection);
         connect(win, &QQuickWindow::sceneGraphInvalidated, this, &TrackerDisplay::cleanup, Qt::DirectConnection);
-//! [1]
-        // If we allow QML to do the clearing, they would clear what we paint
-        // and nothing would show.
-//! [3]
-        win->setClearBeforeRendering(false);
+        // Qt6: setClearBeforeRendering() was removed; set the clear color instead.
+        win->setColor(Qt::black);
     }
 }
 
@@ -940,7 +949,8 @@ void TrackerDisplay::sync()
         m_renderer = new TrackerDisplayRenderer(nullptr, window()->size() * window()->devicePixelRatio());
 //        m_renderer->setShowSaturation(m_showSaturation);
 //        m_renderer->setDisplayFrame(QImage("C:/Users/DBAharoni/Pictures/Miniscope/Logo/1.png"));
-        connect(window(), &QQuickWindow::beforeRendering, m_renderer, &TrackerDisplayRenderer::paint, Qt::DirectConnection);
+        // Qt6: underlay must draw during render-pass recording (see videodisplay.cpp).
+        connect(window(), &QQuickWindow::beforeRenderPassRecording, m_renderer, &TrackerDisplayRenderer::paint, Qt::DirectConnection);
         m_renderer->m_showOcc = m_showOcc;
         m_renderer->pValCut = m_pValCut;
         m_renderer->overlayEnabled = m_overlayEnabled;

--- a/source/behaviortracker.h
+++ b/source/behaviortracker.h
@@ -8,11 +8,11 @@
 #include <opencv2/opencv.hpp>
 
 #include <QtQuick/QQuickItem>
-#include <QtGui/QOpenGLShaderProgram>
+#include <QtOpenGL/QOpenGLShaderProgram>     // Qt6: moved from QtGui to Qt6::OpenGL
 #include <QtGui/QOpenGLFunctions>
-#include <QtGui/QOpenGLTexture>
-#include <QtGui/QOpenGLBuffer>
-#include <QtGui/QOpenGLFramebufferObject>
+#include <QtOpenGL/QOpenGLTexture>   // Qt6: moved from QtGui to Qt6::OpenGL
+#include <QtOpenGL/QOpenGLBuffer>            // Qt6: moved from QtGui to Qt6::OpenGL
+#include <QtOpenGL/QOpenGLFramebufferObject> // Qt6: moved from QtGui to Qt6::OpenGL
 
 #include <QObject>
 #include <QJsonObject>

--- a/source/behaviortrackerworker.cpp
+++ b/source/behaviortrackerworker.cpp
@@ -78,7 +78,8 @@ void BehaviorTrackerWorker::initPython()
 
 int BehaviorTrackerWorker::initNumpy()
 {
-    import_array1(-1);
+    import_array1(-1); // expands to `return -1` on failure; fall through = success
+    return 0;
 }
 
 void BehaviorTrackerWorker::setUpDLCLive()

--- a/source/datasaver.cpp
+++ b/source/datasaver.cpp
@@ -172,7 +172,7 @@ void DataSaver::startRunning()
 
                     for (j = 0; j < poseBuffer[poseBufPosition].length(); j++)
                         poseData.append(QString::number(poseBuffer[poseBufPosition][j], 'g', 3) + ",");
-                    *behavTrackerStream << poseData << endl;
+                    *behavTrackerStream << poseData << Qt::endl;
                 }
                 btPoseCount++;
                 freePoses->release(1);
@@ -213,7 +213,7 @@ void DataSaver::startRunning()
                     bufPosition = frameCount[names[i]] % bufferSize[names[i]];
                     *csvStream[names[i]] << savedFrameCount[names[i]] << ","
                                          << (timeStampBuffer[names[i]][bufPosition] - recordStartDateTime.toMSecsSinceEpoch()) << ","
-                                         << usedCount[names[i]]->available() << endl;
+                                         << usedCount[names[i]]->available() << Qt::endl;
 
                     if (headOrientationStreamState[names[i]] == true && bnoBuffer[names[i]] != nullptr) {
                         if (headOrientationFilterState[names[i]] && bnoBuffer[names[i]][bufPosition*5 + 4] >= 0.05) { // norm is below 0.98. Should be 1 ideally
@@ -224,7 +224,7 @@ void DataSaver::startRunning()
                                                      << bnoBuffer[names[i]][bufPosition*5 + 0] << ","
                                                      << bnoBuffer[names[i]][bufPosition*5 + 1] << ","
                                                      << bnoBuffer[names[i]][bufPosition*5 + 2] << ","
-                                                     << bnoBuffer[names[i]][bufPosition*5 + 3] << endl;
+                                                     << bnoBuffer[names[i]][bufPosition*5 + 3] << Qt::endl;
                         }
 
                     }
@@ -312,7 +312,7 @@ void DataSaver::startRecording(QMap<QString,QVariant> ucInfo)
             behavTrackerStream = new QTextStream(behavTrackerFile);
 
             // TODO: Add header info for behav tracker csv file here
-            *behavTrackerStream << "DLC-Live Pose Data." << endl;
+            *behavTrackerStream << "DLC-Live Pose Data." << Qt::endl;
         }
 
         QString tempStr;
@@ -322,13 +322,13 @@ void DataSaver::startRecording(QMap<QString,QVariant> ucInfo)
             csvFile[keys[i]] = new QFile(deviceDirectory[keys[i]] + "/timeStamps.csv");
             csvFile[keys[i]]->open(QFile::WriteOnly | QFile::Truncate);
             csvStream[keys[i]] = new QTextStream(csvFile[keys[i]]);
-            *csvStream[keys[i]] << "Frame Number,Time Stamp (ms),Buffer Index" << endl;
+            *csvStream[keys[i]] << "Frame Number,Time Stamp (ms),Buffer Index" << Qt::endl;
 
             if (headOrientationStreamState[keys[i]] == true && bnoBuffer[keys[i]] != nullptr) {
                 headOriFile[keys[i]] = new QFile(deviceDirectory[keys[i]] + "/headOrientation.csv");
                 headOriFile[keys[i]]->open(QFile::WriteOnly | QFile::Truncate);
                 headOriStream[keys[i]] = new QTextStream(headOriFile[keys[i]]);
-                *headOriStream[keys[i]] << "Time Stamp (ms),qw,qx,qy,qz" << endl;
+                *headOriStream[keys[i]] << "Time Stamp (ms),qw,qx,qy,qz" << Qt::endl;
             }
             // TODO: Remember to close files on exit or stop recording signal
 
@@ -345,7 +345,7 @@ void DataSaver::startRecording(QMap<QString,QVariant> ucInfo)
         noteFile = new QFile(baseDirectory + "/notes.csv");
         noteFile->open(QFile::WriteOnly | QFile::Truncate);
         noteStream = new QTextStream(noteFile);
-        *noteStream << "Time Stamp (ms), Note" << endl;
+        *noteStream << "Time Stamp (ms), Note" << Qt::endl;
 
         // TODO: Save camera calibration file to data directory for each behavioral camera
         m_recording = true;
@@ -421,7 +421,7 @@ void DataSaver::takeNote(QString note)
     // Writes note to file submitted through control panel
     // Only write notes when recording
     if (m_recording) {
-        *noteStream << QDateTime().currentMSecsSinceEpoch() - recordStartDateTime.toMSecsSinceEpoch() << "," << note << endl;
+        *noteStream << QDateTime().currentMSecsSinceEpoch() - recordStartDateTime.toMSecsSinceEpoch() << "," << note << Qt::endl;
     }
 }
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -8,26 +8,55 @@
 
 #include <QThreadPool>
 
+#include <QQuickWindow>
+#include <QSGRendererInterface>
+#include <QQuickStyle>
+#include <QStyleHints>
+
 #include "backend.h"
 
-#define VERSION_NUMBER "1.10"
+#include <opencv2/core/version.hpp>   // CV_VERSION (e.g. "4.13.0"); macro-only header
+
+#ifdef USE_PYTHON
+#include <patchlevel.h>   // PY_VERSION (e.g. "3.12.7"); pure macro header, safe alone
+#endif
+
+#define VERSION_NUMBER "2.0"
 // TODO: have exit button close everything
 
 // For Window's deployment
 //C:\Qt\5.12.6>C:\Qt\5.12.6\msvc2017_64\bin\windeployqt.exe --qmldir C:\Users\DBAharoni\Documents\Projects\Miniscope-DAQ-QT-Software\Miniscope-DAQ-QT-Software\ C:\Users\DBAharoni\Documents\Projects\Miniscope-DAQ-QT-Software\build-Miniscope-DAQ-QT-Software-Desktop_Qt_5_12_6_MSVC2017_64bit-Release\release\Miniscope-DAQ-QT-Software.exe
 int main(int argc, char *argv[])
 {
-    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    // Qt6: high-DPI scaling is always on, so AA_EnableHighDpiScaling is gone
+    // (it was a no-op / deprecated).
 
-    QApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
+    // The custom video/trace/tracker renderers issue raw OpenGL commands, so
+    // force the scene graph's RHI backend to OpenGL. Qt6 defaults to Direct3D 11
+    // on Windows, under which the raw-GL code would not work. This must be called
+    // before any QQuickWindow is created.
+    QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGL);
     QCoreApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
-    QGuiApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
 
     QGuiApplication app(argc, argv);
+
+    // Qt6: the default Controls style on Windows is the native style, which does
+    // not allow customizing control backgrounds (the QML relies on that). "Basic"
+    // is Qt6's renamed, fully-customizable "Default" style from Qt5.
+    QQuickStyle::setStyle("Basic");
+
+    // Qt6 follows the OS dark/light theme, but this UI is designed for light
+    // backgrounds with implicit (palette) text colors; under Windows dark mode
+    // the default text becomes light and is invisible. Force the light scheme.
+    app.styleHints()->setColorScheme(Qt::ColorScheme::Light);
 
     qRegisterMetaType < QVector<quint8> >("QVector<quint8>");
 
     QQmlApplicationEngine engine;
+    // For a deployed (standalone) build, find the bundled QML modules next to
+    // the exe. Harmless when running against the conda env. (Qt auto-finds the
+    // platform/image plugins in <appdir>/<category>.)
+    engine.addImportPath(QCoreApplication::applicationDirPath() + "/qml");
     const QUrl url(QStringLiteral("qrc:/main.qml"));
     QObject::connect(&engine, &QQmlApplicationEngine::objectCreated,
                      &app, [url](QObject *obj, const QUrl &objUrl) {
@@ -46,6 +75,18 @@ int main(int argc, char *argv[])
     engine.load(url);
 
     backend.setVersionNumber(VERSION_NUMBER);
+
+    // Build/runtime info shown in the Help dialog.
+#ifdef USE_PYTHON
+    const QString pythonVersion = QStringLiteral(PY_VERSION);
+#else
+    const QString pythonVersion = QStringLiteral("not built");
+#endif
+    backend.setBuildInfo(QStringLiteral("Qt %1 | OpenCV %2 | Python %3 | Built %4")
+                             .arg(QString::fromLatin1(qVersion()))
+                             .arg(QStringLiteral(CV_VERSION))
+                             .arg(pythonVersion)
+                             .arg(QStringLiteral(__DATE__)));
 //    qDebug() << "TTTEEEE" << engine.rootObjects().first()->findChild<QObject*>("treeView");
 //    QObject::connect(engine.rootObjects().first()->findChild<QObject*>("treeView"), &QTreeView::clicked, &backend, &backEnd::treeViewclicked);
     QObject::connect(&backend, &backEnd::closeAll, &engine, &QQmlApplicationEngine::quit);

--- a/source/main.qml
+++ b/source/main.qml
@@ -2,7 +2,7 @@ import QtQuick 2.12
 import QtQuick.Window 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.3
-import QtQuick.Dialogs 1.2
+import QtQuick.Dialogs
 
 Window {
     id: root
@@ -20,11 +20,11 @@ Window {
 
         id: fileDialog
         title: "Please choose a user configuration file."
-        folder: shortcuts.home
+        // Qt6: 'folder: shortcuts.home' removed (shortcuts gone); FileDialog defaults are fine.
         nameFilters: [ "JSON files (*.json)", "All files (*)" ]
         onAccepted: {
-            // Send file name to c++ backend
-            backend.userConfigFileName = fileDialog.fileUrl
+            // Send file name to c++ backend  (Qt6: fileUrl -> selectedFile)
+            backend.userConfigFileName = fileDialog.selectedFile
             treeView.visible = true;
             view.visible = false;
 //            rbRun.enabled = true
@@ -35,11 +35,27 @@ Window {
         visible: false
     }
 
+    FileDialog {
+        // Save-As dialog: lets the user choose the folder and filename to save the
+        // (possibly edited) user config to.
+        id: saveConfigDialog
+        title: "Save user configuration as…"
+        fileMode: FileDialog.SaveFile
+        nameFilters: [ "JSON files (*.json)", "All files (*)" ]
+        defaultSuffix: "json"
+        onAccepted: {
+            var path = backend.urlToLocalFile(saveConfigDialog.selectedFile)
+            backend.saveConfigObjectAs(path)
+            saveMessageDialog.savedPath = path
+            saveMessageDialog.open()
+        }
+    }
+
 
     Window {
         id: helpDialog
         width: 600
-        height: 200
+        height: 260
         visible: false
         title: "Miniscope DAQ Help"
         ColumnLayout {
@@ -47,13 +63,12 @@ Window {
 
             TextArea {
                 text: "Miniscope DAQ Software version " + backend.versionNumber + "<br/>" +
-                      "Your OpenGL verions: " + OpenGLInfo.majorVersion + "." + OpenGLInfo.minorVersion + "<br/>" +
+                      "<font color='#555555'>" + backend.buildInfo + "</font><br/> <br/>" +
                       "Developed by the <a href='https://aharoni-lab.github.io/'>Aharoni Lab</a>, UCLA <br/> " +
                       "Overview of the UCLA Miniscope project: <a href='http://www.miniscope.org'>click here</a> <br/>" +
                       "Miniscope Wiki for newest projects: <a href='https://github.com/Aharoni-Lab/Miniscope-v4/wiki'>click here</a> <br/>" +
                       "Miniscope Discussion Board: <a href='https://groups.google.com/d/forum/miniscope'>click here</a> <br/>" +
-                      "Please submit issues, comments, suggestions to the Miniscope DAQ Software Github Repository: <a href='https://github.com/Aharoni-Lab/Miniscope-DAQ-QT-Software'>click here</a> <br/>" +
-                      "Miniscope Twitter Link: <a href='https://twitter.com/MiniscopeTeam'>click here</a> <br/> <br/>" +
+                      "Please submit issues, comments, suggestions to the Miniscope DAQ Software Github Repository: <a href='https://github.com/Aharoni-Lab/Miniscope-DAQ-QT-Software'>click here</a> <br/> <br/>" +
                       "Icons from <a href='https://icons8.com/'>icon8</a>"
                 verticalAlignment: Text.AlignVCenter
                 horizontalAlignment: Text.AlignHCenter
@@ -111,13 +126,28 @@ Window {
 
     MessageDialog {
         id: saveMessageDialog
-        property string fName: backend.userConfigFileName
+        property string savedPath: ""
         title: "User Config File Saved"
-        text:  "The user config file has been saved to " + fName.replace(".json", "_new.json")
+        text:  "The user config file has been saved to " + savedPath
         onAccepted: {
             visible = false
         }
         visible: false
+    }
+
+    MessageDialog {
+        id: deviceScanDialog
+        title: "Connected Video Devices"
+        text: ""
+        onAccepted: visible = false
+        visible: false
+    }
+
+    AddDeviceDialog {
+        id: addDeviceDialog
+        // Insert the chosen device into the config being edited, then the tree
+        // rebuilds itself from the backend model.
+        onAccepted: backend.addDevice(category, deviceType, deviceName, deviceID)
     }
 
 
@@ -165,10 +195,56 @@ Window {
                     border.width: 1
                     color: "#a8a7fd"
                 }
-                onClicked: fileDialog.setVisible(1)
+                onClicked: fileDialog.open()   // Qt6: open() instead of setVisible(1)
                 onHoveredChanged: hovered ? configRect.color = "#f8a7fd" : configRect.color = "#a8a7fd"
 
             }
+
+            RoundButton {
+                id: rbNewConfig
+                height: 40
+                text: "New Config"
+                Layout.minimumHeight: 40
+                Layout.preferredHeight: 40
+                Layout.fillHeight: false
+                Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+                Layout.fillWidth: true
+                font.family: "Arial"
+                font.pointSize: 18
+                font.bold: true
+                font.weight: Font.Normal
+                radius: 10
+
+                Layout.minimumWidth: 100
+                Layout.preferredWidth: 200
+                Layout.maximumWidth: 700
+
+                background: Rectangle {
+                    id: newConfigRect
+                    radius: rbNewConfig.radius
+                    border.width: 1
+                    color: "#a8a7fd"
+                }
+                onClicked: {
+                    // Generate a fresh skeleton config and open it in the tree editor.
+                    backend.newUserConfig()
+                    treeView.visible = true
+                    view.visible = false
+                }
+                onHoveredChanged: hovered ? newConfigRect.color = "#f8a7fd" : newConfigRect.color = "#a8a7fd"
+            }
+        }
+
+        RowLayout {
+            // Second row of top-level buttons, so the four don't crowd into one
+            // row (their labels would otherwise overlap).
+            id: rowLayoutTop2
+            height: 40
+            Layout.minimumHeight: 40
+            Layout.preferredHeight: 40
+            Layout.fillHeight: false
+            Layout.fillWidth: true
+            spacing: 10
 
             RoundButton {
                 id: rbSaveUserConfig
@@ -197,15 +273,70 @@ Window {
                     color: "#a8a7fd"
                 }
                 onClicked: {
-
-                    backend.saveConfigObject()
-                    saveMessageDialog.visible = true
+                    // Seed the dialog with the loaded config's folder + name, then
+                    // let the user pick the folder/filename to save to.
+                    saveConfigDialog.selectedFile = backend.localFileToUrl(backend.userConfigFileName)
+                    saveConfigDialog.open()
                 }
                 onHoveredChanged: hovered ? configSaveRect.color = "#f8a7fd" : configSaveRect.color = "#a8a7fd"
 
             }
+
+            RoundButton {
+                id: rbScanDevices
+                height: 40
+                text: "Scan Devices"
+                Layout.minimumHeight: 40
+                Layout.preferredHeight: 40
+                Layout.fillHeight: false
+                Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+                Layout.fillWidth: true
+                font.family: "Arial"
+                font.pointSize: 18
+                font.bold: true
+                font.weight: Font.Normal
+                radius: 10
+
+                Layout.minimumWidth: 100
+                Layout.preferredWidth: 200
+                Layout.maximumWidth: 700
+
+                background: Rectangle {
+                    id: scanRect
+                    radius: rbScanDevices.radius
+                    border.width: 1
+                    color: "#a8a7fd"
+                }
+                onClicked: {
+                    deviceScanDialog.text = backend.scanVideoDevices()
+                    deviceScanDialog.open()
+                }
+                onHoveredChanged: hovered ? scanRect.color = "#f8a7fd" : scanRect.color = "#a8a7fd"
+            }
         }
         ColumnLayout {
+            RoundButton {
+                id: rbAddDevice
+                text: "Add Device"
+                visible: treeView.visible
+                Layout.fillWidth: true
+                Layout.preferredHeight: 36
+                Layout.minimumHeight: 36
+                font.family: "Arial"
+                font.pointSize: 14
+                font.bold: true
+                font.weight: Font.Normal
+                radius: 10
+                background: Rectangle {
+                    id: addDeviceRect
+                    radius: rbAddDevice.radius
+                    border.width: 1
+                    color: "#a8a7fd"
+                }
+                onClicked: addDeviceDialog.open()
+                onHoveredChanged: hovered ? addDeviceRect.color = "#f8a7fd" : addDeviceRect.color = "#a8a7fd"
+            }
+
             TreeViewerJSON {
                 id: treeView
                 objectName: "treeView"
@@ -307,7 +438,8 @@ Window {
             height: 40
             radius: 10
             text: "Run"
-            enabled: backend.userConfigOK
+            // Need a valid config AND at least one device (miniscope or camera).
+            enabled: backend.userConfigOK && backend.hasDevices
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             Layout.preferredHeight: 40
             font.family: "Arial"
@@ -389,11 +521,12 @@ Window {
 
     Connections{
         target: backend
-        onShowErrorMessage: errorMessageDialog.visible = true
+        // Qt6: Connections requires the function syntax instead of onSignal: ...
+        function onShowErrorMessage() { errorMessageDialog.open() }
     }
     Connections{
         target: backend
-        onShowErrorMessageCompression: errorMessageDialogCompression.visible = true
+        function onShowErrorMessageCompression() { errorMessageDialogCompression.open() }
     }
     Component.onCompleted: {
         setX(Screen.width / 2 - width / 2);

--- a/source/miniscope.cpp
+++ b/source/miniscope.cpp
@@ -47,7 +47,8 @@ void Miniscope::setupDisplayObjectPointers()
     if (getHeadOrienataionStreamState())
         bnoDisplay = getRootDisplayChild("bno");
     QObject* temp = getRootDisplayChild("addTraceRoi");
-    temp->setProperty("enabled", getTraceDisplayStatus());
+    if (temp)   // only present when the trace display is in use
+        temp->setProperty("enabled", getTraceDisplayStatus());
     vidDisplay = getVideoDisplay();
 }
 void Miniscope::handleDFFSwitchChange(bool checked)
@@ -97,27 +98,27 @@ void Miniscope::handleAddNewTraceROI(int leftEdge, int topEdge, int width, int h
 
         tempProp = qvariant_cast< QList<double> >(vidDisplay->property("traceROIx"));
         tempProp.append(leftEdge);
-        varParams.setValue<QList<double>>( tempProp );
+        varParams.setValue( tempProp );  // Qt6: setValue is setValue(T&&); explicit <T> would force an rvalue-ref param
         vidDisplay->setProperty("traceROIx", varParams);
 
         tempProp = qvariant_cast< QList<double> >(vidDisplay->property("traceROIy"));
         tempProp.append(topEdge);
-        varParams.setValue<QList<double>>( tempProp );
+        varParams.setValue( tempProp );  // Qt6: setValue is setValue(T&&); explicit <T> would force an rvalue-ref param
         vidDisplay->setProperty("traceROIy", varParams);
 
         tempProp = qvariant_cast< QList<double> >(vidDisplay->property("traceROIw"));
         tempProp.append(width);
-        varParams.setValue<QList<double>>( tempProp );
+        varParams.setValue( tempProp );  // Qt6: setValue is setValue(T&&); explicit <T> would force an rvalue-ref param
         vidDisplay->setProperty("traceROIw", varParams);
 
         tempProp = qvariant_cast< QList<double> >(vidDisplay->property("traceROIh"));
         tempProp.append(height);
-        varParams.setValue<QList<double>>( tempProp );
+        varParams.setValue( tempProp );  // Qt6: setValue is setValue(T&&); explicit <T> would force an rvalue-ref param
         vidDisplay->setProperty("traceROIh", varParams);
 
         tempProp = qvariant_cast< QList<double> >(vidDisplay->property("traceColor"));
         tempProp.append(m_traceColors[m_numTraces][0]);
-        varParams.setValue<QList<double>>( tempProp );
+        varParams.setValue( tempProp );  // Qt6: setValue is setValue(T&&); explicit <T> would force an rvalue-ref param
         vidDisplay->setProperty("traceColor", varParams);
 
 
@@ -323,9 +324,11 @@ void Miniscope::setupBNOTraceDisplay()
         bnoNumDataInBuf[i][1] = 0;
 
     }
-    bnoScale[0] = 1.0f/3.141592f;
-    bnoScale[1] = 1.0f/3.141592f;
-    bnoScale[2] = 1.0f/3.141592f;
+    // BNO Euler angles span +/-pi. 1/(4*pi) maps that to a +/-0.25 half-amplitude
+    // (half of a neuron trace's +/-0.5), which reads well next to the neuron traces.
+    bnoScale[0] = 1.0f/(4.0f*3.141592f);
+    bnoScale[1] = 1.0f/(4.0f*3.141592f);
+    bnoScale[2] = 1.0f/(4.0f*3.141592f);
 
     if (getHeadOrienataionStreamState()) {
         QJsonArray tempArray = m_ucDevice["headOrientation"].toObject()["plotTrace"].toArray();

--- a/source/newquickview.cpp
+++ b/source/newquickview.cpp
@@ -1,3 +1,58 @@
 #include "newquickview.h"
 
+#ifdef Q_OS_WINDOWS
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#include <QtGlobal>
 
+// Keep interactive resizing locked to m_aspectRatio. WM_SIZING hands us the
+// proposed *window* rect (title bar + borders included) and the edge being
+// dragged; we correct the rect so the *client* area keeps the locked ratio.
+// Working in the native (physical-pixel) RECT and deriving the frame size from
+// GetWindowRect/GetClientRect keeps this correct under display scaling.
+bool NewQuickView::nativeEvent(const QByteArray &eventType, void *message, qintptr *result)
+{
+    if (m_aspectRatio > 0.0 && eventType == "windows_generic_MSG") {
+        MSG *msg = static_cast<MSG *>(message);
+        if (msg->message == WM_SIZING) {
+            RECT *rect = reinterpret_cast<RECT *>(msg->lParam);
+
+            RECT windowRect, clientRect;
+            GetWindowRect(msg->hwnd, &windowRect);
+            GetClientRect(msg->hwnd, &clientRect); // client origin is (0,0)
+            const int frameW = (windowRect.right - windowRect.left) - clientRect.right;
+            const int frameH = (windowRect.bottom - windowRect.top) - clientRect.bottom;
+
+            int clientW = (rect->right - rect->left) - frameW;
+            int clientH = (rect->bottom - rect->top) - frameH;
+
+            switch (msg->wParam) {
+            case WMSZ_LEFT:
+            case WMSZ_RIGHT:
+                // Dragging a vertical edge: width drives height.
+                clientH = qRound(clientW / m_aspectRatio);
+                rect->bottom = rect->top + clientH + frameH;
+                break;
+            case WMSZ_TOP:
+            case WMSZ_BOTTOM:
+                // Dragging a horizontal edge: height drives width.
+                clientW = qRound(clientH * m_aspectRatio);
+                rect->right = rect->left + clientW + frameW;
+                break;
+            default:
+                // Dragging a corner: width drives height, growing toward the corner.
+                clientH = qRound(clientW / m_aspectRatio);
+                if (msg->wParam == WMSZ_TOPLEFT || msg->wParam == WMSZ_TOPRIGHT)
+                    rect->top = rect->bottom - clientH - frameH;
+                else
+                    rect->bottom = rect->top + clientH + frameH;
+                break;
+            }
+            *result = TRUE;
+            return true;
+        }
+    }
+    return QQuickView::nativeEvent(eventType, message, result);
+}
+#endif

--- a/source/newquickview.h
+++ b/source/newquickview.h
@@ -11,6 +11,11 @@ class NewQuickView: public QQuickView {
 public:
     NewQuickView(QUrl url):
         QQuickView(url) {}
+
+    // Lock interactive (border-drag) resizing to a fixed width:height ratio of the
+    // client area. Pass 0 (the default) to leave the window freely resizable.
+    void setLockedAspectRatio(qreal ratio) { m_aspectRatio = ratio; }
+
 public:
     bool event(QEvent *event) override
     {
@@ -21,10 +26,21 @@ public:
         }
         return QQuickView::event(event);
     }
+
+#ifdef Q_OS_WINDOWS
+protected:
+    // Constrains live resizing to m_aspectRatio by adjusting the proposed window
+    // rect on WM_SIZING (see newquickview.cpp).
+    bool nativeEvent(const QByteArray &eventType, void *message, qintptr *result) override;
+#endif
+
 signals:
     void closing();
 
 public slots:
+
+private:
+    qreal m_aspectRatio = 0.0; // 0 => unlocked (free resize)
 
 };
 

--- a/source/qml.qrc
+++ b/source/qml.qrc
@@ -43,5 +43,6 @@
         <file>shaders/trackerOverlay.frag</file>
         <file>shaders/trackerOverlay.vert</file>
         <file>TreeViewerJSON.qml</file>
+        <file>AddDeviceDialog.qml</file>
     </qresource>
 </RCC>

--- a/source/shaders/imageSaturationScaling.frag
+++ b/source/shaders/imageSaturationScaling.frag
@@ -3,13 +3,46 @@ varying highp vec2 v_texcoord;
 uniform lowp float alpha;
 uniform lowp float beta;
 uniform lowp float showSaturation;
+uniform lowp float lutMode;   // 0 grayscale, 1 green, 2 red, 3 inferno
+
+// Polynomial approximation of the Inferno colormap (Matt Zucker,
+// "Simple Analytic Approximations to the CIE colormaps").
+vec3 inferno(float t) {
+    vec3 c0 = vec3(0.0002189403691192265, 0.001651004631001012, -0.01948089843709184);
+    vec3 c1 = vec3(0.1065134194856116, 0.5639564367884091, 3.932712388889277);
+    vec3 c2 = vec3(11.60249308247187, -3.972853965665698, -15.9423941062914);
+    vec3 c3 = vec3(-41.70399613139459, 17.43639888205313, 44.35414519872813);
+    vec3 c4 = vec3(77.162935699427, -33.40235894210092, -81.80730925738993);
+    vec3 c5 = vec3(-71.31942824499214, 32.62606426397723, 73.20951985803202);
+    vec3 c6 = vec3(25.13112622477341, -12.24266895238567, -23.07032500287172);
+    return c0 + t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * (c5 + t * c6)))));
+}
+
 void main() {
    gl_FragColor = texture2D(texture, v_texcoord);
-   if (gl_FragColor.b >= .99 && showSaturation == 1.0)
-       gl_FragColor = vec4(0.0, 0.0, 1.0, 1.0);
-   else
+   if (gl_FragColor.b >= .99 && showSaturation == 1.0) {
+       gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);   // saturation highlight: red
+   }
+   else {
        gl_FragColor.rgb = (gl_FragColor.rgb - beta)/(alpha - beta);
-   lowp float temp = gl_FragColor.r;
-   gl_FragColor.r = gl_FragColor.b;
-   gl_FragColor.b = temp;
+       highp float t = clamp(gl_FragColor.g, 0.0, 1.0);
+       if (lutMode == 1.0) {
+           // GFP/GCaMP-like green (~530 nm): dark -> green -> light green/white.
+           gl_FragColor = vec4(t * t, t, t * t * t, 1.0);
+       }
+       else if (lutMode == 2.0) {
+           // Red indicators (jRGECO/RCaMP/tdTomato): dark -> red -> light red/white.
+           gl_FragColor = vec4(t, t * t, t * t * t, 1.0);
+       }
+       else if (lutMode == 3.0) {
+           // Perceptually-uniform intensity map.
+           gl_FragColor = vec4(clamp(inferno(t), 0.0, 1.0), 1.0);
+       }
+       else {
+           // Grayscale (BGR -> RGB swap for color behaviour cams).
+           lowp float temp = gl_FragColor.r;
+           gl_FragColor.r = gl_FragColor.b;
+           gl_FragColor.b = temp;
+       }
+   }
 }

--- a/source/shaders/movingBar.vert
+++ b/source/shaders/movingBar.vert
@@ -11,7 +11,7 @@ uniform float u_time;
 uniform float u_windowSize;
 
 void main() {
-    float scrollBarPos = 2 * mod(u_time,u_windowSize)/u_windowSize - 1; // From -1 to 1
+    float scrollBarPos = 2.0 * mod(u_time,u_windowSize)/u_windowSize - 1.0; // From -1 to 1
 
     vec2 pos = a_position;
     pos.x = scrollBarPos;

--- a/source/shaders/trace.frag
+++ b/source/shaders/trace.frag
@@ -19,7 +19,7 @@ void main() {
     }
     else if (gl_FragColor.g == -2.0 && gl_FragColor.b == -2.0) {
         // Use parula colormap_parula
-        gl_FragColor = colormap_gnu_plot(gl_FragColor.r, 33.0, 13.0, 10.0);
+        gl_FragColor = colormap_gnu_plot(gl_FragColor.r, 33, 13, 10);
     }
     else if (gl_FragColor.g == -3.0 && gl_FragColor.b == -3.0) {
         // Use parula colormap_parula

--- a/source/shaders/tracker.frag
+++ b/source/shaders/tracker.frag
@@ -8,12 +8,12 @@ vec4 colormap_parula(float x);
 
 void main() {
     gl_FragColor = texture2D(texture, v_texcoord);
-    if (u_displayType == 0.0f) {
+    if (u_displayType == 0.0) {
         float temp = gl_FragColor.r;
         gl_FragColor.r = gl_FragColor.b;
         gl_FragColor.b = temp;
     }
-    else if (u_displayType == 1.0f) {
+    else if (u_displayType == 1.0) {
         float val = gl_FragColor.r * 255.0 + gl_FragColor.g * 65536.0;
         val = log(val) / log(u_occMax);
         gl_FragColor = colormap_parula(val);

--- a/source/shaders/trackerOverlay.frag
+++ b/source/shaders/trackerOverlay.frag
@@ -18,7 +18,7 @@ vec4 colormap_jet(float x);
 
 void main(void)
 {
-    if (v_color == 2) {
+    if (v_color == 2.0) {
         gl_FragColor = vec4(1.0, 1.0, 1.0, 0.5);
     }
     else {
@@ -31,7 +31,7 @@ void main(void)
 //        gl_FragColor = mix(gl_FragColor,vec4(0.0,0.0,0.0,0.0), 0.9);
 //        if (gl_FragColor.a > 0.1)
 //            gl_FragColor.a = 0.1;
-        gl_FragColor.a = gl_FragColor.a * 0.05f;
+        gl_FragColor.a = gl_FragColor.a * 0.05;
     }
 
 

--- a/source/tracedisplay.cpp
+++ b/source/tracedisplay.cpp
@@ -10,10 +10,10 @@
 #include <QtMath>
 
 #include <QtQuick/qquickwindow.h>
-#include <QtGui/QOpenGLShaderProgram>
+#include <QtOpenGL/QOpenGLShaderProgram>        // Qt6: moved from QtGui to Qt6::OpenGL
 #include <QtGui/QOpenGLContext>
-#include <QtGui/QOpenGLTexture>
-#include <QtGui/QOpenGLFramebufferObject>
+#include <QtOpenGL/QOpenGLTexture>   // Qt6: moved from QtGui to Qt6::OpenGL
+#include <QtOpenGL/QOpenGLFramebufferObject>    // Qt6: moved from QtGui to Qt6::OpenGL
 
 TraceDisplayBackend::TraceDisplayBackend(QObject *parent, QJsonObject ucTraceDisplay, qint64 softwareStartTime):
     QObject(parent),
@@ -47,17 +47,33 @@ void TraceDisplayBackend::createView()
     view->setX(m_ucTraceDisplay["windowX"].toInt(1));
     view->setY(m_ucTraceDisplay["windowY"].toInt(1));
 
+    // Let the QML content scale with the window, and lock resizing to the window's
+    // native aspect ratio.
+    view->setResizeMode(QQuickView::SizeRootObjectToView);
+    view->setMinimumSize(QSize(view->width() / 2, view->height() / 2));
+    view->setLockedAspectRatio((qreal)view->width() / (qreal)view->height());
+
 #ifdef Q_OS_WINDOWS
-    view->setFlags(Qt::Window | Qt::MSWindowsFixedSizeDialogHint | Qt::WindowTitleHint);
+    // Resizable window with a system menu + close (X) button. The trace window is
+    // meant to be user-closeable; no maximize button since that would break the
+    // locked aspect ratio.
+    view->setFlags(Qt::Window | Qt::WindowTitleHint | Qt::WindowSystemMenuHint
+                   | Qt::WindowMinimizeButtonHint | Qt::WindowCloseButtonHint);
 #endif
     view->show();
 
     m_traceDisplay = view->rootObject()->findChild<TraceDisplay*>("traceDisplay");
     m_traceDisplay->setSoftwareStartTime(m_softwareStartTime);
+
+    // Tear down cleanly when the window is closed (user X button or app exit).
+    QObject::connect(view, &NewQuickView::closing, this, &TraceDisplayBackend::handleWindowClosing);
 }
 
 void TraceDisplayBackend::addNewTrace(QString name, float color[3], float scale, QString units, bool sameOffset, QAtomicInt *displayBufNum, QAtomicInt *numDataInBuf, int bufSize, float *dataT, float *dataY)
 {
+    // The window may have been closed at runtime; drop trace additions once it's gone.
+    if (!m_traceDisplay)
+        return;
 
     trace_t newTrace = trace_t(name, color, scale, units, sameOffset, displayBufNum, numDataInBuf, bufSize, dataT, dataY);
     m_traceDisplay->addNewTrace(newTrace);
@@ -65,15 +81,26 @@ void TraceDisplayBackend::addNewTrace(QString name, float color[3], float scale,
 
 void TraceDisplayBackend::close()
 {
-    view->close();
+    // Routes through handleWindowClosing() via NewQuickView::closing. Guard against
+    // a second close (e.g. closeAll() after the user already closed the window).
+    if (view)
+        view->close();
+}
+
+void TraceDisplayBackend::handleWindowClosing()
+{
+    // Null the QML item first so a late addNewTrace() can't touch a dying object,
+    // then defer the view deletion (we're inside the view's own close event).
+    m_traceDisplay = nullptr;
+    if (view) {
+        view->deleteLater();
+        view = nullptr;
+    }
 }
 
 TraceDisplay::TraceDisplay()
     : m_t(0),
       m_renderer(nullptr),
-      lastMouseClickEvent(nullptr),
-      lastMouseReleaseEvent(nullptr),
-      lastMouseMoveEvent(nullptr),
       m_softwareStartTime(0)
 {
 
@@ -91,9 +118,10 @@ TraceDisplay::TraceDisplay()
 
 void TraceDisplay::mousePressEvent(QMouseEvent *event)
 {
-    if (event->button() == Qt::LeftButton) {
-        lastMouseClickEvent = new QMouseEvent(*event);
-    }
+    // Qt6: cloning QMouseEvent is no longer the pattern. The drag logic in
+    // mouseMoveEvent() that consumed the stored event is disabled, so nothing
+    // is kept here.
+    Q_UNUSED(event)
 //    qDebug() << "Mouse Press" << event;
 }
 
@@ -121,10 +149,8 @@ void TraceDisplay::mouseMoveEvent(QMouseEvent *event)
 
 void TraceDisplay::mouseReleaseEvent(QMouseEvent *event)
 {
-    if (event->button() == Qt::LeftButton) {
-        lastMouseReleaseEvent = new QMouseEvent(*event);
-        lastMouseMoveEvent = nullptr;
-    }
+    // Qt6: see mousePressEvent() - no stored event needed while drag is disabled.
+    Q_UNUSED(event)
 //    qDebug() << "Mouse Release" << event;
 }
 
@@ -152,7 +178,9 @@ void TraceDisplay::mouseDoubleClickEvent(QMouseEvent *event)
 {
 
     if (event->button() == Qt::LeftButton) {
-        m_renderer->doubleClickEvent(event->x(), event->y());
+        // Qt6: QMouseEvent::x()/y() are deprecated; use position().
+        const QPoint pos = event->position().toPoint();
+        m_renderer->doubleClickEvent(pos.x(), pos.y());
     }
     if (m_renderer->m_selectedTrace.isEmpty()) {
             // This is really poorly done!!!
@@ -247,11 +275,8 @@ void TraceDisplay::handleWindowChanged(QQuickWindow *win)
     if (win) {
         connect(win, &QQuickWindow::beforeSynchronizing, this, &TraceDisplay::sync, Qt::DirectConnection);
         connect(win, &QQuickWindow::sceneGraphInvalidated, this, &TraceDisplay::cleanup, Qt::DirectConnection);
-//! [1]
-        // If we allow QML to do the clearing, they would clear what we paint
-        // and nothing would show.
-//! [3]
-        win->setClearBeforeRendering(false);
+        // Qt6: setClearBeforeRendering() was removed; set the clear color instead.
+        win->setColor(Qt::black);
     }
 }
 
@@ -261,7 +286,8 @@ void TraceDisplay::sync()
         m_renderer = new TraceDisplayRenderer(nullptr, window()->size() * window()->devicePixelRatio(), m_softwareStartTime);
 //        m_renderer->setShowSaturation(m_showSaturation);
 //        m_renderer->setDisplayFrame(QImage("C:/Users/DBAharoni/Pictures/Miniscope/Logo/1.png"));
-        connect(window(), &QQuickWindow::beforeRendering, m_renderer, &TraceDisplayRenderer::paint, Qt::DirectConnection);
+        // Qt6: underlay must draw during render-pass recording (see videodisplay.cpp).
+        connect(window(), &QQuickWindow::beforeRenderPassRecording, m_renderer, &TraceDisplayRenderer::paint, Qt::DirectConnection);
 
         for (int i=0; i < m_tempTraces.length(); i++) {
             m_renderer->addNewTrace(m_tempTraces[i]);
@@ -459,6 +485,12 @@ void TraceDisplayRenderer::drawRenderTexture()
 {
 //    m_texture->bind(m_fbo->takeTexture());
     GLuint textUnit = m_fbo->texture();
+    // Qt6/RHI: the scene graph may leave a texture unit other than 0 active, so a
+    // bare glBindTexture() would attach our FBO color texture to the wrong unit
+    // while the shader samples unit 0 -> the traces never composite onto the
+    // screen (videodisplay avoids this because QOpenGLTexture::bind(0) selects
+    // the unit implicitly). Explicitly select unit 0 before binding.
+    glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, textUnit);
 //    m_texture = new QOpenGLTexture(QImage(":/img/MiniscopeLogo.png").rgbSwapped());
 //    qDebug() << "Texture num" << m_fbo->texture();
@@ -909,6 +941,25 @@ void TraceDisplayRenderer::paint()
 {
     currentTime =  QDateTime().currentMSecsSinceEpoch();
 
+    // Qt6: bracket all raw OpenGL with begin/endExternalCommands (replaces resetOpenGLState).
+    m_window->beginExternalCommands();
+
+    // Qt6: under the RHI the scene graph's render target is NOT framebuffer 0, so
+    // capture the currently bound framebuffer and restore it after our FBO pass,
+    // instead of relying on QOpenGLFramebufferObject::release() binding 0 (which
+    // would send the grid/bar drawing to the wrong target and break compositing
+    // with the QML axis labels drawn on top).
+    GLint prevFbo = 0;
+    glGetIntegerv(GL_FRAMEBUFFER_BINDING, &prevFbo);
+
+    // The render-target FBO is created once at the initial size; recreate it if the
+    // window was resized so the trace texture matches the new viewport.
+    if (m_viewportSize.isValid() && (!m_fbo || m_fbo->size() != m_viewportSize)) {
+        delete m_fbo;
+        m_fbo = new QOpenGLFramebufferObject(m_viewportSize);
+        m_clearDisplayOnNextDraw = true;
+    }
+
     if (m_clearDisplayOnNextDraw)
         initGridH();
 //    m_texture->bind();
@@ -948,7 +999,8 @@ void TraceDisplayRenderer::paint()
     updateTraces();
     drawTraces();
 
-    m_fbo->release();
+    // Qt6: restore the scene graph's framebuffer (was m_fbo->release(), which binds 0).
+    glBindFramebuffer(GL_FRAMEBUFFER, prevFbo);
 //    QImage fboImage(m_fbo->toImage());
 //    fboImage.save("fboImage.png");
 //    m_texture->release();
@@ -988,11 +1040,8 @@ void TraceDisplayRenderer::paint()
 
     m_lastTimeDisplayed = currentTime;
 
-
-
-//    // Not strictly needed for this example, but generally useful for when
-//    // mixing with raw OpenGL.
-    m_window->resetOpenGLState();
+    // Qt6: replaces the removed m_window->resetOpenGLState().
+    m_window->endExternalCommands();
 
 }
 

--- a/source/tracedisplay.h
+++ b/source/tracedisplay.h
@@ -4,11 +4,11 @@
 #include "newquickview.h"
 
 #include <QtQuick/QQuickItem>
-#include <QtGui/QOpenGLShaderProgram>
+#include <QtOpenGL/QOpenGLShaderProgram>     // Qt6: moved from QtGui to Qt6::OpenGL
 #include <QtGui/QOpenGLFunctions>
-#include <QtGui/QOpenGLTexture>
-#include <QtGui/QOpenGLBuffer>
-#include <QtGui/QOpenGLFramebufferObject>
+#include <QtOpenGL/QOpenGLTexture>   // Qt6: moved from QtGui to Qt6::OpenGL
+#include <QtOpenGL/QOpenGLBuffer>            // Qt6: moved from QtGui to Qt6::OpenGL
+#include <QtOpenGL/QOpenGLFramebufferObject> // Qt6: moved from QtGui to Qt6::OpenGL
 
 #include <QJsonObject>
 #include <QVector>
@@ -225,9 +225,8 @@ private:
     QVector<trace_t> m_tempTraces;
 
 
-    QMouseEvent* lastMouseClickEvent;
-    QMouseEvent* lastMouseReleaseEvent;
-    QMouseEvent* lastMouseMoveEvent;
+    // Qt6: removed cloned-QMouseEvent members; the drag logic that used them is
+    // disabled (commented out) in tracedisplay.cpp.
 
     qint64 m_softwareStartTime;
 
@@ -248,6 +247,10 @@ public:
 public slots:
     void addNewTrace(QString name, float color[3], float scale, QString units, bool sameOffset, QAtomicInt* displayBufNum, QAtomicInt* numDataInBuf, int bufSize, float* dataT, float* dataY);
     void close();
+
+private slots:
+    // Tears the window down when the user closes it (X button) or on app exit.
+    void handleWindowClosing();
 
 private:
     NewQuickView *view;

--- a/source/videodevice.cpp
+++ b/source/videodevice.cpp
@@ -11,6 +11,7 @@
 #include <QJsonObject>
 #include <QJsonDocument>
 #include <QJsonArray>
+#include <QFile>   // Qt6: no longer pulled in transitively
 #include <QQmlApplicationEngine>
 #include <QVector>
 
@@ -37,6 +38,7 @@ VideoDevice::VideoDevice(QObject *parent, QJsonObject ucDevice, qint64 softwareS
     m_roiBoundingBox[3] = -1;
 
     m_traceDisplayStatus = false;
+    m_lutColormap = 1; // default to the green LUT when toggled on
     m_ucDevice = ucDevice; // hold user config for this device
     parseUserConfigDevice();
     m_cDevice = getDeviceConfig(m_ucDevice["deviceType"].toString()); // holds specific Miniscope configuration
@@ -166,8 +168,17 @@ void VideoDevice::createView()
         view->setX(m_ucDevice["windowX"].toInt(1));
         view->setY(m_ucDevice["windowY"].toInt(1));
 
+        // Let the video display scale with the window, locked to the camera's
+        // aspect ratio (the full-screen video quad would otherwise distort).
+        view->setResizeMode(QQuickView::SizeRootObjectToView);
+        view->setMinimumSize(QSize(view->width() / 2, view->height() / 2));
+        view->setLockedAspectRatio((qreal)view->width() / (qreal)view->height());
+
 #ifdef Q_OS_WINDOWS
-        view->setFlags(Qt::Window | Qt::MSWindowsFixedSizeDialogHint | Qt::WindowTitleHint);
+        // Resizable (border drag) + minimizable; no maximize since that would break
+        // the locked aspect ratio.
+        view->setFlags(Qt::Window | Qt::WindowTitleHint | Qt::WindowSystemMenuHint
+                       | Qt::WindowMinimizeButtonHint);
 #endif
         view->show();
         // --------------------
@@ -186,6 +197,9 @@ void VideoDevice::createView()
         QObject::connect(rootObject, SIGNAL( saturationSwitchChanged(bool) ),
                              this, SLOT( handleSaturationSwitchChanged(bool) ));
 
+        QObject::connect(rootObject, SIGNAL( lutSwitchChanged(bool) ),
+                             this, SLOT( handleLutSwitchChanged(bool) ));
+
         configureDeviceControls();
         vidDisplay = rootObject->findChild<VideoDisplay*>("vD");
         vidDisplay->setMaxBuffer(FRAME_BUFFER_SIZE);
@@ -200,6 +214,21 @@ void VideoDevice::createView()
             vidDisplay->setShowSaturation(0);
             rootObject->findChild<QQuickItem*>("saturationSwitch")->setProperty("checked", false);
         }
+
+        // Display LUT (colormap) chosen in the user config. The colormap is stored
+        // in m_lutColormap (used by the on-window "Apply LUT" toggle); the switch
+        // starts on when the config selects a real LUT. "None"/absent keeps the
+        // green default available for when the user toggles it.
+        const QString lutName = m_ucDevice["lut"].toString("None");
+        bool lutOn = true;
+        if (lutName == "Red")          m_lutColormap = 2;
+        else if (lutName == "Inferno") m_lutColormap = 3;
+        else if (lutName == "Green")   m_lutColormap = 1;
+        else { m_lutColormap = 1; lutOn = false; } // "None" / unrecognized
+        vidDisplay->setLutMode(lutOn ? m_lutColormap : 0);
+        QQuickItem *lutSwitch = rootObject->findChild<QQuickItem*>("lutSwitch");
+        if (lutSwitch) // only the Miniscope window has the switch
+            lutSwitch->setProperty("checked", lutOn);
 
         // Set ROI Stuff
         QObject::connect(rootObject, SIGNAL( setRoiClicked() ), this, SLOT( handleSetRoiClicked()));
@@ -216,13 +245,17 @@ void VideoDevice::createView()
         QObject::connect(view, &NewQuickView::closing, deviceStream, &VideoStreamOCV::stopSteam);
         QObject::connect(vidDisplay->window(), &QQuickWindow::beforeRendering, this, &VideoDevice::sendNewFrame);
 
+        // Keep the ROI overlay tracking the video as the window is resized.
+        QObject::connect(vidDisplay, &QQuickItem::widthChanged, this, &VideoDevice::handleDisplayResized);
+
         sendMessage(m_deviceName + " is connected.");
 
         if (m_ucDevice.contains("ROI")) {
-            vidDisplay->setROI({(int)round(m_roiBoundingBox[0] * m_ucDevice["windowScale"].toDouble(1)),
-                                (int)round(m_roiBoundingBox[1] * m_ucDevice["windowScale"].toDouble(1)),
-                                (int)round(m_roiBoundingBox[2] * m_ucDevice["windowScale"].toDouble(1)),
-                                (int)round(m_roiBoundingBox[3] * m_ucDevice["windowScale"].toDouble(1)),
+            const QSizeF scale = displayPerCameraScale();
+            vidDisplay->setROI({(int)round(m_roiBoundingBox[0] * scale.width()),
+                                (int)round(m_roiBoundingBox[1] * scale.height()),
+                                (int)round(m_roiBoundingBox[2] * scale.width()),
+                                (int)round(m_roiBoundingBox[3] * scale.height()),
                                 0});
         }
 
@@ -646,6 +679,12 @@ void VideoDevice::handleSaturationSwitchChanged(bool checked)
     vidDisplay->setShowSaturation(checked);
 }
 
+void VideoDevice::handleLutSwitchChanged(bool checked)
+{
+    // Apply the config-selected colormap, or grayscale (0) when toggled off.
+    vidDisplay->setLutMode(checked ? m_lutColormap : 0);
+}
+
 void VideoDevice::handleSetExtTriggerTrackingState(bool state)
 {
      m_extTriggerTrackingState = state;
@@ -688,6 +727,35 @@ void VideoDevice::handleInitCommandsRequest()
     sendInitCommands();
 }
 
+QSizeF VideoDevice::displayPerCameraScale()
+{
+    // The video fills the display item, so display/camera gives pixels-per-camera-
+    // pixel. Computed live so it stays correct as the window is resized; falls back
+    // to the static config windowScale before the display exists.
+    const double camW = m_cDevice["width"].toInt(-1);
+    const double camH = m_cDevice["height"].toInt(-1);
+    if (vidDisplay && camW > 0 && camH > 0 && vidDisplay->width() > 0 && vidDisplay->height() > 0)
+        return QSizeF(vidDisplay->width() / camW, vidDisplay->height() / camH);
+
+    const double s = m_ucDevice["windowScale"].toDouble(1);
+    return QSizeF(s, s);
+}
+
+void VideoDevice::handleDisplayResized()
+{
+    // Reposition the committed ROI overlay for the new display size. The ROI is
+    // stored in camera pixels (m_roiBoundingBox); scale it back to display pixels.
+    if (!vidDisplay || m_roiBoundingBox[0] < 0)
+        return;
+
+    const QSizeF scale = displayPerCameraScale();
+    vidDisplay->setROI({(int)round(m_roiBoundingBox[0] * scale.width()),
+                        (int)round(m_roiBoundingBox[1] * scale.height()),
+                        (int)round(m_roiBoundingBox[2] * scale.width()),
+                        (int)round(m_roiBoundingBox[3] * scale.height()),
+                        0});
+}
+
 void VideoDevice::handleSetRoiClicked()
 {
     // TODO: Don't allow this if recording is active!!!!
@@ -710,11 +778,13 @@ void VideoDevice::handleAddTraceRoiClicked()
 void VideoDevice::handleNewROI(int leftEdge, int topEdge, int width, int height)
 {
     m_roiIsDefined = true;
-    // First scale the local position values to pixel values
-    m_roiBoundingBox[0] = round(leftEdge/m_ucDevice["windowScale"].toDouble(1));
-    m_roiBoundingBox[1] = round(topEdge/m_ucDevice["windowScale"].toDouble(1));
-    m_roiBoundingBox[2] = round(width/m_ucDevice["windowScale"].toDouble(1));
-    m_roiBoundingBox[3] = round(height/m_ucDevice["windowScale"].toDouble(1));
+    // Map the selection (in live display pixels) back to camera pixels using the
+    // current display scale, so the ROI is correct even after the window is resized.
+    const QSizeF scale = displayPerCameraScale();
+    m_roiBoundingBox[0] = round(leftEdge / scale.width());
+    m_roiBoundingBox[1] = round(topEdge / scale.height());
+    m_roiBoundingBox[2] = round(width / scale.width());
+    m_roiBoundingBox[3] = round(height / scale.height());
 
     if ((m_roiBoundingBox[0] + m_roiBoundingBox[2]) > m_cDevice["width"].toInt(-1)) {
         // Edge is off screen

--- a/source/videodevice.h
+++ b/source/videodevice.h
@@ -105,6 +105,7 @@ public slots:
     void handleTakeScreenShotSignal();
 
     void handleSaturationSwitchChanged(bool checked);
+    void handleLutSwitchChanged(bool checked);
     void handleSetExtTriggerTrackingState(bool state);
     void handleRecordStart(); // Currently used to toggle LED on and off
     void handleRecordStop(); // Currently used to toggle LED on and off
@@ -117,10 +118,17 @@ public slots:
     void handleNewROI(int leftEdge, int topEdge, int width, int height);
     virtual void handleAddNewTraceROI(int leftEdge, int topEdge, int width, int height);
 
+    // Re-applies the stored ROI overlay at the current display size so it tracks
+    // window resizes.
+    void handleDisplayResized();
+
 private:
 
     QSize m_resolution;
     void configureDeviceControls();
+    // Live display-pixels-per-camera-pixel (x, y). Used to map ROI selections to
+    // camera coordinates and back, correctly at any (resized) window size.
+    QSizeF displayPerCameraScale();
     QVector<QMap<QString, int>> parseSendCommand(QJsonArray sendCommand);
     int processString2Int(QString s);
     QMap<QString,quint16> deviceAddr; //only used with Miniscopes???
@@ -173,6 +181,10 @@ private:
 
     qint64 m_softwareStartTime;
     bool m_traceDisplayStatus;
+
+    // Display LUT (colormap) selected in the user config: 1=green, 2=red,
+    // 3=inferno; the on-window switch toggles between this and 0 (grayscale).
+    int m_lutColormap;
 };
 
 #endif // VIDEODEVICE_H

--- a/source/videodisplay.cpp
+++ b/source/videodisplay.cpp
@@ -1,9 +1,9 @@
 #include "videodisplay.h"
 
 #include <QtQuick/qquickwindow.h>
-#include <QtGui/QOpenGLShaderProgram>
+#include <QtOpenGL/QOpenGLShaderProgram>   // Qt6: moved from QtGui to Qt6::OpenGL
 #include <QtGui/QOpenGLContext>
-#include <QtGui/QOpenGLTexture>
+#include <QtOpenGL/QOpenGLTexture>   // Qt6: moved from QtGui to Qt6::OpenGL
 
 #include <QImage>
 
@@ -12,10 +12,12 @@ VideoDisplay::VideoDisplay()
     : m_t(0),
       m_acqFPS(0),
       m_renderer(nullptr),
+      m_lutMode(0),
       m_roiSelectionActive(false),
+      m_addTraceRoiSelectionActive(false),   // was uninitialized: garbage-true made a
+                                             // plain click on the video spawn a neuron
       m_ROI({0,0,10,10,0}),
-      lastMouseClickEvent(nullptr),
-      lastMouseReleaseEvent(nullptr)
+      m_hasPressPos(false)
 {
 //    m_displayFrame2.load("C:/Users/DBAharoni/Pictures/Miniscope/Logo/1.png");
     setAcceptedMouseButtons(Qt::AllButtons);
@@ -53,6 +55,14 @@ void VideoDisplay::setShowSaturation(double value)
         m_renderer->setShowSaturation(value);
     }
 }
+
+void VideoDisplay::setLutMode(double value)
+{
+    m_lutMode = value;
+    if (m_renderer) {
+        m_renderer->setLutMode(value);
+    }
+}
 //void VideoDisplayRenderer::setDisplayFrame(QImage frame) {
 //    m_displayFrame = frame;
 //}
@@ -64,11 +74,11 @@ void VideoDisplay::handleWindowChanged(QQuickWindow *win)
     if (win) {
         connect(win, &QQuickWindow::beforeSynchronizing, this, &VideoDisplay::sync, Qt::DirectConnection);
         connect(win, &QQuickWindow::sceneGraphInvalidated, this, &VideoDisplay::cleanup, Qt::DirectConnection);
-//! [1]
-        // If we allow QML to do the clearing, they would clear what we paint
-        // and nothing would show.
-//! [3]
-        win->setClearBeforeRendering(false);
+        // Qt6: QQuickWindow::setClearBeforeRendering() was removed. Instead set the
+        // window clear color; the scene graph clears to it at the start of the
+        // render pass and our underlay (drawn during beforeRenderPassRecording)
+        // paints on top of that, beneath the QML content.
+        win->setColor(Qt::black);
     }
 }
 //! [3]
@@ -95,8 +105,12 @@ void VideoDisplay::sync()
     if (!m_renderer) {
         m_renderer = new VideoDisplayRenderer();
         m_renderer->setShowSaturation(m_showSaturation);
+        m_renderer->setLutMode(m_lutMode);
 //        m_renderer->setDisplayFrame(QImage("C:/Users/DBAharoni/Pictures/Miniscope/Logo/1.png"));
-        connect(window(), &QQuickWindow::beforeRendering, m_renderer, &VideoDisplayRenderer::paint, Qt::DirectConnection);
+        // Qt6: draw during render-pass recording. beforeRendering now fires before
+        // the render pass begins, when there is no bound framebuffer to draw into,
+        // so an underlay must use beforeRenderPassRecording instead.
+        connect(window(), &QQuickWindow::beforeRenderPassRecording, m_renderer, &VideoDisplayRenderer::paint, Qt::DirectConnection);
     }
     m_renderer->setViewportSize(window()->size() * window()->devicePixelRatio());
 //    m_renderer->setT(m_t);
@@ -108,42 +122,41 @@ void VideoDisplay::sync()
 void VideoDisplay::mousePressEvent(QMouseEvent *event){
     if ((m_roiSelectionActive || m_addTraceRoiSelectionActive) && event->button() == Qt::LeftButton) {
         // TODO: Send info to shader to draw rectangle
-        lastMouseClickEvent = new QMouseEvent(*event);
+        // Qt6: QMouseEvent::x()/y() are deprecated (use position()), and cloning a
+        // pointer event is no longer the pattern. Store the press point instead.
+        m_pressPos = event->position().toPoint();
+        m_hasPressPos = true;
     }
 //        qDebug() << "Mouse Press" << event;
 }
 
 void VideoDisplay::mouseMoveEvent(QMouseEvent *event) {
+    if (!m_hasPressPos)
+        return;
 
-    if (m_roiSelectionActive /*&& event->button() == Qt::LeftButton*/ && lastMouseClickEvent != nullptr) {
-        int leftEdge = (lastMouseClickEvent->x() < event->x()) ? (lastMouseClickEvent->x()) : (event->x());
-        int topEdge = (lastMouseClickEvent->y() < event->y()) ? (lastMouseClickEvent->y()) : (event->y());
-        int width = abs(lastMouseClickEvent->x() - event->x());
-        int height = abs(lastMouseClickEvent->y() - event->y());
+    const QPoint pos = event->position().toPoint();
+    const int leftEdge = qMin(m_pressPos.x(), pos.x());
+    const int topEdge  = qMin(m_pressPos.y(), pos.y());
+    const int width    = qAbs(m_pressPos.x() - pos.x());
+    const int height   = qAbs(m_pressPos.y() - pos.y());
 
+    if (m_roiSelectionActive) {
         setROI({leftEdge,topEdge,width,height,m_roiSelectionActive});
-        qDebug() << "Mouse Move" << event;
     }
-    if (m_addTraceRoiSelectionActive /*&& event->button() == Qt::LeftButton*/ && lastMouseClickEvent != nullptr) {
-        int leftEdge = (lastMouseClickEvent->x() < event->x()) ? (lastMouseClickEvent->x()) : (event->x());
-        int topEdge = (lastMouseClickEvent->y() < event->y()) ? (lastMouseClickEvent->y()) : (event->y());
-        int width = abs(lastMouseClickEvent->x() - event->x());
-        int height = abs(lastMouseClickEvent->y() - event->y());
-
+    if (m_addTraceRoiSelectionActive) {
         setAddTraceROI({leftEdge,topEdge,width,height,m_addTraceRoiSelectionActive});
-//        qDebug() << "Mouse Move" << event;
     }
 }
 
 void VideoDisplay::mouseReleaseEvent(QMouseEvent *event) {
-    if (event->button() == Qt::LeftButton && lastMouseClickEvent != nullptr) {
-        lastMouseReleaseEvent = event;
+    if (event->button() == Qt::LeftButton && m_hasPressPos) {
+        const QPoint pos = event->position().toPoint();
 
         // Calculate ROI properties
-        int leftEdge = (lastMouseClickEvent->x() < lastMouseReleaseEvent->x()) ? (lastMouseClickEvent->x()) : (lastMouseReleaseEvent->x());
-        int topEdge = (lastMouseClickEvent->y() < lastMouseReleaseEvent->y()) ? (lastMouseClickEvent->y()) : (lastMouseReleaseEvent->y());
-        int width = abs(lastMouseClickEvent->x() - lastMouseReleaseEvent->x());
-        int height = abs(lastMouseClickEvent->y() - lastMouseReleaseEvent->y());
+        int leftEdge = qMin(m_pressPos.x(), pos.x());
+        int topEdge  = qMin(m_pressPos.y(), pos.y());
+        int width    = qAbs(m_pressPos.x() - pos.x());
+        int height   = qAbs(m_pressPos.y() - pos.y());
 
         if (m_roiSelectionActive ) {
             m_roiSelectionActive = false;
@@ -166,9 +179,8 @@ void VideoDisplay::mouseReleaseEvent(QMouseEvent *event) {
 
         }
     }
-    // Reset these Mouse events
-    lastMouseClickEvent = nullptr;
-    lastMouseReleaseEvent = nullptr;
+    // Reset stored press position
+    m_hasPressPos = false;
 }
 
 void VideoDisplay::setROI(QList<int> roi)
@@ -188,6 +200,12 @@ void VideoDisplay::setAddTraceROI(QList<int> roi)
 void VideoDisplayRenderer::paint()
 {
     //    qDebug() << "Painting!";
+
+    // Qt6: bracket all raw OpenGL with begin/endExternalCommands so the RHI-based
+    // scene graph knows its cached GL state is being touched. This replaces the
+    // old m_window->resetOpenGLState() call.
+    m_window->beginExternalCommands();
+
     if (!m_program) {
         initializeOpenGLFunctions();
 
@@ -240,6 +258,7 @@ void VideoDisplayRenderer::paint()
     m_program->setUniformValue("alpha", (float) m_alpha);
     m_program->setUniformValue("beta", (float) m_beta);
     m_program->setUniformValue("showSaturation", (float) m_showStaturation);
+    m_program->setUniformValue("lutMode", (float) m_lutMode);
 
     glViewport(0, 0, m_viewportSize.width(), m_viewportSize.height());
 
@@ -257,10 +276,6 @@ void VideoDisplayRenderer::paint()
     m_program->disableAttributeArray(1);
     m_program->release();
 
-    // Not strictly needed for this example, but generally useful for when
-    // mixing with raw OpenGL.
-    m_window->resetOpenGLState();
-
     if (m_newFrame) {
 //        qDebug() << "Set new texture QImage";
 
@@ -270,5 +285,7 @@ void VideoDisplayRenderer::paint()
         m_newFrame = false;
     }
 
+    // Qt6: replaces the removed m_window->resetOpenGLState().
+    m_window->endExternalCommands();
 }
 //! [5]

--- a/source/videodisplay.h
+++ b/source/videodisplay.h
@@ -2,9 +2,9 @@
 #define VIDEODISPLAY_H
 
 #include <QtQuick/QQuickItem>
-#include <QtGui/QOpenGLShaderProgram>
+#include <QtOpenGL/QOpenGLShaderProgram>   // Qt6: moved from QtGui to the Qt6::OpenGL module
 #include <QtGui/QOpenGLFunctions>
-#include <QtGui/QOpenGLTexture>
+#include <QtOpenGL/QOpenGLTexture>   // Qt6: moved from QtGui to Qt6::OpenGL
 
 #include <QImage>
 
@@ -23,7 +23,8 @@ public:
         m_texture(nullptr),
         m_alpha(1),
         m_beta(0),
-        m_showStaturation(1)
+        m_showStaturation(1),
+        m_lutMode(0)
     { }
     ~VideoDisplayRenderer();
 
@@ -34,6 +35,7 @@ public:
     void setAlpha(double a) {m_alpha = a;}
     void setBeta(double b) {m_beta = b;}
     void setShowSaturation(double value) {m_showStaturation = value; }
+    void setLutMode(double value) {m_lutMode = value; }
 
 
     bool m_newFrame;
@@ -56,6 +58,7 @@ private:
     double m_alpha;
     double m_beta;
     double m_showStaturation;
+    double m_lutMode;
 
 
 };
@@ -103,6 +106,7 @@ public:
     void setAlpha(double a) {m_renderer->setAlpha(a);}
     void setBeta(double b) {m_renderer->setBeta(b);}
     void setShowSaturation(double value);
+    void setLutMode(double value);
     void setROISelectionState(bool state) { m_roiSelectionActive = state; }
     void addTraceROISelectionState(bool state) { m_addTraceRoiSelectionActive = state; }
     void setWindowScaleValue(double scale) { m_windowScaleValue = scale; }
@@ -137,13 +141,17 @@ private:
     VideoDisplayRenderer *m_renderer;
 
     double m_showSaturation;
+    double m_lutMode;
     bool m_roiSelectionActive;
     bool m_addTraceRoiSelectionActive;
     double m_windowScaleValue;
     QList<int> m_ROI;
     QList<int> m_addTraceROI;
-    QMouseEvent *lastMouseClickEvent;
-    QMouseEvent *lastMouseReleaseEvent;
+    // Qt6: store the press position instead of cloning the QMouseEvent.
+    // QMouseEvent::x()/y() are deprecated (use position()), and copying pointer
+    // events is no longer the right pattern.
+    QPoint m_pressPos;
+    bool m_hasPressPos;
 };
 //! [2]
 

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+Assemble a clean, standalone, double-clickable distribution from a conda build.
+
+This makes the build output dir itself (<build>/Release/) the portable release -
+there is no nested dist/ subfolder. The real exe is built straight into bin/ and
+the configs are placed at the top by CMake (POST_BUILD); this script bundles the
+DLLs into bin/ and drops the launcher on top:
+
+    <build>/Release/
+      MiniscopeDAQ.exe          <- tiny launcher (the only loose file at the top)
+      deviceConfigs/            <- runtime configs, kept visible at the top
+      userConfigs/
+      Scripts/
+      bin/
+        MiniscopeDAQ.exe        <- the real application (built here by CMake)
+        *.dll                   <- Qt, OpenCV, OpenBLAS, Python, ... (bundled)
+        platforms/ imageformats/ iconengines/ styles/   <- Qt plugins
+        qml/                    <- Qt QML modules
+
+The top level stays uncluttered - just the launcher plus folders - so the app is
+easy to find. The launcher (tools/launcher.cpp) starts bin\\MiniscopeDAQ.exe with
+the working dir set to the top, so the real exe finds its DLLs (its own bin\\
+dir), its plugins/QML (applicationDirPath() == bin\\, see main.cpp), and its
+configs (./deviceConfigs etc., read from the working dir = the top). The whole
+folder is portable - copy it anywhere and double-click MiniscopeDAQ.exe; no conda
+env required.
+
+conda-forge's windeployqt is broken for the conda layout, so we deploy manually:
+copy the needed plugins + QML modules, then walk the import graph and copy every
+conda DLL dependency. The dynamically-loaded OpenBLAS BLAS chain (which import
+scanning can't see) is copied explicitly. The env must use OpenBLAS, not MKL.
+
+Usage:  python deploy.py <real-exe> <conda-prefix> [<launcher-exe>]
+Requires: pefile (pip install pefile)
+"""
+import os, sys, shutil, glob
+import pefile
+
+EXE = os.path.abspath(sys.argv[1])
+ENV = os.path.abspath(sys.argv[2])
+LAUNCHER = os.path.abspath(sys.argv[3]) if len(sys.argv) > 3 else None
+
+bindir = os.path.dirname(EXE)            # the real exe is built straight into bin/
+dist = os.path.dirname(bindir)           # release top = build/<config>/
+qt6 = os.path.join(ENV, "Library", "lib", "qt6")
+
+search_dirs = [os.path.join(ENV, "Library", "bin"), ENV, os.path.join(ENV, "DLLs")]
+system32 = os.path.join(os.environ.get("WINDIR", r"C:\Windows"), "System32")
+
+PLUGIN_CATS = ["platforms", "imageformats", "iconengines", "styles"]
+DATA_DIRS = ["deviceConfigs", "userConfigs", "Scripts"]
+# Dynamically-loaded by name (invisible to import-table scanning): the conda
+# OpenBLAS BLAS chain that OpenCV uses. Requires the OpenBLAS BLAS variant (not
+# MKL) - see CMakeLists.txt / environment.yml.
+EXTRA_DYNAMIC = ["openblas.dll", "libblas.dll", "liblapack.dll",
+                 "libcblas.dll", "liblapacke.dll"]
+
+def is_system(name):
+    low = name.lower()
+    if low.startswith("api-ms-") or low.startswith("ext-ms-"):
+        return True
+    return os.path.isfile(os.path.join(system32, name))
+
+def find_in_env(name):
+    for d in search_dirs:
+        p = os.path.join(d, name)
+        if os.path.isfile(p):
+            return p
+    return None
+
+def imports_of(path):
+    try:
+        pe = pefile.PE(path, fast_load=True)
+        pe.parse_data_directories(
+            directories=[pefile.DIRECTORY_ENTRY['IMAGE_DIRECTORY_ENTRY_IMPORT']])
+        out = [e.dll.decode(errors="ignore")
+               for e in getattr(pe, "DIRECTORY_ENTRY_IMPORT", []) if e.dll]
+        pe.close()
+        return out
+    except Exception:
+        return []
+
+# --- clean previously-deployed files in bin/ (keep the freshly-built exe) -
+# The real exe is built straight into bin/ and the configs are placed at the top
+# by CMake, so we assemble in place rather than nuking the folder. Wipe only what a
+# previous deploy added to bin/ (stale DLLs + plugin/QML dirs) so re-runs start
+# from a clean bin/ without deleting the exe or the configs at the top.
+print("[1/6] cleaning previously-deployed files in bin/ ...")
+for p in glob.glob(os.path.join(bindir, "*.dll")):
+    os.remove(p)
+for sub in PLUGIN_CATS + ["qml"]:
+    d = os.path.join(bindir, sub)
+    if os.path.isdir(d):
+        shutil.rmtree(d)
+missing_cfg = [d for d in DATA_DIRS if not os.path.isdir(os.path.join(dist, d))]
+if missing_cfg:
+    print("      note: configs missing at the top (%s) - build MiniscopeDAQ first "
+          "so its POST_BUILD step copies them" % ", ".join(missing_cfg))
+
+# --- plugins + QML (next to the real exe, in bin/) -----------------------
+print("[2/6] copying Qt plugins ...")
+for cat in PLUGIN_CATS:
+    s = os.path.join(qt6, "plugins", cat)
+    if os.path.isdir(s):
+        shutil.copytree(s, os.path.join(bindir, cat))
+print("[3/6] copying QML modules ...")
+shutil.copytree(os.path.join(qt6, "qml"), os.path.join(bindir, "qml"))
+
+# --- dependency walk (everything into bin/) ------------------------------
+print("[4/6] copying conda dependencies ...")
+roots = [os.path.join(bindir, os.path.basename(EXE))]
+for cat in PLUGIN_CATS:
+    roots += glob.glob(os.path.join(bindir, cat, "**", "*.dll"), recursive=True)
+roots += glob.glob(os.path.join(bindir, "qml", "**", "*.dll"), recursive=True)
+for name in EXTRA_DYNAMIC:
+    s = find_in_env(name)
+    if s:
+        d = os.path.join(bindir, name)
+        shutil.copy2(s, d)
+        roots.append(d)
+copied, processed, queue = set(), set(), list(roots)
+while queue:
+    cur = queue.pop()
+    if cur.lower() in processed:
+        continue
+    processed.add(cur.lower())
+    for dll in imports_of(cur):
+        low = dll.lower()
+        if is_system(dll) or low in copied:
+            continue
+        s = find_in_env(dll)
+        if not s:
+            continue
+        shutil.copy2(s, os.path.join(bindir, dll))
+        copied.add(low)
+        queue.append(os.path.join(bindir, dll))
+print("      copied %d conda DLLs" % len(copied))
+
+# --- launcher at top (the single loose file) -----------------------------
+print("[5/6] placing launcher ...")
+if LAUNCHER and os.path.isfile(LAUNCHER):
+    shutil.copy2(LAUNCHER, os.path.join(dist, "MiniscopeDAQ.exe"))
+    print("      MiniscopeDAQ.exe (launcher at top) -> bin/MiniscopeDAQ.exe")
+else:
+    print("      WARNING: launcher exe not provided; run bin/MiniscopeDAQ.exe directly")
+
+# --- verify --------------------------------------------------------------
+print("[6/6] verifying ...")
+local = {os.path.basename(p).lower()
+         for p in glob.glob(os.path.join(bindir, "**", "*.dll"), recursive=True)}
+missing = set()
+for f in [os.path.join(bindir, os.path.basename(EXE))] + \
+         glob.glob(os.path.join(bindir, "**", "*.dll"), recursive=True):
+    for dll in imports_of(f):
+        if is_system(dll) or dll.lower() in local:
+            continue
+        if find_in_env(dll):
+            missing.add(dll)
+if missing:
+    print("  WARNING - conda deps not deployed:")
+    for m in sorted(missing):
+        print("    ", m)
+    sys.exit(1)
+print("  OK -> %s" % dist)
+print("  Double-click MiniscopeDAQ.exe (or copy the whole %s folder anywhere)."
+      % os.path.basename(dist))

--- a/tools/launcher.cpp
+++ b/tools/launcher.cpp
@@ -1,0 +1,44 @@
+// Tiny launcher so the release folder shows just one loose file - the
+// executable - at the top, with all the DLLs / Qt plugins / QML tucked into a
+// "bin" subfolder next to it:
+//
+//   <release>/MiniscopeDAQ.exe          <- this launcher (double-click)
+//   <release>/deviceConfigs/ userConfigs/ Scripts/   <- runtime configs (top level)
+//   <release>/bin/MiniscopeDAQ.exe + all DLLs, plugins/, qml/
+//
+// It launches bin\MiniscopeDAQ.exe with the working directory set to <release>
+// (the launcher's own folder), so the real exe finds:
+//   * its DLLs   - in bin\ (Windows searches the exe's own directory first), and
+//   * its Qt plugins / QML - via applicationDirPath() == bin\ (see main.cpp), and
+//   * its configs - the app reads ./deviceConfigs, ./userConfigs, ./Scripts from
+//                   the working directory, which we point at <release> (top level).
+// Self-contained: depends only on kernel32/user32 (always present).
+
+#include <windows.h>
+#include <string>
+
+int APIENTRY wWinMain(HINSTANCE, HINSTANCE, LPWSTR, int)
+{
+    wchar_t buf[MAX_PATH];
+    DWORD n = GetModuleFileNameW(nullptr, buf, MAX_PATH);
+    std::wstring dir(buf, n);
+    dir.resize(dir.find_last_of(L"\\/"));            // strip "\MiniscopeDAQ.exe" -> <release>
+
+    std::wstring exe = dir + L"\\bin\\MiniscopeDAQ.exe";
+    std::wstring cmd = L"\"" + exe + L"\"";
+
+    STARTUPINFOW si{};  si.cb = sizeof(si);
+    PROCESS_INFORMATION pi{};
+    // Working directory = <release> (this launcher's folder), so the app's relative
+    // ./deviceConfigs, ./userConfigs and ./Scripts resolve to the top level.
+    if (!CreateProcessW(exe.c_str(), cmd.data(), nullptr, nullptr, FALSE,
+                        0, nullptr, dir.c_str(), &si, &pi)) {
+        MessageBoxW(nullptr,
+                    (L"Could not start the application:\n" + exe).c_str(),
+                    L"Miniscope DAQ", MB_ICONERROR | MB_OK);
+        return 1;
+    }
+    CloseHandle(pi.hThread);
+    CloseHandle(pi.hProcess);
+    return 0;
+}

--- a/userConfigs/UserConfigExample-V3-Miniscope-plus-WebCam.json
+++ b/userConfigs/UserConfigExample-V3-Miniscope-plus-WebCam.json
@@ -89,6 +89,7 @@
 					"height": 300
                 },
                 "compression": "FFV1",
+                "lut": "None",
                 "framesPerFile": 1000,
                 "windowScale": 0.75,
                 "windowX": 800,

--- a/userConfigs/UserConfigExample-V4-Miniscope-plus-WebCam.json
+++ b/userConfigs/UserConfigExample-V4-Miniscope-plus-WebCam.json
@@ -94,6 +94,7 @@
 					"height": 600
                 },
                 "compression": "FFV1",
+                "lut": "None",
                 "framesPerFile": 1000,
                 "windowScale": 0.75,
                 "windowX": 800,

--- a/userConfigs/UserConfigExample-V4Miniscope-plus-2-WebCams.json
+++ b/userConfigs/UserConfigExample-V4Miniscope-plus-2-WebCams.json
@@ -94,6 +94,7 @@
 					"height": 600
                 },
                 "compression": "FFV1",
+                "lut": "None",
                 "framesPerFile": 1000,
                 "windowScale": 0.75,
                 "windowX": 800,

--- a/userConfigs/UserConfigExample-primary.json
+++ b/userConfigs/UserConfigExample-primary.json
@@ -136,6 +136,7 @@
                 "COMMENT_compression2": "We suggest using a lossless compression CODEC for Miniscope data. This would be either GREY or FFV1. GREY does no compression. FFV1 losslessly compresses the data but can be CPU intensive.",
                 "COMMENT_compression3": "We generally use FFV1 is our computer can keep up with it. If you notice the frame buffer filling up completely while recording you should switch to GREY.",
                 "compression": "FFV1",
+                "lut": "None",
                 "framesPerFile": 1000,
                 "COMMENT_window": "The window keys define how the GUI for this device will be setup. They don't affect the actual recorded data.",
                 "windowScale": 0.75,


### PR DESCRIPTION
## Summary

This PR ports the Miniscope DAQ QT software from **Qt5 to Qt6**, sets up a **reproducible Windows build with a one-click installer**, and adds a set of **usability features** on top. It's ~40 commits adding **2,135 / removing 399 lines** across 44 files.

The work is grouped into four areas below. Each area was developed and merged on its own feature branch, so the history is easy to follow commit-by-commit.

## 1. Qt5 → Qt6 migration

The application now builds and runs on Qt6.

- New CMake build (`CMakeLists.txt`) replacing the old setup.
- Ported all OpenGL renderers to the Qt6 RHI/QML model: `videodisplay`, `tracedisplay`, and `behaviortracker`.
- Fixed GLSL shaders that failed to compile under the new pipeline (GLSL 1.10: `f`-suffix literals, `float`/`int` comparisons) — these were silently breaking trace plotting and the tracker overlay.
- QML startup hardening: on-demand device views and control panel, unversioned `QtQuick` imports, null-`traceDisplay` crash on Run, and a forced light color scheme fix for invisible white-on-white text.
- `initNumpy` warning (C4715) silenced.

## 2. Reproducible build, packaging & release

- `environment.yml` — a conda spec pinning the toolchain (Qt, OpenCV, Python) so the build is reproducible from scratch.
- `tools/deploy.py` + `tools/launcher.cpp` — produce a **portable, self-contained folder**: a double-clickable `MiniscopeDAQ.exe` at the top with all DLLs tucked away in `bin/`.
- **Windows installer** (`installer/MiniscopeDAQ.iss`, Inno Setup): per-user install (no admin rights), Start Menu / optional desktop shortcut, and clean uninstall via *Add or Remove Programs*.
- **GitHub Actions release workflow** (`.github/workflows/release.yml`): on tag, builds and publishes both the portable zip and the `Setup.exe`.
- README updated with a Windows install section covering both the installer and the portable zip.

## 3. New features & UX

- **In-app user-config generator** — create a new config from scratch and add devices through a guided **Add Device** dialog, with sensible defaults and unique device IDs. No more hand-editing JSON.
- **Scan Devices** button — lists connected cameras as `deviceID → camera name` so you can pick the right index.
- **Display LUT** selector for the Miniscope window, including red-saturation highlighting of clipped pixels.
- **Save-As** dialog for user configs and a **codec dropdown** in the tree editor.
- Display windows are now **resizable, locked to aspect ratio**.
- The **BNO / trace window is user-closeable**.
- Config tree-view editor ported to Qt6 with **path browse buttons**.
- Version bumped to **1.2**; Help dialog now shows build info.
- Four `UserConfigExample-*.json` samples added (V3 / V4, single & dual webcam).

## 4. Bug fixes

- Codec detection no longer leaves a stray `test.avi` behind.
- "Add Neuron ROI" button restored.
- Assorted Qt6 build-error fixes found during first compile.

## Notes for review

- This PR targets the dedicated **`qt6-port`** integration branch (not `master`), so the work can be reviewed and integrated without landing directly on `master`.
- It **reintroduces the exact change set from PR #78**, which was reverted in PR #79. The tree here is byte-for-byte identical to that original work.
- Behavior on Linux/macOS is untested — the build and packaging work is currently Windows-focused.
