### PR TITLE
Multi-scope control-channel safety + stale Linux docs

### DIFF
--- a/BUILD_LINUX.md
+++ b/BUILD_LINUX.md
@@ -70,8 +70,8 @@ cmake --build build -j"$(nproc)"
 ```
 
 Look for `libuvc found (...); Miniscope Linux capture backend enabled` in the
-configure log. Keep `USE_PYTHON=ON` (the DeepLabCut tracker's `PyObject` members
-in `behaviortrackerworker.h` aren't `#ifdef`-guarded, so `OFF` doesn't compile yet).
+configure log. `USE_PYTHON=OFF` also builds if you don't need the DeepLabCut-Live
+behavior tracker (the packaged AppImage ships that way).
 
 - [ ] Configure finds Qt6, OpenCV, Python3+NumPy, **and libuvc**
 - [ ] Build completes; `build/MiniscopeDAQ` exists
@@ -109,8 +109,9 @@ Pick the **capture** node for each device. Example seen during this port:
 `/dev/video2` = **Miniscope capture**, `/dev/video3` = Miniscope metadata. So the
 Miniscope needed `deviceID: 2`, not `1`.
 
-> The **Scan Devices** button is Windows-only (DirectShow, `#ifdef Q_OS_WINDOWS`);
-> set `deviceID` manually on Linux.
+> The **Scan Devices** button does this scan for you (V4L2 enumeration,
+> `backend.cpp: scanVideoDevicesLinux()`), distinguishing capture nodes from
+> metadata nodes; the manual `v4l2-ctl` route above is the fallback/cross-check.
 
 ---
 

--- a/source/avfenumeratormac.h
+++ b/source/avfenumeratormac.h
@@ -21,6 +21,28 @@ struct AvfCameraInfo {
 
 QVector<AvfCameraInfo> enumerateAvfCameras();
 
+// Decision of WHICH USB device the Miniscope control channel opens for a user
+// config's deviceID (an AVFoundation/OpenCV index). Split out as a pure
+// function because getting it wrong is the worst multi-scope failure mode:
+// frames from one scope with LED/gain commands silently driving another.
+struct ControlTarget {
+    bool ok = false;
+    quint32 locationID = 0;  // USB locationID to open when ok
+    QString warning;         // non-fatal, surface to the user when non-empty
+    QString error;           // the reason, when !ok
+};
+
+// cameras/cameraID: the AVFoundation list and the config's index into it.
+// expectedVid/Pid: the Miniscope DAQ USB identity (for a sanity warning).
+// attachedLocations: locationIDs of every attached device with that identity
+// (UVCControlMac::enumerate) - the fallback set when the index doesn't
+// resolve. Falling back is only allowed when that set has exactly ONE entry;
+// with several Miniscopes attached an unresolvable index is an error, never
+// a guess.
+ControlTarget resolveControlTarget(const QVector<AvfCameraInfo> &cameras, int cameraID,
+                                   quint16 expectedVid, quint16 expectedPid,
+                                   const QVector<quint32> &attachedLocations);
+
 // AVCaptureDevice.uniqueID for a USB camera is the hex of the 64-bit value
 // (locationID << 32) | (vid << 16) | pid, with or without a "0x" prefix and
 // possibly without leading zeros. Non-USB devices (the built-in camera on

--- a/source/avfenumeratormac.mm
+++ b/source/avfenumeratormac.mm
@@ -28,3 +28,43 @@ QVector<AvfCameraInfo> enumerateAvfCameras()
 }
 
 #pragma clang diagnostic pop
+
+ControlTarget resolveControlTarget(const QVector<AvfCameraInfo> &cameras, int cameraID,
+                                   quint16 expectedVid, quint16 expectedPid,
+                                   const QVector<quint32> &attachedLocations)
+{
+    ControlTarget target;
+
+    if (cameraID >= 0 && cameraID < cameras.size() && cameras[cameraID].isUsb) {
+        const AvfCameraInfo &cam = cameras[cameraID];
+        if (cam.vid != expectedVid || cam.pid != expectedPid)
+            target.warning = QStringLiteral("deviceID %1 (%2) does not look like a Miniscope DAQ.")
+                                 .arg(cameraID).arg(cam.name);
+        target.ok = true;
+        target.locationID = cam.locationID;
+        return target;
+    }
+
+    // The index doesn't resolve to a USB camera (out of range, a non-USB
+    // camera, or an opaque uniqueID). "Whichever Miniscope IOKit finds" is
+    // only the right answer when there is exactly one to find.
+    if (attachedLocations.size() == 1) {
+        target.ok = true;
+        target.locationID = attachedLocations.first();
+        target.warning = QStringLiteral("deviceID %1 could not be matched to a USB camera; "
+                                        "using the only Miniscope DAQ attached.")
+                             .arg(cameraID);
+        return target;
+    }
+    if (attachedLocations.isEmpty())
+        target.error = QStringLiteral("deviceID %1 could not be matched to a USB camera "
+                                      "and no Miniscope DAQ was found on the USB bus.")
+                           .arg(cameraID);
+    else
+        target.error = QStringLiteral("deviceID %1 could not be matched to a USB camera and "
+                                      "%2 Miniscope DAQs are attached - refusing to guess "
+                                      "which one is meant. Unplug the extras or fix the "
+                                      "deviceID in the user config.")
+                           .arg(cameraID).arg(attachedLocations.size());
+    return target;
+}

--- a/source/videostreammac.cpp
+++ b/source/videostreammac.cpp
@@ -62,25 +62,33 @@ void VideoStreamMac::setBufferParameters(cv::Mat *frameBuf, qint64 *tsBuf, float
 }
 
 // Resolve the AVFoundation/OpenCV device index to the exact USB device and
-// open its VideoControl interface (robust with multiple Miniscopes: the
-// index's uniqueID carries the USB locationID). Falls back to the first
-// Miniscope by VID/PID when the index can't be resolved.
+// open its VideoControl interface. The which-device decision (including when
+// falling back to "the one Miniscope attached" is safe, and when it must fail
+// instead of guessing) lives in resolveControlTarget - see its declaration.
 bool VideoStreamMac::openControlForIndex(int cameraID)
 {
-    quint32 locationID = 0;
-    const auto cameras = enumerateAvfCameras();
-    if (cameraID >= 0 && cameraID < cameras.size() && cameras[cameraID].isUsb) {
-        locationID = cameras[cameraID].locationID;
-        if (cameras[cameraID].vid != kUsbVendorId || cameras[cameraID].pid != kUsbProductId)
-            sendMessage("Warning: deviceID " + QString::number(cameraID) + " (" +
-                        cameras[cameraID].name + ") does not look like a Miniscope DAQ.");
+    QVector<quint32> attached;
+    const auto miniscopes = UVCControlMac::enumerate(kUsbVendorId, kUsbProductId);
+    for (const auto &dev : miniscopes)
+        attached.append(dev.locationID);
+
+    const ControlTarget target = resolveControlTarget(enumerateAvfCameras(), cameraID,
+                                                      kUsbVendorId, kUsbProductId, attached);
+    if (!target.warning.isEmpty())
+        sendMessage("Warning: " + m_deviceName + ": " + target.warning);
+    if (!target.ok) {
+        sendMessage("Error: " + m_deviceName + ": " + target.error);
+        return false;
     }
 
-    if (m_control.open(kUsbVendorId, kUsbProductId, locationID))
+    if (m_control.open(kUsbVendorId, kUsbProductId, target.locationID))
         return true;
-    if (locationID != 0 && m_control.open(kUsbVendorId, kUsbProductId, 0)) {
+    // The resolved device would not open (e.g. a transient IOKit failure).
+    // Retrying as "any Miniscope" is again only safe with exactly one attached.
+    if (target.locationID != 0 && attached.size() == 1
+        && m_control.open(kUsbVendorId, kUsbProductId, 0)) {
         sendMessage("Warning: " + m_deviceName + " control channel fell back to the "
-                    "first Miniscope on the bus.");
+                    "only Miniscope on the bus.");
         return true;
     }
     sendMessage("Error: could not open the Miniscope control channel for " + m_deviceName +

--- a/tests/tst_avfenumerator.cpp
+++ b/tests/tst_avfenumerator.cpp
@@ -14,6 +14,11 @@ private slots:
     void parseWithoutPrefixOrLeadingZeros();
     void parseRejectsOpaqueIds();
     void enumerateRuns();
+    void resolveUsesIndexLocation();
+    void resolveWarnsOnUnexpectedIdentity();
+    void resolveFallsBackToOnlyMiniscope();
+    void resolveRefusesToGuessAmongSeveral();
+    void resolveFailsWithNoneAttached();
 };
 
 void TestAvfEnumerator::parseUsbUniqueId()
@@ -63,6 +68,89 @@ void TestAvfEnumerator::enumerateRuns()
             QVERIFY(cam.vid != 0);
         }
     }
+}
+
+// --- resolveControlTarget: which USB device the control channel opens --------
+// The multi-scope failure mode this guards against: two Miniscopes share
+// VID/PID, so a wrong decision here streams frames from one scope while LED /
+// gain commands silently drive the other.
+
+static const quint16 kVid = 0x04b4, kPid = 0x00f9;   // Miniscope DAQ (Cypress FX3)
+
+static AvfCameraInfo usbCam(const QString &name, quint32 loc, quint16 vid, quint16 pid)
+{
+    AvfCameraInfo cam;
+    cam.name = name;
+    cam.locationID = loc;
+    cam.vid = vid;
+    cam.pid = pid;
+    cam.isUsb = true;
+    return cam;
+}
+
+void TestAvfEnumerator::resolveUsesIndexLocation()
+{
+    // Two Miniscopes attached; the index resolves, so each deviceID must map
+    // to its own locationID - never "the first one found".
+    const QVector<AvfCameraInfo> cams = {usbCam("Miniscope A", 0x00100000, kVid, kPid),
+                                         usbCam("Miniscope B", 0x00200000, kVid, kPid)};
+    const QVector<quint32> attached = {0x00100000, 0x00200000};
+
+    const auto a = resolveControlTarget(cams, 0, kVid, kPid, attached);
+    QVERIFY(a.ok);
+    QCOMPARE(a.locationID, quint32(0x00100000));
+    QVERIFY(a.warning.isEmpty());
+
+    const auto b = resolveControlTarget(cams, 1, kVid, kPid, attached);
+    QVERIFY(b.ok);
+    QCOMPARE(b.locationID, quint32(0x00200000));
+}
+
+void TestAvfEnumerator::resolveWarnsOnUnexpectedIdentity()
+{
+    // The config points at a resolvable USB camera that isn't a Miniscope:
+    // proceed (it may be a behavior cam misconfigured as a Miniscope - the
+    // open will fail cleanly) but tell the user what it looked like.
+    const QVector<AvfCameraInfo> cams = {usbCam("HD Web Camera", 0x00100000, 0x05a3, 0x9331)};
+    const auto t = resolveControlTarget(cams, 0, kVid, kPid, {});
+    QVERIFY(t.ok);
+    QCOMPARE(t.locationID, quint32(0x00100000));
+    QVERIFY(t.warning.contains(QStringLiteral("does not look like a Miniscope")));
+}
+
+void TestAvfEnumerator::resolveFallsBackToOnlyMiniscope()
+{
+    // Index unresolvable (opaque uniqueID -> isUsb=false), but exactly one
+    // Miniscope is attached: unambiguous, use it (with a warning).
+    AvfCameraInfo builtin;
+    builtin.name = QStringLiteral("FaceTime HD Camera");
+    const auto t = resolveControlTarget({builtin}, 0, kVid, kPid, {0x00300000});
+    QVERIFY(t.ok);
+    QCOMPARE(t.locationID, quint32(0x00300000));
+    QVERIFY(t.warning.contains(QStringLiteral("only Miniscope")));
+
+    // Same for an out-of-range index (stale deviceID in the config).
+    const auto o = resolveControlTarget({builtin}, 5, kVid, kPid, {0x00300000});
+    QVERIFY(o.ok);
+    QCOMPARE(o.locationID, quint32(0x00300000));
+}
+
+void TestAvfEnumerator::resolveRefusesToGuessAmongSeveral()
+{
+    // Index unresolvable AND several Miniscopes attached: must fail loudly,
+    // never coin-flip the control channel onto one of them.
+    AvfCameraInfo builtin;
+    const auto t = resolveControlTarget({builtin}, 0, kVid, kPid,
+                                        {0x00100000, 0x00200000});
+    QVERIFY(!t.ok);
+    QVERIFY(t.error.contains(QStringLiteral("refusing to guess")));
+}
+
+void TestAvfEnumerator::resolveFailsWithNoneAttached()
+{
+    const auto t = resolveControlTarget({}, 0, kVid, kPid, {});
+    QVERIFY(!t.ok);
+    QVERIFY(t.error.contains(QStringLiteral("no Miniscope DAQ")));
 }
 
 QTEST_MAIN(TestAvfEnumerator)


### PR DESCRIPTION
**Stacked on #87** — merge order #85 → #86 → #87 → this. Only the last commit (`0bf885c`) is new here.

PR 6a of the macOS port: the hardware-independent half of the planned polish, done now so bench day (when a Miniscope arrives) is pure validation. A thin 6b will follow for whatever the bench uncovers.

## The multi-scope failure mode

The user-facing model is unchanged and identical to Windows: the config's enumerated `deviceID` picks the camera. But on macOS the hybrid backend has a second (IOKit) channel that must be bound to the *same physical device*, via a deviceID → USB locationID translation. All Miniscopes share VID 0x04b4 / PID 0x00f9, so the old fallback — "if the deviceID can't be resolved, open whichever Miniscope IOKit finds first" — was a coin flip with two scopes attached: frames from scope A, LED/gain commands silently driving scope B, no error anywhere. Windows can't have this failure (one capture handle does both frames and controls).

## The fix

`resolveControlTarget()` (in `avfenumeratormac`, pure function, no I/O):

| Situation | Decision |
|---|---|
| deviceID resolves to a USB camera | use its locationID (warn if it isn't Miniscope VID/PID) |
| unresolvable, exactly **one** Miniscope attached | use it, with a warning |
| unresolvable, **several** attached | **fail loudly, never guess** |
| unresolvable, none attached | fail with "no Miniscope DAQ found" |

The retry after a failed open in `openControlForIndex()` obeys the same single-scope rule. Every branch is unit-tested (`tst_avfenumerator`, 5 new cases including the two-scope refusal). Errors/warnings surface in the app's message log through the existing `sendMessage` path.

## Docs housekeeping

BUILD_LINUX.md had two claims the port has since obsoleted: `USE_PYTHON=OFF` "doesn't compile" (it does — the AppImage ships that way) and "Scan Devices is Windows-only" (the V4L2 scan now marks capture vs metadata nodes).

## Still pending hardware (bench, later this week)

`uvc-bench-mac --enable-bno` idle + streaming, then a real scope config through the app: live video, LED/gain/EWL, frame counter, BNO traces — the open checkbox on #85/#86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8EJD2rqn5svYYCLjrtmGK