### PR TITLE
macOS bench fixes: uniqueID-pinned capture, stall diagnosis, dFF crash guard

### DIFF
--- a/BUILD_MACOS.md
+++ b/BUILD_MACOS.md
@@ -1,10 +1,11 @@
 # Building & running the Miniscope DAQ on macOS (Apple Silicon)
 
-Status: **builds and launches natively on Apple Silicon (macOS 15, arm64) with
-zero code changes** — the main window renders, all seven custom GLSL shader
-programs compile against macOS's OpenGL 2.1 context, and the FFV1/GREY
-recording codecs are available. **Miniscope hardware control does not work
-yet** — see "Port status" below for what remains and how it will be done.
+Status: **fully working and bench-validated on real Miniscope hardware**
+(stock V4 + standard DAQ, Apple Silicon, July 2026): native streaming pinned
+to the scope's USB identity, LED/gain/EWL/frame-rate control with confirmed
+effect on the sensor, live DAQ frame counter with zero drops over multi-minute
+runs, BNO head-orientation traces, and dual-device capture alongside a USB
+webcam. See "Port status" below for the per-area detail.
 
 The C++/CMake were already cross-platform: every Windows- or Linux-specific bit
 is gated behind `if(WIN32)` / `UNIX AND NOT APPLE` (CMake) or
@@ -124,8 +125,8 @@ selection can still interfere at session start.
 | Main window / QML UI / OpenGL shaders | ✅ verified (GL 2.1, all 7 shader programs compile+link) |
 | Recording codecs (FFV1, GREY via FFmpeg) | ✅ reported supported |
 | Scan Devices button | ✅ AVFoundation enumeration (index == deviceID; Miniscopes called out) |
-| **Miniscope control transport (IOKit pipe-0)** | ✅ implemented + validated against USB webcams, incl. while streaming — Miniscope bench test pending |
-| **Miniscope capture backend (`VideoStreamMac` hybrid)** | ⚠️ implemented, needs a Miniscope on the bench |
+| **Miniscope control transport (IOKit pipe-0)** | ✅ bench-validated on a real Miniscope (LED/gain/EWL/frame rate, DAQ counter, BNO) |
+| **Miniscope capture backend (`VideoStreamMac` hybrid)** | ✅ bench-validated: uniqueID-pinned stream, zero frame drops, survives iPhone/webcam hot-plugs and USB-drop reconnects |
 | Behavior webcams (OpenCV → AVFoundation) | ✅ `.app` bundle gives proper camera-permission attribution (`NSCameraUsageDescription`) |
 | Packaged `.app` / DMG | ✅ `packaging/macos/build-dmg.sh`, wired into release CI (ad-hoc signed; right-click → Open) |
 
@@ -142,11 +143,13 @@ control channel through UVC Processing-Unit controls (I²C commands out via
   every launch (that is how libuvc-based apps like Pupil Capture ship on
   macOS). Not acceptable here.
 
-**The planned fix** is a hybrid backend: frames stream via OpenCV/AVFoundation
-as a normal camera, while a small IOKit module sends the UVC `SET_CUR`/`GET_CUR`
-requests over **the default control pipe (pipe 0) of the VideoControl
-interface, without opening the interface** — which Apple's driver leaves
-available while it streams (an Apple-DTS-sanctioned pattern, used by
-openpnp-capture among others; requires no root and no special entitlements).
-Unlike Linux's `uvcvideo`, there is no kernel-side control cache in this path,
-so `GET_CUR` reads are live by construction.
+**The fix** (implemented, bench-validated) is a hybrid backend: frames stream
+through a native AVFoundation capture session pinned to the scope's stable
+`uniqueID` (`avfframegrabbermac.mm` — not OpenCV, whose index-based opening
+binds the wrong camera when the device list shifts), while a small IOKit
+module sends the UVC `SET_CUR`/`GET_CUR` requests over **the default control
+pipe (pipe 0) of the VideoControl interface, without opening the interface** —
+which Apple's driver leaves available while it streams (an Apple-DTS-sanctioned
+pattern, used by openpnp-capture among others; requires no root and no special
+entitlements). Unlike Linux's `uvcvideo`, there is no kernel-side control cache
+in this path, so `GET_CUR` reads are live by construction.

--- a/BUILD_MACOS.md
+++ b/BUILD_MACOS.md
@@ -99,9 +99,20 @@ Windows + Linux + macOS together.
 **First launch on another Mac:** the bundle is ad-hoc signed, not notarized,
 so Gatekeeper warns about an unidentified developer. Right-click the app >
 Open > Open (needed once). If macOS claims the app "is damaged", clear the
-quarantine flag instead: `xattr -cr "/Applications/Miniscope DAQ.app"`.
+quarantine flag instead: `xattr -cr /Applications/MiniscopeDAQ.app`.
 Proper Developer ID signing + notarization can be added to the script later
 without changing anything else.
+
+**iPhone / Continuity Camera interference (bench-verified):** a nearby iPhone
+joins the Mac's camera list via Continuity Camera and macOS actively promotes
+it, which can steal the video session away from the Miniscope (symptom: the
+scope "connects" but the video window shows the phone, freezes after ~1 s, or
+never streams — while BNO/controls keep working, since they use a separate
+USB channel bound to the scope). For recording rigs, disable it: on the
+iPhone, Settings > General > AirPlay & Continuity > Continuity Camera off
+(or move the phone away). The app re-binds the scope's video stream to its
+USB identity when the camera list shifts, but macOS's automatic camera
+selection can still interfere at session start.
 
 ---
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,22 @@ if(APPLE)
         PRIVATE "-framework AVFoundation" "-framework CoreMedia")
     target_include_directories(avfenumerator_mac PUBLIC source)
 
+    # Native AVFoundation frame grabber pinned to a device uniqueID. Exists
+    # because OpenCV's AVFoundation backend can only open cameras by LIST
+    # INDEX, and macOS reshuffles that list as devices come and go (iPhone
+    # Continuity Camera, hot-plugged webcams) - bench-verified to stream the
+    # WRONG camera. ARC for safe ObjC object lifetimes.
+    add_library(avfgrabber_mac STATIC
+        source/avfframegrabbermac.mm
+        source/avfframegrabbermac.h
+    )
+    set_source_files_properties(source/avfframegrabbermac.mm PROPERTIES
+        COMPILE_OPTIONS "-fobjc-arc")
+    target_include_directories(avfgrabber_mac PUBLIC source ${OpenCV_INCLUDE_DIRS})
+    target_link_libraries(avfgrabber_mac
+        PUBLIC Qt6::Core ${OpenCV_LIBS}
+        PRIVATE "-framework AVFoundation" "-framework CoreMedia" "-framework CoreVideo")
+
     add_executable(uvc-bench-mac tools/uvc-bench-mac.cpp)
     target_link_libraries(uvc-bench-mac PRIVATE uvccontrol_mac Qt6::Core)
 endif()
@@ -134,7 +150,7 @@ qt_add_executable(MiniscopeDAQ
 )
 
 if(APPLE)
-    target_link_libraries(MiniscopeDAQ PRIVATE uvccontrol_mac avfenumerator_mac)
+    target_link_libraries(MiniscopeDAQ PRIVATE uvccontrol_mac avfenumerator_mac avfgrabber_mac)
 
     # Build as a .app bundle. This is not just packaging polish: macOS kills
     # any camera-touching process whose bundle lacks NSCameraUsageDescription,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,9 +55,9 @@ target_include_directories(miniscope_protocol PUBLIC source)
 # Sends UVC SET_CUR/GET_CUR to the Miniscope over the default control pipe
 # without opening the interface, coexisting with Apple's UVC driver (which owns
 # the streaming path since macOS 12 - libusb/libuvc would need root there).
-# The app itself doesn't consume this yet; the hybrid AVFoundation capture
-# backend that will is the next PR. uvc-bench-mac is the hardware-validation
-# CLI: see its header comment for the bench procedure and pass criteria.
+# Consumed by the hybrid capture backend (videostreammac) and by
+# uvc-bench-mac, the hardware-validation CLI: see its header comment for the
+# bench procedure and pass criteria.
 if(APPLE)
     enable_language(OBJCXX)   # for the AVFoundation enumerator (.mm)
 

--- a/source/avfenumeratormac.h
+++ b/source/avfenumeratormac.h
@@ -43,6 +43,21 @@ ControlTarget resolveControlTarget(const QVector<AvfCameraInfo> &cameras, int ca
                                    quint16 expectedVid, quint16 expectedPid,
                                    const QVector<quint32> &attachedLocations);
 
+// Current AVF/OpenCV list index of the camera with this USB locationID, or -1.
+// The camera list shifts whenever devices come and go (an iPhone joining via
+// Continuity Camera is the classic case), so a config's stored deviceID can
+// silently start pointing at the wrong camera; this re-binds the frame stream
+// to the physical device the control channel already resolved.
+inline int avfIndexForLocation(const QVector<AvfCameraInfo> &cameras, quint32 locationID)
+{
+    if (locationID == 0)
+        return -1;
+    for (int i = 0; i < cameras.size(); i++)
+        if (cameras[i].isUsb && cameras[i].locationID == locationID)
+            return i;
+    return -1;
+}
+
 // AVCaptureDevice.uniqueID for a USB camera is the hex of the 64-bit value
 // (locationID << 32) | (vid << 16) | pid, with or without a "0x" prefix and
 // possibly without leading zeros. Non-USB devices (the built-in camera on

--- a/source/avfenumeratormac.h
+++ b/source/avfenumeratormac.h
@@ -58,6 +58,15 @@ inline int avfIndexForLocation(const QVector<AvfCameraInfo> &cameras, quint32 lo
     return -1;
 }
 
+// The device's stable AVFoundation uniqueID (empty when absent) - what the
+// frame grabber pins its capture session to, so the video stream can never
+// land on a different camera than the control channel.
+inline QString avfUniqueIdForLocation(const QVector<AvfCameraInfo> &cameras, quint32 locationID)
+{
+    const int i = avfIndexForLocation(cameras, locationID);
+    return i < 0 ? QString() : cameras[i].uniqueID;
+}
+
 // AVCaptureDevice.uniqueID for a USB camera is the hex of the 64-bit value
 // (locationID << 32) | (vid << 16) | pid, with or without a "0x" prefix and
 // possibly without leading zeros. Non-USB devices (the built-in camera on

--- a/source/avfenumeratormac.h
+++ b/source/avfenumeratormac.h
@@ -43,28 +43,19 @@ ControlTarget resolveControlTarget(const QVector<AvfCameraInfo> &cameras, int ca
                                    quint16 expectedVid, quint16 expectedPid,
                                    const QVector<quint32> &attachedLocations);
 
-// Current AVF/OpenCV list index of the camera with this USB locationID, or -1.
-// The camera list shifts whenever devices come and go (an iPhone joining via
-// Continuity Camera is the classic case), so a config's stored deviceID can
-// silently start pointing at the wrong camera; this re-binds the frame stream
-// to the physical device the control channel already resolved.
-inline int avfIndexForLocation(const QVector<AvfCameraInfo> &cameras, quint32 locationID)
-{
-    if (locationID == 0)
-        return -1;
-    for (int i = 0; i < cameras.size(); i++)
-        if (cameras[i].isUsb && cameras[i].locationID == locationID)
-            return i;
-    return -1;
-}
-
-// The device's stable AVFoundation uniqueID (empty when absent) - what the
-// frame grabber pins its capture session to, so the video stream can never
-// land on a different camera than the control channel.
+// The stable AVFoundation uniqueID of the camera with this USB locationID
+// (empty when absent) - what the frame grabber pins its capture session to,
+// so the video stream can never land on a different camera than the control
+// channel. Deliberately NOT an index lookup: list positions shift whenever
+// cameras come and go (iPhone Continuity Camera, hot-plugs).
 inline QString avfUniqueIdForLocation(const QVector<AvfCameraInfo> &cameras, quint32 locationID)
 {
-    const int i = avfIndexForLocation(cameras, locationID);
-    return i < 0 ? QString() : cameras[i].uniqueID;
+    if (locationID == 0)
+        return QString();
+    for (const AvfCameraInfo &cam : cameras)
+        if (cam.isUsb && cam.locationID == locationID)
+            return cam.uniqueID;
+    return QString();
 }
 
 // AVCaptureDevice.uniqueID for a USB camera is the hex of the 64-bit value

--- a/source/avfframegrabbermac.h
+++ b/source/avfframegrabbermac.h
@@ -1,0 +1,46 @@
+#ifndef AVFFRAMEGRABBERMAC_H
+#define AVFFRAMEGRABBERMAC_H
+
+#include <QString>
+#include <opencv2/core/core.hpp>
+
+// Native AVFoundation frame grabber pinned to a device uniqueID.
+//
+// Why not cv::VideoCapture: OpenCV's AVFoundation backend can only open a
+// camera by LIST INDEX, and macOS reshuffles the camera list whenever devices
+// come and go (iPhone Continuity Camera, hot-plugged webcams). Bench-verified
+// failure mode: the index resolved to the Miniscope at lookup time but to a
+// different camera by open time, so the app streamed the wrong device while
+// the control channel drove the real scope. uniqueID is stable for the
+// lifetime of the connection, so the session opened here cannot land on the
+// wrong camera by construction.
+//
+// Frames are delivered as 8UC3 BGR cv::Mat (matching what the OpenCV path
+// produced), scaled by CoreVideo to the requested size when one is given.
+class AvfFrameGrabber
+{
+public:
+    AvfFrameGrabber() = default;
+    ~AvfFrameGrabber();
+    AvfFrameGrabber(const AvfFrameGrabber &) = delete;
+    AvfFrameGrabber &operator=(const AvfFrameGrabber &) = delete;
+
+    // uniqueID: AVCaptureDevice.uniqueID (see AvfCameraInfo). width/height > 0
+    // requests scaled output buffers; 0 keeps the device's native size.
+    bool open(const QString &uniqueID, int width = 0, int height = 0);
+    bool isOpened() const;
+    void release();
+
+    // Blocks until the NEXT frame arrives (or timeout). Returns false on
+    // timeout or when not open - the caller treats that like a failed grab.
+    bool read(cv::Mat &frame, int timeoutMs = 5000);
+
+    QString lastError() const { return m_lastError; }
+
+private:
+    struct Impl;
+    Impl *m_impl = nullptr;
+    QString m_lastError;
+};
+
+#endif // AVFFRAMEGRABBERMAC_H

--- a/source/avfframegrabbermac.mm
+++ b/source/avfframegrabbermac.mm
@@ -1,0 +1,161 @@
+#include "avfframegrabbermac.h"
+
+#import <AVFoundation/AVFoundation.h>
+#import <CoreVideo/CoreVideo.h>
+
+#include <condition_variable>
+#include <mutex>
+
+#include <opencv2/imgproc.hpp>
+
+// Compiled with ARC (see CMakeLists) - no manual retain/release.
+
+// Delegate receiving frames on the capture dispatch queue. Keeps only the
+// LATEST frame (a mailbox, not a queue): the consumer loop paces itself and
+// the ring buffer downstream handles buffering; stale frames are worthless.
+@interface MSFrameSink : NSObject <AVCaptureVideoDataOutputSampleBufferDelegate>
+{
+@public
+    std::mutex mutex;
+    std::condition_variable frameArrived;
+    cv::Mat latest;      // 8UC3 BGR
+    uint64_t sequence;   // bumps once per delivered frame
+}
+@end
+
+@implementation MSFrameSink
+- (void)captureOutput:(AVCaptureOutput *)output
+    didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer
+           fromConnection:(AVCaptureConnection *)connection
+{
+    CVImageBufferRef image = CMSampleBufferGetImageBuffer(sampleBuffer);
+    if (!image)
+        return;
+    CVPixelBufferLockBaseAddress(image, kCVPixelBufferLock_ReadOnly);
+    const int w = int(CVPixelBufferGetWidth(image));
+    const int h = int(CVPixelBufferGetHeight(image));
+    const size_t stride = CVPixelBufferGetBytesPerRow(image);
+    void *base = CVPixelBufferGetBaseAddress(image);
+    if (base && w > 0 && h > 0) {
+        const cv::Mat bgra(h, w, CV_8UC4, base, stride);
+        std::lock_guard<std::mutex> lock(mutex);
+        cv::cvtColor(bgra, latest, cv::COLOR_BGRA2BGR);
+        sequence++;
+    }
+    CVPixelBufferUnlockBaseAddress(image, kCVPixelBufferLock_ReadOnly);
+    frameArrived.notify_all();
+}
+@end
+
+struct AvfFrameGrabber::Impl {
+    AVCaptureSession *session = nil;
+    MSFrameSink *sink = nil;
+    dispatch_queue_t queue = nil;
+    uint64_t consumedSequence = 0;
+};
+
+AvfFrameGrabber::~AvfFrameGrabber()
+{
+    release();
+}
+
+bool AvfFrameGrabber::open(const QString &uniqueID, int width, int height)
+{
+    release();
+    @autoreleasepool {
+        AVCaptureDevice *device =
+            [AVCaptureDevice deviceWithUniqueID:uniqueID.toNSString()];
+        if (!device) {
+            m_lastError = QStringLiteral("no capture device with uniqueID %1").arg(uniqueID);
+            return false;
+        }
+
+        NSError *error = nil;
+        AVCaptureDeviceInput *input =
+            [AVCaptureDeviceInput deviceInputWithDevice:device error:&error];
+        if (!input) {
+            m_lastError = QStringLiteral("could not open %1: %2")
+                              .arg(QString::fromNSString(device.localizedName),
+                                   QString::fromNSString(error.localizedDescription));
+            return false;
+        }
+
+        AVCaptureSession *session = [[AVCaptureSession alloc] init];
+        if (![session canAddInput:input]) {
+            m_lastError = QStringLiteral("capture session rejected %1 (in use by another app?)")
+                              .arg(QString::fromNSString(device.localizedName));
+            return false;
+        }
+        [session addInput:input];
+
+        AVCaptureVideoDataOutput *output = [[AVCaptureVideoDataOutput alloc] init];
+        NSMutableDictionary *settings = [@{
+            (id)kCVPixelBufferPixelFormatTypeKey : @(kCVPixelFormatType_32BGRA)
+        } mutableCopy];
+        if (width > 0 && height > 0) {
+            // CoreVideo scales the output buffers; when this matches the
+            // device's native format (the Miniscope case) it is a no-op.
+            settings[(id)kCVPixelBufferWidthKey] = @(width);
+            settings[(id)kCVPixelBufferHeightKey] = @(height);
+        }
+        output.videoSettings = settings;
+        output.alwaysDiscardsLateVideoFrames = YES;
+
+        MSFrameSink *sink = [MSFrameSink new];
+        dispatch_queue_t queue =
+            dispatch_queue_create("org.aharonilab.miniscope.avfgrabber", DISPATCH_QUEUE_SERIAL);
+        [output setSampleBufferDelegate:sink queue:queue];
+        if (![session canAddOutput:output]) {
+            m_lastError = QStringLiteral("capture session rejected the video output");
+            return false;
+        }
+        [session addOutput:output];
+        [session startRunning];
+
+        m_impl = new Impl;
+        m_impl->session = session;
+        m_impl->sink = sink;
+        m_impl->queue = queue;
+    }
+    m_lastError.clear();
+    return true;
+}
+
+bool AvfFrameGrabber::isOpened() const
+{
+    return m_impl && m_impl->session.running;
+}
+
+void AvfFrameGrabber::release()
+{
+    if (!m_impl)
+        return;
+    @autoreleasepool {
+        [m_impl->session stopRunning];
+        for (AVCaptureOutput *out in m_impl->session.outputs)
+            if ([out isKindOfClass:[AVCaptureVideoDataOutput class]])
+                [(AVCaptureVideoDataOutput *)out setSampleBufferDelegate:nil queue:nil];
+    }
+    delete m_impl;   // ARC releases the session/sink/queue with the Impl
+    m_impl = nullptr;
+}
+
+bool AvfFrameGrabber::read(cv::Mat &frame, int timeoutMs)
+{
+    if (!m_impl) {
+        m_lastError = QStringLiteral("grabber is not open");
+        return false;
+    }
+    MSFrameSink *sink = m_impl->sink;
+    std::unique_lock<std::mutex> lock(sink->mutex);
+    const bool arrived = sink->frameArrived.wait_for(
+        lock, std::chrono::milliseconds(timeoutMs),
+        [&] { return sink->sequence != m_impl->consumedSequence; });
+    if (!arrived) {
+        m_lastError = QStringLiteral("no frame within %1 ms").arg(timeoutMs);
+        return false;
+    }
+    sink->latest.copyTo(frame);
+    m_impl->consumedSequence = sink->sequence;
+    return true;
+}

--- a/source/avfframegrabbermac.mm
+++ b/source/avfframegrabbermac.mm
@@ -19,9 +19,10 @@
 @public
     std::mutex mutex;
     std::condition_variable frameArrived;
-    cv::Mat latest;      // 8UC3 BGR
+    cv::Mat latest;      // 8UC3 BGR mailbox slot (guarded by mutex)
     uint64_t sequence;   // bumps once per delivered frame
     OSType loggedFormat; // first delivered format, logged once
+    cv::Mat scratch;     // delegate-only conversion target (serial queue, no lock)
 }
 @end
 
@@ -49,31 +50,39 @@
     }
 
     if (base && w > 0 && h > 0) {
-        std::lock_guard<std::mutex> lock(mutex);
         // Interpret the buffer by what AVFoundation actually DELIVERED, never
         // by what was requested - a device may ignore the requested format
         // (reading YUY2 bytes as BGRA shows as garbled, row-shifted video).
+        // Convert into the delegate-private scratch Mat WITHOUT the lock (this
+        // runs on a serial dispatch queue), then swap it in: holding the lock
+        // across a full-frame conversion stalls the capture queue against the
+        // consumer's read() and turns contention into dropped frames.
+        bool converted = true;
         switch (format) {
         case kCVPixelFormatType_32BGRA:
-            cv::cvtColor(cv::Mat(h, w, CV_8UC4, base, stride), latest, cv::COLOR_BGRA2BGR);
+            cv::cvtColor(cv::Mat(h, w, CV_8UC4, base, stride), scratch, cv::COLOR_BGRA2BGR);
             break;
         case kCVPixelFormatType_422YpCbCr8:        // '2vuy' = UYVY
-            cv::cvtColor(cv::Mat(h, w, CV_8UC2, base, stride), latest, cv::COLOR_YUV2BGR_UYVY);
+            cv::cvtColor(cv::Mat(h, w, CV_8UC2, base, stride), scratch, cv::COLOR_YUV2BGR_UYVY);
             break;
         case kCVPixelFormatType_422YpCbCr8_yuvs:   // 'yuvs' = YUYV / YUY2
         case kCVPixelFormatType_422YpCbCr8FullRange:
-            cv::cvtColor(cv::Mat(h, w, CV_8UC2, base, stride), latest, cv::COLOR_YUV2BGR_YUY2);
+            cv::cvtColor(cv::Mat(h, w, CV_8UC2, base, stride), scratch, cv::COLOR_YUV2BGR_YUY2);
             break;
         case kCVPixelFormatType_24BGR:
-            cv::Mat(h, w, CV_8UC3, base, stride).copyTo(latest);
+            cv::Mat(h, w, CV_8UC3, base, stride).copyTo(scratch);
             break;
         default:
             // Unknown layout: drop the frame rather than mis-render it. The
             // one-time format log above tells us what to add.
-            CVPixelBufferUnlockBaseAddress(image, kCVPixelBufferLock_ReadOnly);
-            return;
+            converted = false;
+            break;
         }
-        sequence++;
+        if (converted) {
+            std::lock_guard<std::mutex> lock(mutex);
+            cv::swap(scratch, latest);
+            sequence++;
+        }
     }
     CVPixelBufferUnlockBaseAddress(image, kCVPixelBufferLock_ReadOnly);
     frameArrived.notify_all();
@@ -188,7 +197,9 @@ bool AvfFrameGrabber::read(cv::Mat &frame, int timeoutMs)
         m_lastError = QStringLiteral("no frame within %1 ms").arg(timeoutMs);
         return false;
     }
-    sink->latest.copyTo(frame);
+    // Swap, don't copy: the consumer's previous frame buffer becomes the next
+    // mailbox slot, so steady state runs allocation- and copy-free here.
+    cv::swap(sink->latest, frame);
     m_impl->consumedSequence = sink->sequence;
     return true;
 }

--- a/source/avfframegrabbermac.mm
+++ b/source/avfframegrabbermac.mm
@@ -6,6 +6,7 @@
 #include <condition_variable>
 #include <mutex>
 
+#include <QDebug>
 #include <opencv2/imgproc.hpp>
 
 // Compiled with ARC (see CMakeLists) - no manual retain/release.
@@ -20,6 +21,7 @@
     std::condition_variable frameArrived;
     cv::Mat latest;      // 8UC3 BGR
     uint64_t sequence;   // bumps once per delivered frame
+    OSType loggedFormat; // first delivered format, logged once
 }
 @end
 
@@ -35,11 +37,42 @@
     const int w = int(CVPixelBufferGetWidth(image));
     const int h = int(CVPixelBufferGetHeight(image));
     const size_t stride = CVPixelBufferGetBytesPerRow(image);
+    const OSType format = CVPixelBufferGetPixelFormatType(image);
     void *base = CVPixelBufferGetBaseAddress(image);
+
+    if (loggedFormat != format) {
+        loggedFormat = format;
+        const char fourcc[5] = {char(format >> 24), char(format >> 16),
+                                char(format >> 8), char(format), 0};
+        qInfo().nospace() << "[diag] grabber pixel format '" << fourcc << "' " << w << "x" << h
+                          << " stride=" << stride;
+    }
+
     if (base && w > 0 && h > 0) {
-        const cv::Mat bgra(h, w, CV_8UC4, base, stride);
         std::lock_guard<std::mutex> lock(mutex);
-        cv::cvtColor(bgra, latest, cv::COLOR_BGRA2BGR);
+        // Interpret the buffer by what AVFoundation actually DELIVERED, never
+        // by what was requested - a device may ignore the requested format
+        // (reading YUY2 bytes as BGRA shows as garbled, row-shifted video).
+        switch (format) {
+        case kCVPixelFormatType_32BGRA:
+            cv::cvtColor(cv::Mat(h, w, CV_8UC4, base, stride), latest, cv::COLOR_BGRA2BGR);
+            break;
+        case kCVPixelFormatType_422YpCbCr8:        // '2vuy' = UYVY
+            cv::cvtColor(cv::Mat(h, w, CV_8UC2, base, stride), latest, cv::COLOR_YUV2BGR_UYVY);
+            break;
+        case kCVPixelFormatType_422YpCbCr8_yuvs:   // 'yuvs' = YUYV / YUY2
+        case kCVPixelFormatType_422YpCbCr8FullRange:
+            cv::cvtColor(cv::Mat(h, w, CV_8UC2, base, stride), latest, cv::COLOR_YUV2BGR_YUY2);
+            break;
+        case kCVPixelFormatType_24BGR:
+            cv::Mat(h, w, CV_8UC3, base, stride).copyTo(latest);
+            break;
+        default:
+            // Unknown layout: drop the frame rather than mis-render it. The
+            // one-time format log above tells us what to add.
+            CVPixelBufferUnlockBaseAddress(image, kCVPixelBufferLock_ReadOnly);
+            return;
+        }
         sequence++;
     }
     CVPixelBufferUnlockBaseAddress(image, kCVPixelBufferLock_ReadOnly);

--- a/source/backend.cpp
+++ b/source/backend.cpp
@@ -805,6 +805,25 @@ QString backEnd::scanVideoDevices()
 #endif
 }
 
+#if defined(Q_OS_WINDOWS) || defined(Q_OS_MACOS)
+// Shared Scan-Devices report for the platforms whose enumerator returns a
+// plain name list whose position == the config deviceID (Linux formats its
+// own richer capture-vs-metadata report).
+static QString formatDeviceScan(const QStringList &names, const QString &trailerNote)
+{
+    if (names.isEmpty())
+        return QStringLiteral("No video devices detected.");
+    QStringList lines;
+    for (int i = 0; i < names.size(); i++)
+        lines << QString("    deviceID %1:  %2")
+                     .arg(i)
+                     .arg(names[i].isEmpty() ? QStringLiteral("(unknown)") : names[i]);
+    return QStringLiteral("Detected video devices:\n") + lines.join("\n")
+           + QStringLiteral("\n\nUse these deviceID numbers in your user config.")
+           + trailerNote;
+}
+#endif
+
 #if defined(Q_OS_WINDOWS)
 // Names of the connected DirectShow video-input devices, indexed the same way
 // OpenCV's CAP_DSHOW backend orders them, so the position == the config deviceID.
@@ -848,18 +867,9 @@ QStringList backEnd::enumerateVideoDevices()
 
 QString backEnd::scanVideoDevicesWindows()
 {
-    const QStringList names = enumerateVideoDevices();
-    if (names.isEmpty())
-        return QStringLiteral("No video devices detected.");
-    QStringList lines;
-    for (int i = 0; i < names.size(); i++)
-        lines << QString("    deviceID %1:  %2")
-                     .arg(i)
-                     .arg(names[i].isEmpty() ? QStringLiteral("(unknown)") : names[i]);
-    return QStringLiteral("Detected video devices:\n") + lines.join("\n")
-           + QStringLiteral("\n\nUse these deviceID numbers in your user config. "
-                            "Note: a Miniscope might appear under a generic name "
-                            "(e.g. \"USB Video Device\").");
+    return formatDeviceScan(enumerateVideoDevices(),
+                            QStringLiteral(" Note: a Miniscope might appear under a generic "
+                                           "name (e.g. \"USB Video Device\")."));
 }
 
 #elif defined(Q_OS_LINUX)
@@ -939,14 +949,7 @@ QStringList backEnd::enumerateVideoDevices()
 
 QString backEnd::scanVideoDevicesMac()
 {
-    const QStringList names = enumerateVideoDevices();
-    if (names.isEmpty())
-        return QStringLiteral("No video devices detected.");
-    QStringList lines;
-    for (int i = 0; i < names.size(); i++)
-        lines << QString("    deviceID %1:  %2").arg(i).arg(names[i]);
-    return QStringLiteral("Detected video devices:\n") + lines.join("\n")
-           + QStringLiteral("\n\nUse these deviceID numbers in your user config.");
+    return formatDeviceScan(enumerateVideoDevices(), QString());
 }
 #endif
 

--- a/source/miniscope.cpp
+++ b/source/miniscope.cpp
@@ -153,9 +153,11 @@ void Miniscope::handleNewDisplayFrame(qint64 timeStamp, cv::Mat frame, int bufId
     // A frame size change (a device reconnect can renegotiate the format, or
     // a mis-bound camera can deliver foreign frames) must restart the baseline
     // accumulation: mixing sizes in the += / divide below is a fatal
-    // cv::Exception (observed as an app crash on the macOS bench).
-    if (!baselineFrame.empty()
-        && (frame.cols != baselineFrame.cols || frame.rows != baselineFrame.rows)) {
+    // cv::Exception (observed as an app crash on the macOS bench). This one
+    // predicate drives the reset here and the dFF fallbacks below.
+    bool baselineSizeMatches = !baselineFrame.empty()
+        && frame.cols == baselineFrame.cols && frame.rows == baselineFrame.rows;
+    if (!baselineFrame.empty() && !baselineSizeMatches) {
         qWarning() << getDeviceName() << "frame size changed to" << frame.cols << "x" << frame.rows
                    << "- resetting dFF baseline";
         baselineFrameBufWritePos = 0;
@@ -169,6 +171,7 @@ void Miniscope::handleNewDisplayFrame(qint64 timeStamp, cv::Mat frame, int bufId
         tempMat1 = tempMat1/(BASELINE_FRAME_BUFFER_SIZE);
         if (baselineFrameBufWritePos == 0) {
             baselineFrame = tempMat1;
+            baselineSizeMatches = true;   // baseline just restarted at this frame's size
         }
         else if (baselineFrameBufWritePos < BASELINE_FRAME_BUFFER_SIZE) {
             baselineFrame += tempMat1;
@@ -191,8 +194,7 @@ void Miniscope::handleNewDisplayFrame(qint64 timeStamp, cv::Mat frame, int bufId
     else if (m_displatState == "dFF") {
         // While the baseline is (re)accumulating at a new size, show raw
         // rather than dividing by a mismatched-size baseline (fatal).
-        if (baselineFrame.empty()
-            || frame.cols != baselineFrame.cols || frame.rows != baselineFrame.rows) {
+        if (!baselineSizeMatches) {
             vidDisp->setDisplayFrame(tempFrame2);
         }
         else {

--- a/source/miniscope.cpp
+++ b/source/miniscope.cpp
@@ -150,6 +150,17 @@ void Miniscope::handleNewDisplayFrame(qint64 timeStamp, cv::Mat frame, int bufId
     else
         tempFrame2 = QImage(frame.data, frame.cols, frame.rows, frame.step, QImage::Format_RGB888);
 
+    // A frame size change (a device reconnect can renegotiate the format, or
+    // a mis-bound camera can deliver foreign frames) must restart the baseline
+    // accumulation: mixing sizes in the += / divide below is a fatal
+    // cv::Exception (observed as an app crash on the macOS bench).
+    if (!baselineFrame.empty()
+        && (frame.cols != baselineFrame.cols || frame.rows != baselineFrame.rows)) {
+        qWarning() << getDeviceName() << "frame size changed to" << frame.cols << "x" << frame.rows
+                   << "- resetting dFF baseline";
+        baselineFrameBufWritePos = 0;
+    }
+
     // Generate moving average baseline frame
     if ((timeStamp - baselinePreviousTimeStamp) > 50) {
         // update baseline frame buffer every ~500ms
@@ -178,6 +189,13 @@ void Miniscope::handleNewDisplayFrame(qint64 timeStamp, cv::Mat frame, int bufId
         vidDisp->setDisplayFrame(tempFrame2);
     }
     else if (m_displatState == "dFF") {
+        // While the baseline is (re)accumulating at a new size, show raw
+        // rather than dividing by a mismatched-size baseline (fatal).
+        if (baselineFrame.empty()
+            || frame.cols != baselineFrame.cols || frame.rows != baselineFrame.rows) {
+            vidDisp->setDisplayFrame(tempFrame2);
+        }
+        else {
         // TODO: Implement this better. I am sure it can be sped up a lot. Maybe do most of it in a shader
         tempMat2 = frame.clone();
         tempMat2.convertTo(tempMat2, CV_32F);
@@ -187,6 +205,7 @@ void Miniscope::handleNewDisplayFrame(qint64 timeStamp, cv::Mat frame, int bufId
         cv::cvtColor(tempMat2, tempFrame, cv::COLOR_GRAY2BGR);
         tempFrame2 = QImage(tempFrame.data, tempFrame.cols, tempFrame.rows, tempFrame.step, QImage::Format_RGB888);
         vidDisp->setDisplayFrame(tempFrame2); //TODO: Probably doesn't need "copy"
+        }
     }
     if (getHeadOrienataionStreamState()) {
         // TODO: Clean up this section. Consolidate
@@ -251,10 +270,12 @@ void Miniscope::handleNewDisplayFrame(qint64 timeStamp, cv::Mat frame, int bufId
         int bufNum;
         int dataCount;
 
-        float meanIntensity;
+        float meanIntensity = 0.0f;
 
         float meanFrameIntensity;
-        if (m_displatState == "dFF") {
+        // tempMat2 is empty while the dFF baseline is rebuilding after a
+        // frame-size change (see above) - skip the dFF trace math then.
+        if (m_displatState == "dFF" && !tempMat2.empty()) {
             // Remove or find a fast way (maybe with resize or downsamp) if needed.
             // Use center 60% of frame for mean calculation
             cv::Rect frameMeanROIRect(tempMat2.rows * 0.2,
@@ -286,7 +307,7 @@ void Miniscope::handleNewDisplayFrame(qint64 timeStamp, cv::Mat frame, int bufId
                 if (m_displatState == "Raw") {
                     meanIntensity = cv::mean(frame(roiRect))[0];
                 }
-                else if (m_displatState == "dFF") {
+                else if (m_displatState == "dFF" && !tempMat2.empty()) {
                     meanIntensity = cv::mean(tempMat2(roiRect))[0];
                 }
                 // Used for mean window smoothing of traces

--- a/source/videostreambase.h
+++ b/source/videostreambase.h
@@ -3,8 +3,11 @@
 
 #include <QObject>
 #include <QString>
+#include <QThread>
 #include <QVector>
 #include <opencv2/core/core.hpp>
+
+#include "miniscopeprotocol.h"
 
 class QSemaphore;
 class QAtomicInt;
@@ -55,6 +58,25 @@ public slots:
     virtual void startRecording() = 0;
     virtual void stopRecording() = 0;
     virtual void openCamPropsDialog() = 0;
+
+protected:
+    // Flush queued I2C command packets to the device (transport-specific:
+    // UVC SET_CUR on libuvc/macOS, CAP_PROP passthrough on OpenCV).
+    virtual void sendCommands() = 0;
+
+    // Queue + flush the pixel-clock dependent SERDES setup packets, then let
+    // the video link settle. One shared copy of this order-critical connect
+    // ritual - the pre-refactor code had four inline copies that had drifted.
+    void sendSerdesModeCommands(double pixelClock)
+    {
+        const auto packets = MiniscopeProtocol::serdesModePackets(pixelClock);
+        if (packets.isEmpty())
+            return;
+        for (int i = 0; i < packets.size(); i++)
+            setPropertyI2C(i, packets[i]);
+        sendCommands();
+        QThread::msleep(500);
+    }
 };
 
 #endif // VIDEOSTREAMBASE_H

--- a/source/videostreamlibuvc.cpp
+++ b/source/videostreamlibuvc.cpp
@@ -176,17 +176,6 @@ bool VideoStreamLibUVC::negotiateFormat()
     return false;
 }
 
-void VideoStreamLibUVC::sendSerdesModeCommands()
-{
-    const auto packets = serdesModePackets(m_pixelClock);
-    if (packets.isEmpty())
-        return;
-    for (int i = 0; i < packets.size(); i++)
-        setPropertyI2C(i, packets[i]);
-    sendCommands();
-    QThread::msleep(500);
-}
-
 int VideoStreamLibUVC::connect2Camera(int cameraID)
 {
     m_cameraID = cameraID;
@@ -201,7 +190,7 @@ int VideoStreamLibUVC::connect2Camera(int cameraID)
         return 0;
     }
     m_connectionType = "libuvc";
-    sendSerdesModeCommands();
+    sendSerdesModeCommands(m_pixelClock);
     return 1;
 }
 
@@ -360,7 +349,7 @@ bool VideoStreamLibUVC::attemptReconnect()
         return false;
     if (!negotiateFormat())
         return false;
-    sendSerdesModeCommands();
+    sendSerdesModeCommands(m_pixelClock);
     if (uvc_stream_open_ctrl(m_devh, &m_strmh, &m_streamCtrl) < 0 ||
         uvc_stream_start(m_strmh, nullptr, nullptr, 0) < 0) {
         closeStream();

--- a/source/videostreamlibuvc.h
+++ b/source/videostreamlibuvc.h
@@ -9,7 +9,6 @@
 
 #include <QSemaphore>
 #include <QAtomicInt>
-#include <QMap>
 #include <QVector>
 #include <opencv2/core/core.hpp>
 
@@ -48,8 +47,7 @@ private:
     // with the macOS IOKit control transport).
     bool openByVideoIndex(int cameraID);   // resolve /dev/videoN -> USB bus/addr, open via libuvc
     bool negotiateFormat();
-    void sendSerdesModeCommands();         // pixel-clock dependent SERDES setup
-    void sendCommands();                   // flush queued I2C packets as UVC SET_CUR
+    void sendCommands() override;          // flush queued I2C packets as UVC SET_CUR
     bool setPU(quint8 selector, quint16 value);
     int  getPU(quint8 selector);           // fresh GET_CUR, returned as signed 16-bit
     bool attemptReconnect();

--- a/source/videostreammac.cpp
+++ b/source/videostreammac.cpp
@@ -107,6 +107,26 @@ void VideoStreamMac::sendSerdesModeCommands()
     QThread::msleep(500);
 }
 
+// The config's deviceID indexes the AVF camera list, but that list shifts as
+// cameras come and go - an iPhone joining via Continuity Camera is the classic
+// case, observed on the bench: the index opened the phone's video while the
+// control channel (bound by USB identity) drove the real scope. The control
+// channel has already resolved the exact USB device by this point, so bind the
+// frame stream to that SAME device's current index. Falls back to the config
+// index when the lookup fails.
+int VideoStreamMac::frameIndexForControl(int configIndex)
+{
+    const int idx = avfIndexForLocation(enumerateAvfCameras(), m_control.locationID());
+    if (idx < 0)
+        return configIndex;
+    if (idx != configIndex)
+        sendMessage("Warning: " + m_deviceName + ": deviceID " + QString::number(configIndex) +
+                    " does not currently point at the Miniscope (the camera list has shifted, "
+                    "e.g. a phone joined via Continuity Camera); streaming from index " +
+                    QString::number(idx) + " instead.");
+    return idx;
+}
+
 int VideoStreamMac::connect2Camera(int cameraID)
 {
     m_cameraID = cameraID;
@@ -116,10 +136,12 @@ int VideoStreamMac::connect2Camera(int cameraID)
     if (!openControlForIndex(cameraID))
         return 0;
 
+    const int avfIndex = frameIndexForControl(cameraID);
     cam = new cv::VideoCapture;
-    if (!cam->open(cameraID, cv::CAP_AVFOUNDATION)) {
+    if (!cam->open(avfIndex, cv::CAP_AVFOUNDATION)) {
         sendMessage("Error: could not open AVFoundation stream for " + m_deviceName +
-                    " (deviceID " + QString::number(cameraID) + ")");
+                    " (deviceID " + QString::number(cameraID) + ", AVF index " +
+                    QString::number(avfIndex) + ")");
         m_control.close();
         return 0;
     }
@@ -314,7 +336,9 @@ bool VideoStreamMac::attemptReconnect()
     m_control.close();
     if (!openControlForIndex(m_cameraID))
         return false;
-    if (!cam->open(m_cameraID, cv::CAP_AVFOUNDATION))
+    // Re-resolve the frame index too: the camera list may have changed (that
+    // can be exactly why we are reconnecting).
+    if (!cam->open(frameIndexForControl(m_cameraID), cv::CAP_AVFOUNDATION))
         return false;
     sendSerdesModeCommands();
     cam->set(cv::CAP_PROP_FRAME_WIDTH, m_expectedWidth);

--- a/source/videostreammac.cpp
+++ b/source/videostreammac.cpp
@@ -162,18 +162,29 @@ int VideoStreamMac::connect2Camera(int cameraID)
 // SET_CURs into the I2C tunnel).
 void VideoStreamMac::logStallDiagnosis()
 {
-    const int c0 = getPU(SEL_CONTRAST);
+    quint16 c0 = 0, c1 = 0, c2 = 0;
+    const bool ok0 = m_control.getCur(kProcessingUnitId, SEL_CONTRAST, &c0);
     QThread::msleep(500);
-    const int c1 = getPU(SEL_CONTRAST);
+    const bool ok1 = m_control.getCur(kProcessingUnitId, SEL_CONTRAST, &c1);
     QThread::msleep(500);
-    const int c2 = getPU(SEL_CONTRAST);
-    const bool advancing = (c1 != c0) || (c2 != c1);
-    const QString verdict = advancing
-        ? QStringLiteral("DAQ frame counter ADVANCING (%1 -> %2 -> %3): scope video link is "
-                         "alive, AVFoundation session died")
-        : QStringLiteral("DAQ frame counter FROZEN (%1 -> %2 -> %3): scope video pipeline is "
-                         "down (sensor/SERDES state suspect)");
-    const QString msg = verdict.arg(c0).arg(c1).arg(c2);
+    const bool ok2 = m_control.getCur(kProcessingUnitId, SEL_CONTRAST, &c2);
+
+    QString msg;
+    if (!ok0 && !ok1 && !ok2) {
+        // The control channel is gone too: this is a USB-level disconnect
+        // (cable/power/bus), not a video-layer problem.
+        msg = QStringLiteral("control channel unreachable as well (%1): the DAQ has "
+                             "disconnected at the USB level - check cable/hub/power")
+                  .arg(m_control.lastError());
+    } else if (c0 != c1 || c1 != c2) {
+        msg = QStringLiteral("DAQ frame counter ADVANCING (%1 -> %2 -> %3): scope video link "
+                             "is alive, AVFoundation session died")
+                  .arg(c0).arg(c1).arg(c2);
+    } else {
+        msg = QStringLiteral("DAQ frame counter FROZEN (%1 -> %2 -> %3): scope video pipeline "
+                             "is down (sensor/SERDES state suspect)")
+                  .arg(c0).arg(c1).arg(c2);
+    }
     qInfo().noquote() << "[diag]" << m_deviceName << msg;
     sendMessage("Diag: " + m_deviceName + " " + msg);
 }
@@ -228,6 +239,7 @@ void VideoStreamMac::startStream()
 
     qInfo() << "[diag]" << m_deviceName << "stream loop starting";
 
+    int reconnectAttempts = 0;
     m_isStreaming = true;
     forever {
         if (m_stopStreaming) {
@@ -236,15 +248,26 @@ void VideoStreamMac::startStream()
         }
 
         if (!m_grabber.read(frame)) {
-            qInfo() << "[diag]" << m_deviceName << "no frame at" << idx << "("
-                    << m_grabber.lastError() << ") - running stall diagnosis";
-            sendMessage("Warning: " + m_deviceName + " grab frame failed. Attempting to reconnect.");
-            logStallDiagnosis();
+            // Diagnose and message on the FIRST failure of a stall episode;
+            // later attempts back off quietly (a device that fell off the bus
+            // can take a while to come back, and every attempt already logs).
+            if (reconnectAttempts == 0) {
+                qInfo() << "[diag]" << m_deviceName << "no frame at" << idx << "("
+                        << m_grabber.lastError() << ") - running stall diagnosis";
+                sendMessage("Warning: " + m_deviceName + " grab frame failed. Attempting to reconnect.");
+                logStallDiagnosis();
+            }
+            reconnectAttempts++;
             m_grabber.release();
-            QThread::msleep(1000);
+            QThread::msleep(qMin(1000 * reconnectAttempts, 5000));
+            QCoreApplication::processEvents();   // keep stopSteam() deliverable while down
+            if (m_stopStreaming)
+                continue;
             if (attemptReconnect()) {
-                sendMessage("Warning: " + m_deviceName + " reconnected.");
+                sendMessage("Warning: " + m_deviceName + " reconnected (after " +
+                            QString::number(reconnectAttempts) + " attempts).");
                 qDebug() << "Reconnect to camera" << m_cameraID;
+                reconnectAttempts = 0;
             }
             continue;
         }

--- a/source/videostreammac.cpp
+++ b/source/videostreammac.cpp
@@ -15,7 +15,6 @@ VideoStreamMac::VideoStreamMac(QObject *parent, int width, int height, double pi
     VideoStreamBase(parent),
     m_cameraID(-1),
     m_deviceName(""),
-    cam(nullptr),
     m_isStreaming(false),
     m_stopStreaming(false),
     m_headOrientationStreamState(false),
@@ -41,9 +40,7 @@ VideoStreamMac::VideoStreamMac(QObject *parent, int width, int height, double pi
 VideoStreamMac::~VideoStreamMac()
 {
     qDebug() << "Closing macOS hybrid video stream";
-    if (cam && cam->isOpened())
-        cam->release();
-    delete cam;
+    m_grabber.release();
     m_control.close();
 }
 
@@ -107,24 +104,34 @@ void VideoStreamMac::sendSerdesModeCommands()
     QThread::msleep(500);
 }
 
-// The config's deviceID indexes the AVF camera list, but that list shifts as
-// cameras come and go - an iPhone joining via Continuity Camera is the classic
-// case, observed on the bench: the index opened the phone's video while the
-// control channel (bound by USB identity) drove the real scope. The control
-// channel has already resolved the exact USB device by this point, so bind the
-// frame stream to that SAME device's current index. Falls back to the config
-// index when the lookup fails.
-int VideoStreamMac::frameIndexForControl(int configIndex)
+// Open the video stream pinned to the SAME physical device the control
+// channel resolved, via its stable AVFoundation uniqueID. Never opens by list
+// index: macOS reshuffles the camera list as devices come and go (iPhone
+// Continuity Camera, hot-plugged webcams), and both bench failures came from
+// an index resolving to a different camera by open time.
+bool VideoStreamMac::openFrameStream()
 {
-    const int idx = avfIndexForLocation(enumerateAvfCameras(), m_control.locationID());
-    if (idx < 0)
-        return configIndex;
-    if (idx != configIndex)
-        sendMessage("Warning: " + m_deviceName + ": deviceID " + QString::number(configIndex) +
-                    " does not currently point at the Miniscope (the camera list has shifted, "
-                    "e.g. a phone joined via Continuity Camera); streaming from index " +
-                    QString::number(idx) + " instead.");
-    return idx;
+    QString uniqueId = avfUniqueIdForLocation(enumerateAvfCameras(), m_control.locationID());
+    if (uniqueId.isEmpty()) {
+        // The control channel just opened this device over USB, so it exists;
+        // AVFoundation's list can briefly lag a hot-plug. One settle+retry.
+        QThread::msleep(500);
+        uniqueId = avfUniqueIdForLocation(enumerateAvfCameras(), m_control.locationID());
+    }
+    if (uniqueId.isEmpty()) {
+        sendMessage("Error: " + m_deviceName + ": the Miniscope's USB device (locationID 0x" +
+                    QString::number(m_control.locationID(), 16) +
+                    ") never appeared in the camera list.");
+        return false;
+    }
+    if (!m_grabber.open(uniqueId, m_expectedWidth, m_expectedHeight)) {
+        sendMessage("Error: could not open the video stream for " + m_deviceName + " (" +
+                    m_grabber.lastError() + ")");
+        return false;
+    }
+    qInfo().nospace() << "[diag] " << m_deviceName << " frame stream pinned to uniqueID "
+                      << uniqueId << " at " << m_expectedWidth << "x" << m_expectedHeight;
+    return true;
 }
 
 int VideoStreamMac::connect2Camera(int cameraID)
@@ -136,33 +143,14 @@ int VideoStreamMac::connect2Camera(int cameraID)
     if (!openControlForIndex(cameraID))
         return 0;
 
-    const int avfIndex = frameIndexForControl(cameraID);
-    cam = new cv::VideoCapture;
-    if (!cam->open(avfIndex, cv::CAP_AVFOUNDATION)) {
-        sendMessage("Error: could not open AVFoundation stream for " + m_deviceName +
-                    " (deviceID " + QString::number(cameraID) + ", AVF index " +
-                    QString::number(avfIndex) + ")");
+    if (!openFrameStream()) {
         m_control.close();
         return 0;
     }
     m_connectionType = "AVF";
 
-    qInfo().nospace() << "[diag] " << m_deviceName << " AVF opened: native "
-                      << cam->get(cv::CAP_PROP_FRAME_WIDTH) << "x"
-                      << cam->get(cv::CAP_PROP_FRAME_HEIGHT) << " @ "
-                      << cam->get(cv::CAP_PROP_FPS) << "fps; requesting "
-                      << m_expectedWidth << "x" << m_expectedHeight;
-
     sendSerdesModeCommands();
-
-    cam->set(cv::CAP_PROP_FRAME_WIDTH, m_expectedWidth);
-    cam->set(cv::CAP_PROP_FRAME_HEIGHT, m_expectedHeight);
     QThread::msleep(500);
-
-    qInfo().nospace() << "[diag] " << m_deviceName << " after set: "
-                      << cam->get(cv::CAP_PROP_FRAME_WIDTH) << "x"
-                      << cam->get(cv::CAP_PROP_FRAME_HEIGHT) << " @ "
-                      << cam->get(cv::CAP_PROP_FPS) << "fps";
     return 1;
 }
 
@@ -227,7 +215,7 @@ void VideoStreamMac::startStream()
 
     m_stopStreaming = false;
 
-    if (!cam || !cam->isOpened()) {
+    if (!m_grabber.isOpened()) {
         sendMessage("Error: Could not connect to video stream " + QString::number(m_cameraID));
         qDebug() << "Camera " << m_cameraID << " not open (macOS hybrid).";
         return;
@@ -247,13 +235,12 @@ void VideoStreamMac::startStream()
             break;
         }
 
-        if (!cam->grab() || !cam->retrieve(frame)) {
-            qInfo() << "[diag]" << m_deviceName << "grab/retrieve returned false at frame"
-                    << idx << "- running stall diagnosis";
+        if (!m_grabber.read(frame)) {
+            qInfo() << "[diag]" << m_deviceName << "no frame at" << idx << "("
+                    << m_grabber.lastError() << ") - running stall diagnosis";
             sendMessage("Warning: " + m_deviceName + " grab frame failed. Attempting to reconnect.");
             logStallDiagnosis();
-            if (cam->isOpened())
-                cam->release();
+            m_grabber.release();
             QThread::msleep(1000);
             if (attemptReconnect()) {
                 sendMessage("Warning: " + m_deviceName + " reconnected.");
@@ -327,7 +314,7 @@ void VideoStreamMac::startStream()
         if (!m_commandQueue.isEmpty())
             sendCommands();
     }
-    cam->release();
+    m_grabber.release();
     m_control.close();
 }
 
@@ -336,13 +323,11 @@ bool VideoStreamMac::attemptReconnect()
     m_control.close();
     if (!openControlForIndex(m_cameraID))
         return false;
-    // Re-resolve the frame index too: the camera list may have changed (that
+    // Re-resolve the uniqueID too: the device may have re-enumerated (which
     // can be exactly why we are reconnecting).
-    if (!cam->open(frameIndexForControl(m_cameraID), cv::CAP_AVFOUNDATION))
+    if (!openFrameStream())
         return false;
     sendSerdesModeCommands();
-    cam->set(cv::CAP_PROP_FRAME_WIDTH, m_expectedWidth);
-    cam->set(cv::CAP_PROP_FRAME_HEIGHT, m_expectedHeight);
     QThread::msleep(500);
     setPU(SEL_SATURATION, 0x0001);
     emit requestInitCommands();

--- a/source/videostreammac.cpp
+++ b/source/videostreammac.cpp
@@ -3,6 +3,7 @@
 #include <QDebug>
 #include <QCoreApplication>
 #include <QDateTime>
+#include <QLoggingCategory>
 #include <QThread>
 
 #include <opencv2/imgproc.hpp>
@@ -11,14 +12,16 @@
 
 using namespace MiniscopeProtocol;
 
+// Bench diagnostics (heartbeats, stall verdicts, pin lines). On by default;
+// silence with QT_LOGGING_RULES="miniscope.diag=false".
+Q_LOGGING_CATEGORY(msDiag, "miniscope.diag")
+
 VideoStreamMac::VideoStreamMac(QObject *parent, int width, int height, double pixelClock) :
     VideoStreamBase(parent),
     m_cameraID(-1),
     m_deviceName(""),
-    m_isStreaming(false),
     m_stopStreaming(false),
     m_headOrientationStreamState(false),
-    m_headOrientationFilterState(false),
     m_isColor(false),
     frameBuffer(nullptr),
     timeStampBuffer(nullptr),
@@ -31,8 +34,7 @@ VideoStreamMac::VideoStreamMac(QObject *parent, int width, int height, double pi
     m_trackExtTrigger(false),
     m_expectedWidth(width > 0 ? width : 608),
     m_expectedHeight(height > 0 ? height : 608),
-    m_pixelClock(pixelClock),
-    m_connectionType("")
+    m_pixelClock(pixelClock)
 {
     m_control.setWriteSettleUs(kCtrlSettleUs);
 }
@@ -62,14 +64,14 @@ void VideoStreamMac::setBufferParameters(cv::Mat *frameBuf, qint64 *tsBuf, float
 // open its VideoControl interface. The which-device decision (including when
 // falling back to "the one Miniscope attached" is safe, and when it must fail
 // instead of guessing) lives in resolveControlTarget - see its declaration.
-bool VideoStreamMac::openControlForIndex(int cameraID)
+bool VideoStreamMac::openControlForIndex(int cameraID, const QVector<AvfCameraInfo> &cameras)
 {
     QVector<quint32> attached;
     const auto miniscopes = UVCControlMac::enumerate(kUsbVendorId, kUsbProductId);
     for (const auto &dev : miniscopes)
         attached.append(dev.locationID);
 
-    const ControlTarget target = resolveControlTarget(enumerateAvfCameras(), cameraID,
+    const ControlTarget target = resolveControlTarget(cameras, cameraID,
                                                       kUsbVendorId, kUsbProductId, attached);
     if (!target.warning.isEmpty())
         sendMessage("Warning: " + m_deviceName + ": " + target.warning);
@@ -93,25 +95,14 @@ bool VideoStreamMac::openControlForIndex(int cameraID)
     return false;
 }
 
-void VideoStreamMac::sendSerdesModeCommands()
-{
-    const auto packets = serdesModePackets(m_pixelClock);
-    if (packets.isEmpty())
-        return;
-    for (int i = 0; i < packets.size(); i++)
-        setPropertyI2C(i, packets[i]);
-    sendCommands();
-    QThread::msleep(500);
-}
-
 // Open the video stream pinned to the SAME physical device the control
 // channel resolved, via its stable AVFoundation uniqueID. Never opens by list
 // index: macOS reshuffles the camera list as devices come and go (iPhone
 // Continuity Camera, hot-plugged webcams), and both bench failures came from
 // an index resolving to a different camera by open time.
-bool VideoStreamMac::openFrameStream()
+bool VideoStreamMac::openFrameStream(const QVector<AvfCameraInfo> &cameras)
 {
-    QString uniqueId = avfUniqueIdForLocation(enumerateAvfCameras(), m_control.locationID());
+    QString uniqueId = avfUniqueIdForLocation(cameras, m_control.locationID());
     if (uniqueId.isEmpty()) {
         // The control channel just opened this device over USB, so it exists;
         // AVFoundation's list can briefly lag a hot-plug. One settle+retry.
@@ -129,8 +120,8 @@ bool VideoStreamMac::openFrameStream()
                     m_grabber.lastError() + ")");
         return false;
     }
-    qInfo().nospace() << "[diag] " << m_deviceName << " frame stream pinned to uniqueID "
-                      << uniqueId << " at " << m_expectedWidth << "x" << m_expectedHeight;
+    qCInfo(msDiag).nospace() << m_deviceName << " frame stream pinned to uniqueID "
+                             << uniqueId << " at " << m_expectedWidth << "x" << m_expectedHeight;
     return true;
 }
 
@@ -138,19 +129,22 @@ int VideoStreamMac::connect2Camera(int cameraID)
 {
     m_cameraID = cameraID;
 
+    // One AVFoundation enumeration feeds both the control-channel policy and
+    // the uniqueID pin (enumeration touches the camera-permission machinery
+    // and costs tens of ms).
+    const auto cameras = enumerateAvfCameras();
+
     // Control channel first: if the Miniscope isn't reachable over USB there
     // is no point opening a video stream to it.
-    if (!openControlForIndex(cameraID))
+    if (!openControlForIndex(cameraID, cameras))
         return 0;
 
-    if (!openFrameStream()) {
+    if (!openFrameStream(cameras)) {
         m_control.close();
         return 0;
     }
-    m_connectionType = "AVF";
 
-    sendSerdesModeCommands();
-    QThread::msleep(500);
+    sendSerdesModeCommands(m_pixelClock);   // ends with its own settle sleep
     return 1;
 }
 
@@ -185,7 +179,7 @@ void VideoStreamMac::logStallDiagnosis()
                              "is down (sensor/SERDES state suspect)")
                   .arg(c0).arg(c1).arg(c2);
     }
-    qInfo().noquote() << "[diag]" << m_deviceName << msg;
+    qCInfo(msDiag).noquote() << m_deviceName << msg;
     sendMessage("Diag: " + m_deviceName + " " + msg);
 }
 
@@ -237,23 +231,20 @@ void VideoStreamMac::startStream()
     // as the libuvc backend).
     setPU(SEL_SATURATION, 0x0001);
 
-    qInfo() << "[diag]" << m_deviceName << "stream loop starting";
+    qCInfo(msDiag) << m_deviceName << "stream loop starting";
 
     int reconnectAttempts = 0;
-    m_isStreaming = true;
     forever {
-        if (m_stopStreaming) {
-            m_isStreaming = false;
+        if (m_stopStreaming)
             break;
-        }
 
         if (!m_grabber.read(frame)) {
             // Diagnose and message on the FIRST failure of a stall episode;
             // later attempts back off quietly (a device that fell off the bus
             // can take a while to come back, and every attempt already logs).
             if (reconnectAttempts == 0) {
-                qInfo() << "[diag]" << m_deviceName << "no frame at" << idx << "("
-                        << m_grabber.lastError() << ") - running stall diagnosis";
+                qCInfo(msDiag) << m_deviceName << "no frame at" << idx << "("
+                               << m_grabber.lastError() << ") - running stall diagnosis";
                 sendMessage("Warning: " + m_deviceName + " grab frame failed. Attempting to reconnect.");
                 logStallDiagnosis();
             }
@@ -272,60 +263,61 @@ void VideoStreamMac::startStream()
             continue;
         }
 
-        if (idx == 0)
-            qInfo().nospace() << "[diag] " << m_deviceName << " first frame: "
-                              << frame.cols << "x" << frame.rows
-                              << " channels=" << frame.channels()
-                              << " daqFrameCounter=" << getPU(SEL_CONTRAST);
-        else if (idx % 100 == 0)
-            qInfo().nospace() << "[diag] " << m_deviceName << " heartbeat: acqFrame=" << idx
-                              << " daqFrameCounter=" << getPU(SEL_CONTRAST)
-                              << " ts=" << QDateTime::currentMSecsSinceEpoch();
-
-        timeStampBuffer[idx % frameBufferSize] = QDateTime().currentMSecsSinceEpoch();
-
-        if (m_isColor)
-            frame.copyTo(frameBuffer[idx % frameBufferSize]);
-        else
-            cv::cvtColor(frame, frameBuffer[idx % frameBufferSize], cv::COLOR_BGR2GRAY);
-
-        if (m_trackExtTrigger) {
-            if (extTriggerLast == -1) {
-                extTriggerLast = getPU(SEL_GAMMA);
-            } else {
-                extTrigger = getPU(SEL_GAMMA);
-                if (extTriggerLast != extTrigger) {
-                    if (extTriggerLast == 0)
-                        emit extTriggered(true);
-                    else
-                        emit extTriggered(false);
-                }
-                extTriggerLast = extTrigger;
-            }
-        }
-
-        if (m_headOrientationStreamState) {
-            // BNO output is a unit quaternion after a 2^14 division.
-            qint16 quat[4];   // w, x, y, z per kBnoSelectors order
-            for (int i = 0; i < 4; i++)
-                quat[i] = static_cast<qint16>(getPU(kBnoSelectors[i]));
-            unpackBnoQuaternion(quat[0], quat[1], quat[2], quat[3],
-                                &bnoBuffer[(idx % frameBufferSize) * 5]);
-        }
-
-        if (daqFrameNum != nullptr) {
-            *daqFrameNum = getPU(SEL_CONTRAST) - daqFrameNumOffset;
-            if (*m_acqFrameNum == 0)
-                daqFrameNumOffset = *daqFrameNum - 1;
-        }
-
-        // Thread-safe buffer handoff (mirrors the other backends).
+        // Reserve the ring-buffer slot BEFORE any per-frame work: a full
+        // buffer drops this frame anyway, so the USB control reads (~6 ms
+        // each while streaming) and the color conversion would only deepen
+        // the backpressure - and acquiring first guarantees a slot is never
+        // overwritten while DataSaver still owns it.
         if (!freeFrames->tryAcquire()) {
             if (freeFrames->available() == 0) {
                 sendMessage("Error: " + m_deviceName + " frame buffer is full. Frames will be lost!");
                 QThread::msleep(100);
             }
         } else {
+            timeStampBuffer[idx % frameBufferSize] = QDateTime().currentMSecsSinceEpoch();
+
+            if (m_isColor)
+                frame.copyTo(frameBuffer[idx % frameBufferSize]);
+            else
+                cv::cvtColor(frame, frameBuffer[idx % frameBufferSize], cv::COLOR_BGR2GRAY);
+
+            if (m_trackExtTrigger) {
+                if (extTriggerLast == -1) {
+                    extTriggerLast = getPU(SEL_GAMMA);
+                } else {
+                    extTrigger = getPU(SEL_GAMMA);
+                    if (extTriggerLast != extTrigger) {
+                        if (extTriggerLast == 0)
+                            emit extTriggered(true);
+                        else
+                            emit extTriggered(false);
+                    }
+                    extTriggerLast = extTrigger;
+                }
+            }
+
+            if (m_headOrientationStreamState) {
+                // BNO output is a unit quaternion after a 2^14 division.
+                qint16 quat[4];   // w, x, y, z per kBnoSelectors order
+                for (int i = 0; i < 4; i++)
+                    quat[i] = static_cast<qint16>(getPU(kBnoSelectors[i]));
+                unpackBnoQuaternion(quat[0], quat[1], quat[2], quat[3],
+                                    &bnoBuffer[(idx % frameBufferSize) * 5]);
+            }
+
+            if (daqFrameNum != nullptr) {
+                *daqFrameNum = getPU(SEL_CONTRAST) - daqFrameNumOffset;
+                if (*m_acqFrameNum == 0)
+                    daqFrameNumOffset = *daqFrameNum - 1;
+                // Diagnostics reuse this read - never a second GET_CUR.
+                if (idx % 100 == 0)
+                    qCInfo(msDiag).nospace()
+                        << m_deviceName << (idx == 0 ? " first frame: " : " heartbeat: ")
+                        << frame.cols << "x" << frame.rows << " acqFrame=" << idx
+                        << " daqFrameCounter=" << (*daqFrameNum + daqFrameNumOffset)
+                        << " ts=" << timeStampBuffer[idx % frameBufferSize];
+            }
+
             m_acqFrameNum->operator++();
             idx++;
             emit newFrameAvailable(m_deviceName, *m_acqFrameNum);
@@ -344,14 +336,14 @@ void VideoStreamMac::startStream()
 bool VideoStreamMac::attemptReconnect()
 {
     m_control.close();
-    if (!openControlForIndex(m_cameraID))
+    // Fresh enumeration: the device may have re-enumerated (which can be
+    // exactly why we are reconnecting).
+    const auto cameras = enumerateAvfCameras();
+    if (!openControlForIndex(m_cameraID, cameras))
         return false;
-    // Re-resolve the uniqueID too: the device may have re-enumerated (which
-    // can be exactly why we are reconnecting).
-    if (!openFrameStream())
+    if (!openFrameStream(cameras))
         return false;
-    sendSerdesModeCommands();
-    QThread::msleep(500);
+    sendSerdesModeCommands(m_pixelClock);
     setPU(SEL_SATURATION, 0x0001);
     emit requestInitCommands();
     return true;

--- a/source/videostreammac.cpp
+++ b/source/videostreammac.cpp
@@ -125,12 +125,47 @@ int VideoStreamMac::connect2Camera(int cameraID)
     }
     m_connectionType = "AVF";
 
+    qInfo().nospace() << "[diag] " << m_deviceName << " AVF opened: native "
+                      << cam->get(cv::CAP_PROP_FRAME_WIDTH) << "x"
+                      << cam->get(cv::CAP_PROP_FRAME_HEIGHT) << " @ "
+                      << cam->get(cv::CAP_PROP_FPS) << "fps; requesting "
+                      << m_expectedWidth << "x" << m_expectedHeight;
+
     sendSerdesModeCommands();
 
     cam->set(cv::CAP_PROP_FRAME_WIDTH, m_expectedWidth);
     cam->set(cv::CAP_PROP_FRAME_HEIGHT, m_expectedHeight);
     QThread::msleep(500);
+
+    qInfo().nospace() << "[diag] " << m_deviceName << " after set: "
+                      << cam->get(cv::CAP_PROP_FRAME_WIDTH) << "x"
+                      << cam->get(cv::CAP_PROP_FRAME_HEIGHT) << " @ "
+                      << cam->get(cv::CAP_PROP_FPS) << "fps";
     return 1;
+}
+
+// Stall discriminator: when AVF frames stop, the control channel usually
+// stays alive - so poll the DAQ's hardware frame counter. Advancing counter =
+// the scope's video link is fine and the AVFoundation session died (format /
+// session problem). Frozen counter = the scope's video pipeline itself went
+// down (e.g. corrupted sensor/SERDES config - suspect driver-injected
+// SET_CURs into the I2C tunnel).
+void VideoStreamMac::logStallDiagnosis()
+{
+    const int c0 = getPU(SEL_CONTRAST);
+    QThread::msleep(500);
+    const int c1 = getPU(SEL_CONTRAST);
+    QThread::msleep(500);
+    const int c2 = getPU(SEL_CONTRAST);
+    const bool advancing = (c1 != c0) || (c2 != c1);
+    const QString verdict = advancing
+        ? QStringLiteral("DAQ frame counter ADVANCING (%1 -> %2 -> %3): scope video link is "
+                         "alive, AVFoundation session died")
+        : QStringLiteral("DAQ frame counter FROZEN (%1 -> %2 -> %3): scope video pipeline is "
+                         "down (sensor/SERDES state suspect)");
+    const QString msg = verdict.arg(c0).arg(c1).arg(c2);
+    qInfo().noquote() << "[diag]" << m_deviceName << msg;
+    sendMessage("Diag: " + m_deviceName + " " + msg);
 }
 
 int VideoStreamMac::connect2Video(QString, QString, float)
@@ -181,6 +216,8 @@ void VideoStreamMac::startStream()
     // as the libuvc backend).
     setPU(SEL_SATURATION, 0x0001);
 
+    qInfo() << "[diag]" << m_deviceName << "stream loop starting";
+
     m_isStreaming = true;
     forever {
         if (m_stopStreaming) {
@@ -189,7 +226,10 @@ void VideoStreamMac::startStream()
         }
 
         if (!cam->grab() || !cam->retrieve(frame)) {
+            qInfo() << "[diag]" << m_deviceName << "grab/retrieve returned false at frame"
+                    << idx << "- running stall diagnosis";
             sendMessage("Warning: " + m_deviceName + " grab frame failed. Attempting to reconnect.");
+            logStallDiagnosis();
             if (cam->isOpened())
                 cam->release();
             QThread::msleep(1000);
@@ -199,6 +239,16 @@ void VideoStreamMac::startStream()
             }
             continue;
         }
+
+        if (idx == 0)
+            qInfo().nospace() << "[diag] " << m_deviceName << " first frame: "
+                              << frame.cols << "x" << frame.rows
+                              << " channels=" << frame.channels()
+                              << " daqFrameCounter=" << getPU(SEL_CONTRAST);
+        else if (idx % 100 == 0)
+            qInfo().nospace() << "[diag] " << m_deviceName << " heartbeat: acqFrame=" << idx
+                              << " daqFrameCounter=" << getPU(SEL_CONTRAST)
+                              << " ts=" << QDateTime::currentMSecsSinceEpoch();
 
         timeStampBuffer[idx % frameBufferSize] = QDateTime().currentMSecsSinceEpoch();
 

--- a/source/videostreammac.h
+++ b/source/videostreammac.h
@@ -21,6 +21,7 @@
 #include <QVector>
 #include <opencv2/core/core.hpp>
 
+#include "avfenumeratormac.h"
 #include "avfframegrabbermac.h"
 #include "miniscopeprotocol.h"
 #include "uvccontrolmac.h"
@@ -38,7 +39,7 @@ public:
                              QAtomicInt *acqFrameNum, QAtomicInt *daqFrameNumber) override;
     int connect2Camera(int cameraID) override;
     int connect2Video(QString folderPath, QString filePrefix, float playbackFPS) override;
-    void setHeadOrientationConfig(bool enableState, bool filterState) override { m_headOrientationStreamState = enableState; m_headOrientationFilterState = filterState; }
+    void setHeadOrientationConfig(bool enableState, bool) override { m_headOrientationStreamState = enableState; }
     void setIsColor(bool isColor) override { m_isColor = isColor; }
     void setDeviceName(QString name) override { m_deviceName = name; }
 
@@ -52,10 +53,11 @@ public slots:
     void openCamPropsDialog() override;
 
 private:
-    bool openControlForIndex(int cameraID);   // AVFoundation index -> USB locationID -> UVCControlMac
-    bool openFrameStream();                   // pin the grabber to the control channel's uniqueID
-    void sendSerdesModeCommands();            // pixel-clock dependent SERDES setup
-    void sendCommands();                      // flush queued I2C packets as UVC SET_CUR
+    // AVFoundation index -> USB locationID -> UVCControlMac (policy in resolveControlTarget)
+    bool openControlForIndex(int cameraID, const QVector<AvfCameraInfo> &cameras);
+    // Pin the grabber to the control channel's device via its uniqueID.
+    bool openFrameStream(const QVector<AvfCameraInfo> &cameras);
+    void sendCommands() override;             // flush queued I2C packets as UVC SET_CUR
     bool setPU(quint8 selector, quint16 value);
     int  getPU(quint8 selector);              // fresh GET_CUR, returned as signed 16-bit; 0 on failure
     bool attemptReconnect();
@@ -67,10 +69,8 @@ private:
     AvfFrameGrabber m_grabber;
     UVCControlMac m_control;
 
-    bool m_isStreaming;
     bool m_stopStreaming;
     bool m_headOrientationStreamState;
-    bool m_headOrientationFilterState;
     bool m_isColor;
 
     cv::Mat *frameBuffer;
@@ -89,7 +89,6 @@ private:
     int m_expectedWidth;
     int m_expectedHeight;
     double m_pixelClock;
-    QString m_connectionType;
 };
 
 #endif // VIDEOSTREAMMAC_H

--- a/source/videostreammac.h
+++ b/source/videostreammac.h
@@ -58,6 +58,7 @@ private:
     bool setPU(quint8 selector, quint16 value);
     int  getPU(quint8 selector);              // fresh GET_CUR, returned as signed 16-bit; 0 on failure
     bool attemptReconnect();
+    void logStallDiagnosis();                 // frame-counter poll: AVF session vs scope video link
 
     int m_cameraID;
     QString m_deviceName;

--- a/source/videostreammac.h
+++ b/source/videostreammac.h
@@ -20,8 +20,8 @@
 #include <QAtomicInt>
 #include <QVector>
 #include <opencv2/core/core.hpp>
-#include <opencv2/videoio.hpp>
 
+#include "avfframegrabbermac.h"
 #include "miniscopeprotocol.h"
 #include "uvccontrolmac.h"
 #include "videostreambase.h"
@@ -53,7 +53,7 @@ public slots:
 
 private:
     bool openControlForIndex(int cameraID);   // AVFoundation index -> USB locationID -> UVCControlMac
-    int  frameIndexForControl(int configIndex); // current AVF index of the control channel's device
+    bool openFrameStream();                   // pin the grabber to the control channel's uniqueID
     void sendSerdesModeCommands();            // pixel-clock dependent SERDES setup
     void sendCommands();                      // flush queued I2C packets as UVC SET_CUR
     bool setPU(quint8 selector, quint16 value);
@@ -64,7 +64,7 @@ private:
     int m_cameraID;
     QString m_deviceName;
 
-    cv::VideoCapture *cam;
+    AvfFrameGrabber m_grabber;
     UVCControlMac m_control;
 
     bool m_isStreaming;

--- a/source/videostreammac.h
+++ b/source/videostreammac.h
@@ -53,6 +53,7 @@ public slots:
 
 private:
     bool openControlForIndex(int cameraID);   // AVFoundation index -> USB locationID -> UVCControlMac
+    int  frameIndexForControl(int configIndex); // current AVF index of the control channel's device
     void sendSerdesModeCommands();            // pixel-clock dependent SERDES setup
     void sendCommands();                      // flush queued I2C packets as UVC SET_CUR
     bool setPU(quint8 selector, quint16 value);

--- a/source/videostreamocv.cpp
+++ b/source/videostreamocv.cpp
@@ -8,7 +8,6 @@
 #include <QDebug>
 #include <QAtomicInt>
 #include <QCoreApplication>
-#include <QMap>
 #include <QVector>
 #include <QDateTime>
 #include <QThread>
@@ -66,7 +65,7 @@ int VideoStreamOCV::connect2Camera(int cameraID) {
     }
     // The SERDES mode must be set before any other SERDES traffic (TI 913/914).
     if (connectionState != 0)
-        sendSerdesModeCommands();
+        sendSerdesModeCommands(m_pixelClock);
 
     if (connectionState != 0) {
          cam->set(cv::CAP_PROP_FRAME_WIDTH, m_expectedWidth);
@@ -355,17 +354,6 @@ void VideoStreamOCV::sendCommands()
         qDebug() << "Send setting failed";
 }
 
-void VideoStreamOCV::sendSerdesModeCommands()
-{
-    const auto packets = MiniscopeProtocol::serdesModePackets(m_pixelClock);
-    if (packets.isEmpty())
-        return;
-    for (int i = 0; i < packets.size(); i++)
-        setPropertyI2C(i, packets[i]);
-    sendCommands();
-    QThread::msleep(500);
-}
-
 bool VideoStreamOCV::attemptReconnect()
 {
     // TODO: handle quitting nicely when stuck in this loop
@@ -380,7 +368,7 @@ bool VideoStreamOCV::attemptReconnect()
     else {
         return false;
     }
-    sendSerdesModeCommands();
+    sendSerdesModeCommands(m_pixelClock);
     cam->set(cv::CAP_PROP_FRAME_WIDTH, m_expectedWidth);
     cam->set(cv::CAP_PROP_FRAME_HEIGHT, m_expectedHeight);
     QThread::msleep(500);

--- a/source/videostreamocv.h
+++ b/source/videostreamocv.h
@@ -10,7 +10,6 @@
 #include <opencv2/imgproc.hpp>
 #include <opencv2/videoio.hpp>
 #include <QAtomicInt>
-#include <QMap>
 #include <QVector>
 
 #include "miniscopeprotocol.h"
@@ -43,8 +42,7 @@ public slots:
     void openCamPropsDialog() override;
 
 private:
-    void sendCommands();
-    void sendSerdesModeCommands();   // pixel-clock dependent SERDES setup
+    void sendCommands() override;    // flush queued I2C packets via CAP_PROP passthrough
     bool attemptReconnect();
     int m_cameraID;
     QString m_deviceName;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,11 @@ if(APPLE)
     qt_add_executable(tst_avfenumerator tst_avfenumerator.cpp)
     target_link_libraries(tst_avfenumerator PRIVATE avfenumerator_mac Qt6::Test Qt6::Gui)
     add_test(NAME avfenumerator COMMAND tst_avfenumerator)
+
+    # uniqueID-pinned frame grabber: failure paths must fail cleanly.
+    qt_add_executable(tst_avfframegrabber tst_avfframegrabber.cpp)
+    target_link_libraries(tst_avfframegrabber PRIVATE avfgrabber_mac Qt6::Test)
+    add_test(NAME avfframegrabber COMMAND tst_avfframegrabber)
 endif()
 
 # --- Shader compile check ------------------------------------------------------

--- a/tests/tst_avfenumerator.cpp
+++ b/tests/tst_avfenumerator.cpp
@@ -163,13 +163,19 @@ void TestAvfEnumerator::indexForLocationRebindsShiftedList()
     // resolved.
     AvfCameraInfo phone;
     phone.name = QStringLiteral("iPhone Camera");
-    const QVector<AvfCameraInfo> shifted = {phone,
-                                            usbCam("Miniscope", 0x00100000, kVid, kPid)};
+    QVector<AvfCameraInfo> shifted = {phone,
+                                      usbCam("Miniscope", 0x00100000, kVid, kPid)};
+    shifted[1].uniqueID = QStringLiteral("0x0010000004b400f9");
     QCOMPARE(avfIndexForLocation(shifted, 0x00100000), 1);
 
     // Not in the list / no location resolved -> -1 (caller falls back).
     QCOMPARE(avfIndexForLocation(shifted, 0x00990000), -1);
     QCOMPARE(avfIndexForLocation(shifted, 0), -1);
+
+    // The uniqueID lookup the frame grabber pins its session to.
+    QCOMPARE(avfUniqueIdForLocation(shifted, 0x00100000),
+             shifted[1].uniqueID);
+    QVERIFY(avfUniqueIdForLocation(shifted, 0x00990000).isEmpty());
 }
 
 QTEST_MAIN(TestAvfEnumerator)

--- a/tests/tst_avfenumerator.cpp
+++ b/tests/tst_avfenumerator.cpp
@@ -19,7 +19,7 @@ private slots:
     void resolveFallsBackToOnlyMiniscope();
     void resolveRefusesToGuessAmongSeveral();
     void resolveFailsWithNoneAttached();
-    void indexForLocationRebindsShiftedList();
+    void uniqueIdForLocationIgnoresListOrder();
 };
 
 void TestAvfEnumerator::parseUsbUniqueId()
@@ -154,28 +154,22 @@ void TestAvfEnumerator::resolveFailsWithNoneAttached()
     QVERIFY(t.error.contains(QStringLiteral("no Miniscope DAQ")));
 }
 
-void TestAvfEnumerator::indexForLocationRebindsShiftedList()
+void TestAvfEnumerator::uniqueIdForLocationIgnoresListOrder()
 {
     // The bench-observed failure: an iPhone (Continuity Camera, opaque
-    // uniqueID) joins the list ahead of the Miniscope, so the config's
-    // deviceID 0 now points at the phone. The frame stream must re-bind to
-    // the Miniscope's CURRENT index via the locationID the control channel
-    // resolved.
+    // uniqueID) joins the list ahead of the Miniscope, shifting every list
+    // index. The frame grabber pins by the uniqueID looked up from the
+    // control channel's locationID, so list order must be irrelevant.
     AvfCameraInfo phone;
     phone.name = QStringLiteral("iPhone Camera");
     QVector<AvfCameraInfo> shifted = {phone,
                                       usbCam("Miniscope", 0x00100000, kVid, kPid)};
     shifted[1].uniqueID = QStringLiteral("0x0010000004b400f9");
-    QCOMPARE(avfIndexForLocation(shifted, 0x00100000), 1);
+    QCOMPARE(avfUniqueIdForLocation(shifted, 0x00100000), shifted[1].uniqueID);
 
-    // Not in the list / no location resolved -> -1 (caller falls back).
-    QCOMPARE(avfIndexForLocation(shifted, 0x00990000), -1);
-    QCOMPARE(avfIndexForLocation(shifted, 0), -1);
-
-    // The uniqueID lookup the frame grabber pins its session to.
-    QCOMPARE(avfUniqueIdForLocation(shifted, 0x00100000),
-             shifted[1].uniqueID);
+    // Unknown location / no location resolved -> empty (caller errors out).
     QVERIFY(avfUniqueIdForLocation(shifted, 0x00990000).isEmpty());
+    QVERIFY(avfUniqueIdForLocation(shifted, 0).isEmpty());
 }
 
 QTEST_MAIN(TestAvfEnumerator)

--- a/tests/tst_avfenumerator.cpp
+++ b/tests/tst_avfenumerator.cpp
@@ -19,6 +19,7 @@ private slots:
     void resolveFallsBackToOnlyMiniscope();
     void resolveRefusesToGuessAmongSeveral();
     void resolveFailsWithNoneAttached();
+    void indexForLocationRebindsShiftedList();
 };
 
 void TestAvfEnumerator::parseUsbUniqueId()
@@ -151,6 +152,24 @@ void TestAvfEnumerator::resolveFailsWithNoneAttached()
     const auto t = resolveControlTarget({}, 0, kVid, kPid, {});
     QVERIFY(!t.ok);
     QVERIFY(t.error.contains(QStringLiteral("no Miniscope DAQ")));
+}
+
+void TestAvfEnumerator::indexForLocationRebindsShiftedList()
+{
+    // The bench-observed failure: an iPhone (Continuity Camera, opaque
+    // uniqueID) joins the list ahead of the Miniscope, so the config's
+    // deviceID 0 now points at the phone. The frame stream must re-bind to
+    // the Miniscope's CURRENT index via the locationID the control channel
+    // resolved.
+    AvfCameraInfo phone;
+    phone.name = QStringLiteral("iPhone Camera");
+    const QVector<AvfCameraInfo> shifted = {phone,
+                                            usbCam("Miniscope", 0x00100000, kVid, kPid)};
+    QCOMPARE(avfIndexForLocation(shifted, 0x00100000), 1);
+
+    // Not in the list / no location resolved -> -1 (caller falls back).
+    QCOMPARE(avfIndexForLocation(shifted, 0x00990000), -1);
+    QCOMPARE(avfIndexForLocation(shifted, 0), -1);
 }
 
 QTEST_MAIN(TestAvfEnumerator)

--- a/tests/tst_avfframegrabber.cpp
+++ b/tests/tst_avfframegrabber.cpp
@@ -1,0 +1,45 @@
+#include <QtTest>
+
+#include <opencv2/core/core.hpp>
+
+#include "avfframegrabbermac.h"
+
+// Hardware-free smoke tests for the uniqueID-pinned frame grabber: the
+// failure paths must fail cleanly (message, no crash), because the stream
+// loop leans on them for its reconnect handling.
+class TestAvfFrameGrabber : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void openRejectsUnknownUniqueId();
+    void readWithoutOpenFails();
+    void releaseWithoutOpenIsSafe();
+};
+
+void TestAvfFrameGrabber::openRejectsUnknownUniqueId()
+{
+    AvfFrameGrabber grabber;
+    QVERIFY(!grabber.open(QStringLiteral("0xdeadbeef00000000"), 608, 608));
+    QVERIFY(grabber.lastError().contains(QStringLiteral("no capture device")));
+    QVERIFY(!grabber.isOpened());
+}
+
+void TestAvfFrameGrabber::readWithoutOpenFails()
+{
+    AvfFrameGrabber grabber;
+    cv::Mat frame;
+    QVERIFY(!grabber.read(frame, 10));
+    QVERIFY(!grabber.lastError().isEmpty());
+}
+
+void TestAvfFrameGrabber::releaseWithoutOpenIsSafe()
+{
+    AvfFrameGrabber grabber;
+    grabber.release();
+    grabber.release();   // double-release must also be a no-op
+    QVERIFY(!grabber.isOpened());
+}
+
+QTEST_MAIN(TestAvfFrameGrabber)
+#include "tst_avfframegrabber.moc"


### PR DESCRIPTION
**Stacked on #88** — merge order #85 → #86 → #87 → #88 → this. This is PR 6b: everything learned from the first real-Miniscope bench validation (stock V4 + standard DAQ on an M-series Mac, tested by a lab member via the distributed DMG over four diagnostic rounds).

## What the bench found, in order

1. **Index-based camera opening is unfixable on macOS.** The config's `deviceID` indexes AVFoundation's camera list, which reshuffles whenever devices come and go (iPhone via Continuity Camera, hot-plugged webcams). Observed: the app streamed the *phone's* video while the control channel drove the real scope ("streams 1 s then dies" — Continuity sessions halt when the phone is locked). An index re-binding fix wasn't enough: OpenCV's internal list diverges from ours between lookup and open.
2. **The fix: `AvfFrameGrabber`** (new, ARC Objective-C++) — a minimal `AVCaptureSession` pinned to the device's stable `uniqueID`, resolved from the control channel's USB locationID. `cv::VideoCapture` is gone from the Miniscope path; there is no index anywhere, so video and control cannot land on different devices *by construction*. Interprets the **delivered** pixel-buffer format (BGRA/UYVY/YUY2/24BGR) rather than trusting the requested one — the third bench round showed garbled rows when the device delivered YUY2 where BGRA was assumed. Bench-verified: scope + USB webcam dual-streaming, 1800+ frames with zero counter drift (zero drops), LED/gain/EWL/frame-rate control all confirmed live (frame-rate changes measurably alter heartbeat timing).
3. **Crash fix (`miniscope.cpp`):** the dF/F display divided incoming frames by a baseline accumulated at a different size — an uncaught `cv::Exception` that killed the whole app when a mis-bound/reconnected camera changed frame size. Size changes now reset the baseline and fall back to raw display while it rebuilds.
4. **Stall diagnosis (keeper instrumentation):** on frame loss, poll the DAQ frame counter over the still-alive control channel — `ADVANCING` = AVF session died, `FROZEN` = scope video pipeline down, all-reads-failing = **USB-level disconnect (check cable/hub/power)**. This one-liner is what cracked every bench mystery; reconnects now back off 1→5 s with a single diagnosis per episode.
5. **Docs:** BUILD_MACOS.md gains the bench-verified Continuity Camera troubleshooting section.

## Tests
New: grabber failure paths (unknown uniqueID, read-before-open, double-release), uniqueID/index-for-locationID lookups including the phone-shifts-the-list scenario. All 7 suites pass.

## Known remaining (not in this PR)
Behavior webcams still open by index (a ghost "reconnect" can silently bind the wrong device) — extending identity-binding to them is a follow-up candidate. The broader codebase modernization findings (teardown, recording integrity) are a separate track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)