### PR TITLE
Fix four latent recording bugs (BNO CSV suppression, ring-buffer corruption, date/time tokens, playback leak)

### DIFF
--- a/source/datasaver.cpp
+++ b/source/datasaver.cpp
@@ -117,9 +117,12 @@ void DataSaver::setupBaseDirectory()
         baseDirectory = m_userConfig["dataDirectory"].toString();
         for (int i = 0; i < directoryStructure.size(); i++) {
             tempString = directoryStructure[i].toString();
-            if (tempString == "date")
+            // "date"/"time" are reserved tokens; accept any casing ("Date",
+            // "TIME", ...) so a capitalized config doesn't silently produce
+            // literal "DateMissing" folders.
+            if (tempString.compare("date", Qt::CaseInsensitive) == 0)
                 baseDirectory += "/" + recordStartDateTime.date().toString("yyyy_MM_dd");
-            else if (tempString == "time")
+            else if (tempString.compare("time", Qt::CaseInsensitive) == 0)
                 baseDirectory += "/" + recordStartDateTime.time().toString("HH_mm_ss");
             else {
                 tempString2 = m_userConfig[tempString].toString().replace(" ", "_");
@@ -461,7 +464,8 @@ QJsonDocument DataSaver::constructBaseDirectoryMetaData()
     QJsonArray directoryStructure = m_userConfig["directoryStructure"].toArray();
     for (int i = 0; i < directoryStructure.size(); i++) {
         tempString = directoryStructure[i].toString();
-        if (tempString != "date" && tempString != "time" && !tempString.isEmpty())
+        if (tempString.compare("date", Qt::CaseInsensitive) != 0
+            && tempString.compare("time", Qt::CaseInsensitive) != 0 && !tempString.isEmpty())
             metaData[tempString] = m_userConfig[tempString].toString();
     }
     if (!metaData.contains("researcherName"))

--- a/source/datasaver.h
+++ b/source/datasaver.h
@@ -28,9 +28,15 @@ public:
     bool setupFilePaths();
     void setRecord(bool input) {m_recording = input;}
     void setFrameBufferParameters(QString name, cv::Mat* frameBuf, qint64 *tsBuffer, float *bnoBuf, int bufSize, QSemaphore* freeFrames, QSemaphore* usedFrames, QAtomicInt* acqFrame);
-    void setHeadOrientationConfig(QString name, bool enable, bool filter) {headOrientationStreamState[name] = enable; headOrientationStreamState[name] = filter; }
+    void setHeadOrientationConfig(QString name, bool enable, bool filter) {headOrientationStreamState[name] = enable; headOrientationFilterState[name] = filter; }
     void setupBaseDirectory();
     void setROI(QString name, int *bbox);
+
+    // Inspection accessors (also pin the behavior above down in unit tests)
+    QString getBaseDirectory() const { return baseDirectory; }
+    void setRecordStartDateTime(const QDateTime &dateTime) { recordStartDateTime = dateTime; }
+    bool getHeadOrientationStreamState(QString name) const { return headOrientationStreamState.value(name, false); }
+    bool getHeadOrientationFilterState(QString name) const { return headOrientationFilterState.value(name, false); }
 
     void setPoseBufferParameters(QVector<float>* poseBuf, int* poseFrameNumBuf, int poseBufSize, QSemaphore* freePos, QSemaphore* usedPos);
 

--- a/source/videostreamlibuvc.cpp
+++ b/source/videostreamlibuvc.cpp
@@ -277,52 +277,58 @@ void VideoStreamLibUVC::startStream()
             continue;
         }
 
-        timeStampBuffer[idx % frameBufferSize] = QDateTime().currentMSecsSinceEpoch();
-
-        // libuvc gives raw YUYV; the Y plane is the Miniscope image.
-        cv::Mat yuyv((int)frame->height, (int)frame->width, CV_8UC2, frame->data);
-        if (m_isColor)
-            cv::cvtColor(yuyv, frameBuffer[idx % frameBufferSize], cv::COLOR_YUV2BGR_YUYV);
-        else
-            cv::cvtColor(yuyv, frameBuffer[idx % frameBufferSize], cv::COLOR_YUV2GRAY_YUYV);
-
-        if (m_trackExtTrigger) {
-            if (extTriggerLast == -1) {
-                extTriggerLast = getPU(SEL_GAMMA);
-            } else {
-                extTrigger = getPU(SEL_GAMMA);
-                if (extTriggerLast != extTrigger) {
-                    if (extTriggerLast == 0)
-                        emit extTriggered(true);
-                    else
-                        emit extTriggered(false);
-                }
-                extTriggerLast = extTrigger;
-            }
-        }
-
-        if (m_headOrientationStreamState) {
-            // BNO output is a unit quaternion after a 2^14 division.
-            qint16 quat[4];   // w, x, y, z per kBnoSelectors order
-            for (int i = 0; i < 4; i++)
-                quat[i] = static_cast<qint16>(getPU(kBnoSelectors[i]));
-            MiniscopeProtocol::unpackBnoQuaternion(quat[0], quat[1], quat[2], quat[3],
-                                                   &bnoBuffer[(idx % frameBufferSize) * 5]);
-        }
-
-        if (daqFrameNum != nullptr) {
-            *daqFrameNum = getPU(SEL_CONTRAST) - daqFrameNumOffset;
-            if (*m_acqFrameNum == 0)
-                daqFrameNumOffset = *daqFrameNum - 1;
-        }
-
-        // Thread-safe buffer handoff (mirrors VideoStreamOCV).
+        // Reserve a buffer slot BEFORE writing anything into it: when the
+        // buffer is full, idx%frameBufferSize is the oldest unconsumed slot,
+        // which DataSaver may be reading right now - writing first corrupts
+        // the frame being saved. Acquiring first also skips the per-frame
+        // control reads for frames we are about to drop.
         if (!freeFrames->tryAcquire()) {
+            // No free slot: this frame is thrown away
             if (freeFrames->available() == 0) {
                 sendMessage("Error: " + m_deviceName + " frame buffer is full. Frames will be lost!");
                 QThread::msleep(100);
             }
         } else {
+            const int bufIdx = idx % frameBufferSize;
+            timeStampBuffer[bufIdx] = QDateTime::currentMSecsSinceEpoch();
+
+            // libuvc gives raw YUYV; the Y plane is the Miniscope image.
+            cv::Mat yuyv((int)frame->height, (int)frame->width, CV_8UC2, frame->data);
+            if (m_isColor)
+                cv::cvtColor(yuyv, frameBuffer[bufIdx], cv::COLOR_YUV2BGR_YUYV);
+            else
+                cv::cvtColor(yuyv, frameBuffer[bufIdx], cv::COLOR_YUV2GRAY_YUYV);
+
+            if (m_trackExtTrigger) {
+                if (extTriggerLast == -1) {
+                    extTriggerLast = getPU(SEL_GAMMA);
+                } else {
+                    extTrigger = getPU(SEL_GAMMA);
+                    if (extTriggerLast != extTrigger) {
+                        if (extTriggerLast == 0)
+                            emit extTriggered(true);
+                        else
+                            emit extTriggered(false);
+                    }
+                    extTriggerLast = extTrigger;
+                }
+            }
+
+            if (m_headOrientationStreamState) {
+                // BNO output is a unit quaternion after a 2^14 division.
+                qint16 quat[4];   // w, x, y, z per kBnoSelectors order
+                for (int i = 0; i < 4; i++)
+                    quat[i] = static_cast<qint16>(getPU(kBnoSelectors[i]));
+                MiniscopeProtocol::unpackBnoQuaternion(quat[0], quat[1], quat[2], quat[3],
+                                                       &bnoBuffer[bufIdx * 5]);
+            }
+
+            if (daqFrameNum != nullptr) {
+                *daqFrameNum = getPU(SEL_CONTRAST) - daqFrameNumOffset;
+                if (*m_acqFrameNum == 0)
+                    daqFrameNumOffset = *daqFrameNum - 1;
+            }
+
             m_acqFrameNum->operator++();
             idx++;
             emit newFrameAvailable(m_deviceName, *m_acqFrameNum);

--- a/source/videostreamocv.cpp
+++ b/source/videostreamocv.cpp
@@ -118,6 +118,7 @@ void VideoStreamOCV::startStream()
     double extTriggerLast = -1;
     double extTrigger;
     bool status = false;
+    qint64 timestamp = 0;
     cv::Mat frame;
 
     m_stopStreaming = false;
@@ -154,7 +155,7 @@ void VideoStreamOCV::startStream()
                 }
                 else {
                     // Grab successful
-                    timeStampBuffer[idx%frameBufferSize] = QDateTime().currentMSecsSinceEpoch();
+                    timestamp = QDateTime::currentMSecsSinceEpoch();
                     if (!cam->retrieve(frame)) {
                         // Retrieve failed
                         status = false;
@@ -176,81 +177,31 @@ void VideoStreamOCV::startStream()
             }
             else if (m_connectionType == "videoFile") {
                 QThread::msleep(1000.0/m_playbackFPS);
-                timeStampBuffer[idx%frameBufferSize] = QDateTime().currentMSecsSinceEpoch();
+                timestamp = QDateTime::currentMSecsSinceEpoch();
                 if (!cam->read(frame)) {
-                    // Try next file before fully giving up
+                    // Try next file before fully giving up. End playback with
+                    // a break, not a return: break falls through to the
+                    // cam->release() after the loop, a return leaks the handle.
                     m_playbackFileIndex++;
-//                    if (m_playbackFileIndex == 4)
-//                        m_playbackFileIndex = 0;
                     qDebug() << "FILE INDEX" << m_playbackFileIndex;
                     fileName = m_playbackFolderPath + "/" + m_playbackFilePrefix + QString::number(m_playbackFileIndex) + ".avi";
                     cam->release();
-                    if (cam->open(fileName.toStdString())) {
-                        if (!cam->read(frame)) {
-                            status = false;
-                            return;
-                        }
+                    if (!cam->open(fileName.toStdString()) || !cam->read(frame)) {
+                        sendMessage(m_deviceName + " playback reached the end of the recording.");
+                        m_isStreaming = false;
+                        break;
                     }
-                    else
-                        return;
-
                 }
             }
             if (status) {
-                // frame was grabbed
-                // Grab and retieve successful
-
-                if (m_isColor) {
-                    frame.copyTo(frameBuffer[idx%frameBufferSize]);
-                }
-                else {
-                    //                            frame = cv::repeat(frame,4,4);
-                    cv::cvtColor(frame, frameBuffer[idx%frameBufferSize], cv::COLOR_BGR2GRAY);
-                }
-                // qDebug() << "Frame Number:" << *m_acqFrameNum - cam->get(cv::CAP_PROP_CONTRAST);
-
-                if (m_trackExtTrigger) {
-                    if (extTriggerLast == -1) {
-                        // first time grabbing trigger state.
-                        extTriggerLast = cam->get(cv::CAP_PROP_GAMMA);
-                    }
-                    else {
-                        extTrigger = cam->get(cv::CAP_PROP_GAMMA);
-                        if (extTriggerLast != extTrigger) {
-                            // State change
-                            if (extTriggerLast == 0) {
-                                // Went from 0 to 1
-                                emit extTriggered(true);
-                            }
-                            else {
-                                // Went from 1 to 0
-                                emit extTriggered(false);
-                            }
-                        }
-                        extTriggerLast = extTrigger;
-                    }
-                }
-
-                if (m_headOrientationStreamState) {
-                    // BNO output is a unit quaternion after 2^14 division
-                    MiniscopeProtocol::unpackBnoQuaternion(
-                        static_cast<qint16>(cam->get(cv::CAP_PROP_SATURATION)),
-                        static_cast<qint16>(cam->get(cv::CAP_PROP_HUE)),
-                        static_cast<qint16>(cam->get(cv::CAP_PROP_GAIN)),
-                        static_cast<qint16>(cam->get(cv::CAP_PROP_BRIGHTNESS)),
-                        &bnoBuffer[(idx%frameBufferSize)*5]);
-                }
-                if (daqFrameNum != nullptr) {
-                    *daqFrameNum = cam->get(cv::CAP_PROP_CONTRAST) - daqFrameNumOffset;
-                    // qDebug() << cam->get(cv::CAP_PROP_CONTRAST);// *daqFrameNum;
-                    if (*m_acqFrameNum == 0) // Used to initially sync daqFrameNum with acqFrameNum
-                        daqFrameNumOffset = *daqFrameNum - 1;
-                }
-
-                // Handle thread safe controls of buffer
-                if(!freeFrames->tryAcquire()) {
-                    // Failed to acquire free frame
-                    // Will throw away this acquired frame
+                // Grab and retrieve successful. Reserve a buffer slot BEFORE
+                // writing anything into it: when the buffer is full,
+                // idx%frameBufferSize is the oldest unconsumed slot, which
+                // DataSaver may be reading right now - writing first corrupts
+                // the frame being saved. Acquiring first also skips the
+                // per-frame control reads for frames we are about to drop.
+                if (!freeFrames->tryAcquire()) {
+                    // No free slot: this frame is thrown away
                     if (freeFrames->available() == 0) {
                         // Buffers are full!
                         sendMessage("Error: " + m_deviceName + " frame buffer is full. Frames will be lost!");
@@ -258,13 +209,57 @@ void VideoStreamOCV::startStream()
                     }
                 }
                 else {
+                    const int bufIdx = idx % frameBufferSize;
+                    timeStampBuffer[bufIdx] = timestamp;
+                    if (m_isColor) {
+                        frame.copyTo(frameBuffer[bufIdx]);
+                    }
+                    else {
+                        cv::cvtColor(frame, frameBuffer[bufIdx], cv::COLOR_BGR2GRAY);
+                    }
+
+                    if (m_trackExtTrigger) {
+                        if (extTriggerLast == -1) {
+                            // first time grabbing trigger state.
+                            extTriggerLast = cam->get(cv::CAP_PROP_GAMMA);
+                        }
+                        else {
+                            extTrigger = cam->get(cv::CAP_PROP_GAMMA);
+                            if (extTriggerLast != extTrigger) {
+                                // State change
+                                if (extTriggerLast == 0) {
+                                    // Went from 0 to 1
+                                    emit extTriggered(true);
+                                }
+                                else {
+                                    // Went from 1 to 0
+                                    emit extTriggered(false);
+                                }
+                            }
+                            extTriggerLast = extTrigger;
+                        }
+                    }
+
+                    if (m_headOrientationStreamState) {
+                        // BNO output is a unit quaternion after 2^14 division
+                        MiniscopeProtocol::unpackBnoQuaternion(
+                            static_cast<qint16>(cam->get(cv::CAP_PROP_SATURATION)),
+                            static_cast<qint16>(cam->get(cv::CAP_PROP_HUE)),
+                            static_cast<qint16>(cam->get(cv::CAP_PROP_GAIN)),
+                            static_cast<qint16>(cam->get(cv::CAP_PROP_BRIGHTNESS)),
+                            &bnoBuffer[bufIdx*5]);
+                    }
+                    if (daqFrameNum != nullptr) {
+                        *daqFrameNum = cam->get(cv::CAP_PROP_CONTRAST) - daqFrameNumOffset;
+                        if (*m_acqFrameNum == 0) // Used to initially sync daqFrameNum with acqFrameNum
+                            daqFrameNumOffset = *daqFrameNum - 1;
+                    }
+
                     m_acqFrameNum->operator++();
-                    // qDebug() << *m_acqFrameNum << *daqFrameNum;
                     idx++;
                     emit newFrameAvailable(m_deviceName, *m_acqFrameNum);
                     usedFrames->release();
                 }
-
             }
             // Get any new events
             QCoreApplication::processEvents(); // Is there a better way to do this. This is against best practices

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,14 @@ target_include_directories(tst_bundlepaths PRIVATE ${CMAKE_SOURCE_DIR}/source)
 target_link_libraries(tst_bundlepaths PRIVATE Qt6::Core Qt6::Test)
 add_test(NAME bundlepaths COMMAND tst_bundlepaths)
 
+# --- DataSaver config handling (head-orientation flags, directory tokens) ------
+qt_add_executable(tst_datasaver tst_datasaver.cpp
+    ${CMAKE_SOURCE_DIR}/source/datasaver.cpp)
+target_include_directories(tst_datasaver PRIVATE ${CMAKE_SOURCE_DIR}/source
+    ${OpenCV_INCLUDE_DIRS})
+target_link_libraries(tst_datasaver PRIVATE Qt6::Core Qt6::Test ${OpenCV_LIBS})
+add_test(NAME datasaver COMMAND tst_datasaver)
+
 # --- macOS IOKit UVC transport (hardware-free smoke tests) ---------------------
 if(APPLE)
     qt_add_executable(tst_uvccontrolmac tst_uvccontrolmac.cpp)

--- a/tests/tst_datasaver.cpp
+++ b/tests/tst_datasaver.cpp
@@ -1,0 +1,81 @@
+// Regression tests for DataSaver configuration handling:
+//  - setHeadOrientationConfig once assigned the filter flag over the enable
+//    flag (copy-paste bug), silently suppressing the headOrientation.csv
+//    whenever filterBadData was false.
+//  - The reserved "date"/"time" directoryStructure tokens were matched
+//    case-sensitively, so a capitalized config entry ("Date") produced a
+//    literal "DateMissing" folder instead of the date.
+
+#include <QtTest/QtTest>
+#include <QJsonArray>
+#include <QJsonObject>
+
+#include "datasaver.h"
+
+class TestDataSaver : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void headOrientationEnableSurvivesFilterOff()
+    {
+        // The exact bug: enable=true + filter=false must leave enable TRUE.
+        DataSaver saver;
+        saver.setHeadOrientationConfig("Miniscope", true, false);
+        QCOMPARE(saver.getHeadOrientationStreamState("Miniscope"), true);
+        QCOMPARE(saver.getHeadOrientationFilterState("Miniscope"), false);
+    }
+
+    void headOrientationFlagsAreIndependent()
+    {
+        DataSaver saver;
+        saver.setHeadOrientationConfig("A", true, true);
+        saver.setHeadOrientationConfig("B", false, true);
+        QCOMPARE(saver.getHeadOrientationStreamState("A"), true);
+        QCOMPARE(saver.getHeadOrientationFilterState("A"), true);
+        QCOMPARE(saver.getHeadOrientationStreamState("B"), false);
+        QCOMPARE(saver.getHeadOrientationFilterState("B"), true);
+    }
+
+    void directoryTokensLowerCase()
+    {
+        QCOMPARE(baseDirFor({"researcherName", "date", "time"}),
+                 QStringLiteral("/data/Test_Person/2026_07_23/13_04_05"));
+    }
+
+    void directoryTokensAnyCase()
+    {
+        QCOMPARE(baseDirFor({"researcherName", "Date", "TIME"}),
+                 QStringLiteral("/data/Test_Person/2026_07_23/13_04_05"));
+    }
+
+    void unknownTokenStillGetsPlaceholder()
+    {
+        // Non-reserved tokens without a config value keep the documented
+        // "<token>Missing" placeholder behavior.
+        QCOMPARE(baseDirFor({"animalName", "date"}),
+                 QStringLiteral("/data/animalNameMissing/2026_07_23"));
+    }
+
+private:
+    static QString baseDirFor(const QStringList &structure)
+    {
+        QJsonObject config;
+        config["dataDirectory"] = "/data";
+        config["researcherName"] = "Test Person";
+        QJsonArray tokens;
+        for (const QString &entry : structure)
+            tokens.append(entry);
+        config["directoryStructure"] = tokens;
+
+        DataSaver saver;
+        saver.setUserConfig(config);
+        saver.setRecordStartDateTime(
+            QDateTime(QDate(2026, 7, 23), QTime(13, 4, 5)));
+        saver.setupBaseDirectory();
+        return saver.getBaseDirectory();
+    }
+};
+
+QTEST_GUILESS_MAIN(TestDataSaver)
+#include "tst_datasaver.moc"


### PR DESCRIPTION
First PR of the modernization series (PR A of the plan): the four outright bugs found by the July 2026 codebase review. All four affect recorded data or resource lifetime; none change any config format or user-visible behavior beyond fixing the defects.

## 1. Head-orientation CSV silently suppressed (cross-platform, worst of the four)
`datasaver.h` `setHeadOrientationConfig()` assigned the **filter** flag over the **enable** flag:

```cpp
headOrientationStreamState[name] = enable; headOrientationStreamState[name] = filter;  // before
headOrientationStreamState[name] = enable; headOrientationFilterState[name] = filter;  // after
```

Since `headOrientationStreamState` gates every `headOrientation.csv` write in DataSaver, any config with `headOrientation.enabled: true` + `filterBadData: false` recorded **no BNO CSV at all** — while the live traces looked fine, because the display path uses the device's own flags.

## 2. Ring-buffer write-before-acquire (OpenCV + libuvc backends)
Both stream loops wrote the frame, timestamp, and BNO sample into `buffer[idx % size]` **before** `freeFrames->tryAcquire()`. When the buffer is full, that slot is the oldest unconsumed frame — possibly the one DataSaver is encoding right now — so a full buffer corrupted saved frames in addition to dropping new ones. Both loops now reserve the slot first and do all per-frame work inside the acquired branch, matching the shape already bench-validated in the macOS backend (#89). Side benefit: no wasted UVC control reads (BNO/ext-trigger/frame counter) for frames that are about to be thrown away.

## 3. `date`/`time` directory tokens matched case-sensitively
A `directoryStructure` entry of `"Date"` or `"Time"` fell through to the custom-token path and produced literal `DateMissing`/`TimeMissing` folders. Reserved tokens now match any casing, in both `setupBaseDirectory()` and the metadata writer.

## 4. Playback path leaked the capture handle
End-of-playback `return`ed straight out of the stream loop, skipping `cam->release()` — and when the next file opened but its first read failed, the freshly opened handle leaked too. Now exits through the loop's release path and reports "playback reached the end of the recording".

## Tests
New `tests/tst_datasaver.cpp` (runs on all three CI platforms) pins down the head-orientation flag assignment and the directory-token casing, including the placeholder behavior for genuinely unknown tokens. Small `const` inspection accessors were added to `DataSaver` to make these observable. The refactored libuvc loop is compiled for real by the Linux CI job.

Bugs 2 and 4 live in camera-driven loops and aren't unit-testable without hardware scaffolding; they're covered by compilation on all platforms plus the same pattern already running on the mac backend.
