### PR TITLE
Recording fails loudly: file-open checks, disk-space guard, UI reset on failure

### DIFF
--- a/source/backend.cpp
+++ b/source/backend.cpp
@@ -535,7 +535,10 @@ void backEnd::saveConfigObject()
     fName.chop(5);
     fName.append("_new.json");
     file.setFileName(fName);
-    file.open(QFile::WriteOnly | QFile::Text | QFile::Truncate);
+    if (!file.open(QFile::WriteOnly | QFile::Text | QFile::Truncate)) {
+        qWarning() << "Could not save user config to" << fName << ":" << file.errorString();
+        return;
+    }
     file.write(d.toJson());
     file.close();
 }
@@ -1002,7 +1005,11 @@ void backEnd::loadUserConfigFile()
     QString jsonFile;
     QFile file;
     file.setFileName(m_userConfigFileName);
-    file.open(QIODevice::ReadOnly | QIODevice::Text);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        setUserConfigDisplay("Could not open User Config file: " + m_userConfigFileName
+                             + " (" + file.errorString() + ")");
+        return;
+    }
     jsonFile = file.readAll();
     setUserConfigDisplay("User Config File Selected: " + m_userConfigFileName + "\n" + jsonFile);
     file.close();
@@ -1115,6 +1122,9 @@ void backEnd::connectSnS()
         QObject::connect(this, SIGNAL( closeAll()), traceDisplay, SLOT (close()));
 
     QObject::connect(dataSaver, SIGNAL(sendMessage(QString)), controlPanel, SLOT( receiveMessage(QString)));
+    // A recording that could not create/continue its files must drop the UI's
+    // "Recording" state instead of pretending to record.
+    QObject::connect(dataSaver, &DataSaver::recordingFailed, controlPanel, &ControlPanel::onRecordingFailed);
 
     for (int i = 0; i < miniscope.length(); i++) {
         // For triggering screenshots
@@ -1249,8 +1259,7 @@ bool backEnd::checkUserConfigForIssues()
         setUserConfigOK(true);
         userConfigOKChanged();
     }
-    // TODO: make return do something or remove
-    return true;
+    return m_userConfigOK;
 }
 
 void backEnd::parseUserConfig()

--- a/source/controlpanel.cpp
+++ b/source/controlpanel.cpp
@@ -182,6 +182,20 @@ void ControlPanel::onStopActivated()
 
 }
 
+void ControlPanel::onRecordingFailed()
+{
+    // DataSaver could not create/continue the recording files: reset the UI so
+    // it does not claim to be recording while nothing is being saved.
+    if (!m_recording)
+        return;
+    m_recording = false;
+    rootObject->setProperty("recording", false);
+    if (recordTimer->isActive())
+        recordTimer->stop();
+    currentRecordTime = 0;
+    receiveMessage("Recording FAILED - nothing is being saved. See error messages above.");
+}
+
 void ControlPanel::recordTimerTick()
 {
     currentRecordTime++;

--- a/source/controlpanel.h
+++ b/source/controlpanel.h
@@ -22,6 +22,7 @@ public slots:
     void receiveMessage(QString msg);
     void onRecordActivated();
     void onStopActivated();
+    void onRecordingFailed();
     void recordTimerTick();
     void handleNoteSumbit(QString note);
     void extTriggerSwitchToggled2(bool checkedState);

--- a/source/datasaver.cpp
+++ b/source/datasaver.cpp
@@ -19,6 +19,15 @@
 #include <QTextStream>
 #include <QVariant>
 #include <QMetaType>
+#include <QStorageInfo>
+
+// Fail-loudly disk guards: refuse to start a recording without this much free
+// space, and stop an active one before the disk is completely full - a full
+// disk turns every subsequent frame/CSV write into silent data loss.
+static constexpr qint64 kMinFreeBytesToStart    = 500LL * 1024 * 1024;
+static constexpr qint64 kMinFreeBytesToContinue = 250LL * 1024 * 1024;
+static constexpr qint64 kLowDiskWarnBytes       = 5LL * 1024 * 1024 * 1024;
+static constexpr int    kDiskCheckFrameInterval = 100;
 
 DataSaver::DataSaver(QObject *parent) :
     QObject(parent),
@@ -199,20 +208,33 @@ void DataSaver::startRunning()
                         else
                             isColor = true;
                         // TODO: Add compression options here
-                        if (ROI[names[i]][0] >= 0 && ROI[names[i]][1] >= 0 && ROI[names[i]][2] >= 0 && ROI[names[i]][3] >= 0) {
+                        // A device that never got setROI() must record
+                        // un-trimmed, not crash on the null pointer.
+                        const int *roi = ROI.value(names[i], nullptr);
+                        bool videoFileOpened;
+                        if (roi && roi[0] >= 0 && roi[1] >= 0 && roi[2] >= 0 && roi[3] >= 0) {
                             // Need to trim frame to ROI
-//                            qDebug() << ROI[names[i]][0] << ROI[names[i]][1] << ROI[names[i]][2] << ROI[names[i]][3];
-                            videoWriter[names[i]]->open(tempStr.toUtf8().constData(),
+                            videoFileOpened = videoWriter[names[i]]->open(tempStr.toUtf8().constData(),
                                     dataCompressionFourCC[names[i]], 60,
-                                    cv::Size(ROI[names[i]][2], ROI[names[i]][3]), isColor); // color should be set to false?
+                                    cv::Size(roi[2], roi[3]), isColor); // color should be set to false?
                         }
                         else {
-                            videoWriter[names[i]]->open(tempStr.toUtf8().constData(),
+                            videoFileOpened = videoWriter[names[i]]->open(tempStr.toUtf8().constData(),
                                     dataCompressionFourCC[names[i]], 60,
                                     cv::Size(frameBuffer[names[i]][0].cols, frameBuffer[names[i]][0].rows), isColor); // color should be set to false?
                         }
-
+                        if (!videoFileOpened) {
+                            // Without this check every subsequent write() would
+                            // silently discard frames while the UI says Recording.
+                            sendMessage("Error: " + names[i] + " could not create video file "
+                                        + tempStr + " (full disk? missing codec?). Recording stopped; "
+                                        + "data recorded so far is saved.");
+                            stopRecording();
+                            emit recordingFailed();
+                        }
                     }
+                }
+                if (m_recording) {
                     bufPosition = frameCount[names[i]] % bufferSize[names[i]];
                     *csvStream[names[i]] << savedFrameCount[names[i]] << ","
                                          << (timeStampBuffer[names[i]][bufPosition] - recordStartDateTime.toMSecsSinceEpoch()) << ","
@@ -233,14 +255,29 @@ void DataSaver::startRunning()
                     }
 
                     // TODO: Increment video file if reach max frame number per file
-                    if (ROI[names[i]][0] >= 0 && ROI[names[i]][1] >= 0 && ROI[names[i]][2] >= 0 && ROI[names[i]][3] >= 0) {
-                        videoWriter[names[i]]->write(frameBuffer[names[i]][bufPosition](cv::Rect(ROI[names[i]][0],ROI[names[i]][1],ROI[names[i]][2],ROI[names[i]][3])));
+                    const int *roi = ROI.value(names[i], nullptr);
+                    if (roi && roi[0] >= 0 && roi[1] >= 0 && roi[2] >= 0 && roi[3] >= 0) {
+                        videoWriter[names[i]]->write(frameBuffer[names[i]][bufPosition](cv::Rect(roi[0], roi[1], roi[2], roi[3])));
 
                     }
                     else
                         videoWriter[names[i]]->write(frameBuffer[names[i]][bufPosition]);
 
                     savedFrameCount[names[i]]++;
+
+                    // Stop cleanly before the disk fills: a full disk makes
+                    // every write above a silent no-op. Checked every
+                    // kDiskCheckFrameInterval frames (one statfs call).
+                    if ((savedFrameCount[names[i]] % kDiskCheckFrameInterval) == 0) {
+                        const qint64 bytesFree = QStorageInfo(baseDirectory).bytesAvailable();
+                        if (bytesFree >= 0 && bytesFree < kMinFreeBytesToContinue) {
+                            sendMessage("Error: disk holding " + baseDirectory + " is nearly full ("
+                                        + QString::number(bytesFree / (1024 * 1024))
+                                        + " MB free). Recording stopped; data recorded so far is saved.");
+                            stopRecording();
+                            emit recordingFailed();
+                        }
+                    }
                 }
 
                 frameCount[names[i]]++;
@@ -276,6 +313,37 @@ void DataSaver::startRecording(QMap<QString,QVariant> ucInfo)
     QJsonDocument jDoc;
     recordStartDateTime = QDateTime::currentDateTime();
     if (setupFilePaths()) {
+        // Refuse to start a recording that is about to run into a full disk.
+        const qint64 bytesFree = QStorageInfo(baseDirectory).bytesAvailable();
+        if (bytesFree >= 0 && bytesFree < kMinFreeBytesToStart) {
+            sendMessage("Error: only " + QString::number(bytesFree / (1024 * 1024))
+                        + " MB free on the drive holding " + baseDirectory
+                        + ". Recording NOT started.");
+            emit recordingFailed();
+            return;
+        }
+        if (bytesFree >= 0 && bytesFree < kLowDiskWarnBytes)
+            sendMessage("Warning: less than " + QString::number(kLowDiskWarnBytes / (1024 * 1024 * 1024))
+                        + " GB free on the drive holding " + baseDirectory
+                        + ". Recording will stop itself before the disk fills.");
+
+        // Every file in the save path must open, or the recording must not
+        // claim to be running - a silently unwritable CSV is total data loss.
+        QVector<QFile *> openedFiles;
+        bool openFailed = false;
+        auto openForWrite = [&](QFile *file) {
+            if (openFailed)
+                return false;
+            if (!file->open(QFile::WriteOnly | QFile::Truncate)) {
+                sendMessage("Error: could not create " + file->fileName() + " ("
+                            + file->errorString() + "). Recording NOT started.");
+                openFailed = true;
+                return false;
+            }
+            openedFiles.append(file);
+            return true;
+        };
+
         // TODO: Save meta data JSONs
         jDoc = constructBaseDirectoryMetaData();
         saveJson(jDoc, baseDirectory + "/metaData.json");
@@ -311,11 +379,12 @@ void DataSaver::startRecording(QMap<QString,QVariant> ucInfo)
 
             // Create pose data file
             behavTrackerFile = new QFile(baseDirectory + "/behaviorTracker/pose.csv");
-            behavTrackerFile->open(QFile::WriteOnly | QFile::Truncate);
-            behavTrackerStream = new QTextStream(behavTrackerFile);
+            if (openForWrite(behavTrackerFile)) {
+                behavTrackerStream = new QTextStream(behavTrackerFile);
 
-            // TODO: Add header info for behav tracker csv file here
-            *behavTrackerStream << "DLC-Live Pose Data." << Qt::endl;
+                // TODO: Add header info for behav tracker csv file here
+                *behavTrackerStream << "DLC-Live Pose Data." << Qt::endl;
+            }
         }
 
         QString tempStr;
@@ -323,15 +392,17 @@ void DataSaver::startRecording(QMap<QString,QVariant> ucInfo)
         for (int i = 0; i < keys.length(); i++) {
             // loop through devices that make frames and setup csv file and videoWriter
             csvFile[keys[i]] = new QFile(deviceDirectory[keys[i]] + "/timeStamps.csv");
-            csvFile[keys[i]]->open(QFile::WriteOnly | QFile::Truncate);
-            csvStream[keys[i]] = new QTextStream(csvFile[keys[i]]);
-            *csvStream[keys[i]] << "Frame Number,Time Stamp (ms),Buffer Index" << Qt::endl;
+            if (openForWrite(csvFile[keys[i]])) {
+                csvStream[keys[i]] = new QTextStream(csvFile[keys[i]]);
+                *csvStream[keys[i]] << "Frame Number,Time Stamp (ms),Buffer Index" << Qt::endl;
+            }
 
             if (headOrientationStreamState[keys[i]] == true && bnoBuffer[keys[i]] != nullptr) {
                 headOriFile[keys[i]] = new QFile(deviceDirectory[keys[i]] + "/headOrientation.csv");
-                headOriFile[keys[i]]->open(QFile::WriteOnly | QFile::Truncate);
-                headOriStream[keys[i]] = new QTextStream(headOriFile[keys[i]]);
-                *headOriStream[keys[i]] << "Time Stamp (ms),qw,qx,qy,qz" << Qt::endl;
+                if (openForWrite(headOriFile[keys[i]])) {
+                    headOriStream[keys[i]] = new QTextStream(headOriFile[keys[i]]);
+                    *headOriStream[keys[i]] << "Time Stamp (ms),qw,qx,qy,qz" << Qt::endl;
+                }
             }
             // TODO: Remember to close files on exit or stop recording signal
 
@@ -346,16 +417,24 @@ void DataSaver::startRecording(QMap<QString,QVariant> ucInfo)
 
         // Creates note csv file
         noteFile = new QFile(baseDirectory + "/notes.csv");
-        noteFile->open(QFile::WriteOnly | QFile::Truncate);
-        noteStream = new QTextStream(noteFile);
-        *noteStream << "Time Stamp (ms), Note" << Qt::endl;
+        if (openForWrite(noteFile)) {
+            noteStream = new QTextStream(noteFile);
+            *noteStream << "Time Stamp (ms), Note" << Qt::endl;
+        }
+
+        if (openFailed) {
+            for (QFile *file : openedFiles)
+                file->close();
+            emit recordingFailed();
+            return;
+        }
 
         // TODO: Save camera calibration file to data directory for each behavioral camera
         m_recording = true;
     }
     else {
         qDebug() << "Failed to record due to base directory creation failing";
-        // TODO: Stop counting and disable buttons since data directory needs to be corrected in user config
+        emit recordingFailed();
     }
 }
 
@@ -521,12 +600,13 @@ QJsonDocument DataSaver::constructDeviceMetaData(QString type, QString deviceNam
     metaData["framesPerFile"] = deviceObj["framesPerFile"].toInt(1000);
     metaData["compression"] = deviceObj["compression"].toString("FFV1");
 
-    if (ROI[deviceName][0] >= 0 && ROI[deviceName][1] >= 0 && ROI[deviceName][2] >= 0 && ROI[deviceName][3] >= 0) {
+    const int *roi = ROI.value(deviceName, nullptr);
+    if (roi && roi[0] >= 0 && roi[1] >= 0 && roi[2] >= 0 && roi[3] >= 0) {
         QJsonObject jROI;
-        jROI["leftEdge"] = ROI[deviceName][0];
-        jROI["topEdge"] = ROI[deviceName][1];
-        jROI["width"] = ROI[deviceName][2];
-        jROI["height"] = ROI[deviceName][3];
+        jROI["leftEdge"] = roi[0];
+        jROI["topEdge"] = roi[1];
+        jROI["width"] = roi[2];
+        jROI["height"] = roi[3];
         metaData["ROI"] = jROI;
     }
     // loop through device properties at the start of recording
@@ -545,8 +625,10 @@ QJsonDocument DataSaver::constructDeviceMetaData(QString type, QString deviceNam
 void DataSaver::saveJson(QJsonDocument document, QString fileName)
 {
     QFile jsonFile(fileName);
-    jsonFile.open(QFile::NewOnly);
+    if (!jsonFile.open(QFile::NewOnly)) {
+        sendMessage("Warning: could not write " + fileName + " (" + jsonFile.errorString() + ").");
+        return;
+    }
     jsonFile.write(document.toJson());
-
 }
 

--- a/source/datasaver.h
+++ b/source/datasaver.h
@@ -33,6 +33,7 @@ public:
     void setROI(QString name, int *bbox);
 
     // Inspection accessors (also pin the behavior above down in unit tests)
+    bool isRecording() const { return m_recording; }
     QString getBaseDirectory() const { return baseDirectory; }
     void setRecordStartDateTime(const QDateTime &dateTime) { recordStartDateTime = dateTime; }
     bool getHeadOrientationStreamState(QString name) const { return headOrientationStreamState.value(name, false); }
@@ -42,6 +43,10 @@ public:
 
 signals:
     void sendMessage(QString msg);
+    // Emitted when a recording could not start (a save-path file failed to
+    // open) or had to stop (disk full, video file creation failed), so the UI
+    // can drop its "Recording" state instead of silently saving nothing.
+    void recordingFailed();
 
 public slots:
     void startRunning();

--- a/tests/tst_datasaver.cpp
+++ b/tests/tst_datasaver.cpp
@@ -6,9 +6,16 @@
 //    case-sensitively, so a capitalized config entry ("Date") produced a
 //    literal "DateMissing" folder instead of the date.
 
+//  - startRecording() ignored every QFile::open in the save path, so an
+//    unwritable data directory produced a UI stuck on "Recording" while
+//    nothing was saved. It must fail loudly (recordingFailed) instead.
+
 #include <QtTest/QtTest>
 #include <QJsonArray>
 #include <QJsonObject>
+#include <QSemaphore>
+#include <QSignalSpy>
+#include <QTemporaryDir>
 
 #include "datasaver.h"
 
@@ -57,7 +64,88 @@ private slots:
                  QStringLiteral("/data/animalNameMissing/2026_07_23"));
     }
 
+    void startRecordingSucceedsInWritableDir()
+    {
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+
+        DataSaver saver;
+        saver.setUserConfig(deviceFreeConfig(dir.path()));
+        QSignalSpy failed(&saver, &DataSaver::recordingFailed);
+
+        saver.startRecording({});
+        QVERIFY(saver.isRecording());
+        QCOMPARE(failed.count(), 0);
+        QVERIFY(QFile::exists(dir.path() + "/notes.csv"));
+        QVERIFY(QFile::exists(dir.path() + "/metaData.json"));
+        saver.stopRecording();
+    }
+
+    void startRecordingFailsWhenBaseDirUncreatable()
+    {
+        // dataDirectory routed THROUGH an existing file: mkpath must fail.
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        QFile blocker(dir.path() + "/blocker");
+        QVERIFY(blocker.open(QFile::WriteOnly));
+        blocker.close();
+
+        DataSaver saver;
+        saver.setUserConfig(deviceFreeConfig(dir.path() + "/blocker/sub"));
+        QSignalSpy failed(&saver, &DataSaver::recordingFailed);
+
+        saver.startRecording({});
+        QVERIFY(!saver.isRecording());
+        QCOMPARE(failed.count(), 1);
+    }
+
+    void startRecordingFailsWhenDeviceCsvUnwritable()
+    {
+        // A FILE occupies the device-directory name, so the per-device mkdir
+        // fails and timeStamps.csv cannot be created. Recording must not
+        // claim to start.
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        QFile blocker(dir.path() + "/Cam");
+        QVERIFY(blocker.open(QFile::WriteOnly));
+        blocker.close();
+
+        QJsonObject config = deviceFreeConfig(dir.path());
+        QJsonObject camera;
+        camera["deviceType"] = "WebCam";
+        QJsonObject cameras;
+        cameras["Cam"] = camera;
+        QJsonObject devices;
+        devices["cameras"] = cameras;
+        config["devices"] = devices;
+
+        DataSaver saver;
+        saver.setUserConfig(config);
+
+        // Register the frame source the way backEnd does, so startRecording
+        // walks the timeStamps.csv setup for this device.
+        cv::Mat frames[1];
+        qint64 timestamps[1] = {0};
+        QSemaphore freeFrames(1), usedFrames;
+        QAtomicInt acqFrame;
+        saver.setFrameBufferParameters("Cam", frames, timestamps, nullptr, 1,
+                                       &freeFrames, &usedFrames, &acqFrame);
+
+        QSignalSpy failed(&saver, &DataSaver::recordingFailed);
+        saver.startRecording({});
+        QVERIFY(!saver.isRecording());
+        QCOMPARE(failed.count(), 1);
+    }
+
 private:
+    static QJsonObject deviceFreeConfig(const QString &dataDir)
+    {
+        QJsonObject config;
+        config["dataDirectory"] = dataDir;
+        config["directoryStructure"] = QJsonArray();
+        return config;
+    }
+
     static QString baseDirFor(const QStringList &structure)
     {
         QJsonObject config;


### PR DESCRIPTION
PR B of the modernization series (R1, recording integrity). **Stacked on #90** — merge that first; this PR's base is the `fix-recording-bugs` branch so the diff shows only its own changes, and GitHub will retarget it to `qt6-port` automatically when #90 merges.

## The problem
Every `VideoWriter::open` and `QFile::open` in the save path ignored its return value. A full disk, an unwritable data directory, or a missing codec meant the UI showed "Recording" with the timer counting while **zero bytes hit the disk** — the worst possible failure mode for an experiment.

## What this does
- **`startRecording()` verifies every file it creates** (timeStamps.csv, headOrientation.csv, pose.csv, notes.csv). On any failure: close what opened, report the exact file + OS error, emit the new `recordingFailed()` signal, and never enter the recording state.
- **Video-file rolls are checked**: if `VideoWriter::open` fails mid-recording (disk full, codec missing), the recording stops *cleanly* — everything recorded so far is preserved and the user is told why.
- **Disk-space guard** (`QStorageInfo`): refuse to start under 500 MB free, warn under 5 GB, and stop an active recording at 250 MB (checked every 100 saved frames per device — one `statfs` call, nothing on the hot path).
- **UI reset**: `DataSaver::recordingFailed()` → `ControlPanel::onRecordingFailed()` drops the record-button state and timer, with a clear "Recording FAILED — nothing is being saved" message.
- **Bonus crash fix the new tests caught**: `ROI` is a `QMap<QString,int*>`, so any device that never received `setROI()` crashed on a null dereference at record start (three sites: file-open sizing, frame write, device metadata). Missing ROI now records untrimmed.
- Housekeeping in the same family: `saveJson()`/`loadUserConfigFile()`/`saveConfigObject()` report open failures (clears the last `-Wunused-result` warnings); `checkUserConfigForIssues()` returns its real result instead of a hardcoded `true`.

## Tests
`tst_datasaver` grows from 5 to 8 cases: success path in a writable temp dir (notes.csv + metaData.json land, no failure signal), uncreatable base directory (path routed through a file), and unwritable device CSV (file squatting on the device-directory name) — the last one is what exposed the ROI null-pointer crash. All 8 suites pass locally; build is warning-clean.
