### PR TITLE
R2: log the DAQ frame counter per frame, monotonic timestamps, drain buffer on stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,20 @@ published together from CI.
   channel refuses to guess which device to drive when the configured ID can't
   be resolved ([#88](https://github.com/Aharoni-Lab/Miniscope-DAQ-QT-Software/pull/88)).
 
+**Recorded-data quality**
+- Miniscope `timeStamps.csv` files gain a **`DAQ Frame Number`** column: the
+  DAQ hardware's own frame counter logged per saved frame. A jump in it is
+  on-disk evidence of frames lost between the DAQ hardware and the software —
+  previously undetectable — and lets recordings be aligned to the DAQ's
+  per-frame TTL output post-hoc. Behavior-camera CSVs are unchanged.
+- Frame timestamps now come from a **monotonic clock** instead of the wall
+  clock, so an NTP sync, DST change, or manual clock adjustment mid-recording
+  can no longer corrupt inter-frame intervals. CSV times are still
+  milliseconds since recording start; absolute wall-clock start time remains
+  in `metaData.json`.
+- Stopping a recording now **drains the ring buffer** first, so the last
+  frames of a session are saved instead of silently dropped.
+
 ### Changed
 - Build system: qmake → **CMake** (Qt 6.4+, C++17). The old `.pro` file is no
   longer used.

--- a/source/backend.cpp
+++ b/source/backend.cpp
@@ -1,4 +1,5 @@
 #include "backend.h"
+#include "monotonicclock.h"
 #include <QDebug>
 #include <QFileDialog>
 #include <QApplication>
@@ -77,7 +78,7 @@ backEnd::backEnd(QObject *parent) :
 
 //    setUserConfigOK(true);
 #endif
-    m_softwareStartTime = QDateTime().currentMSecsSinceEpoch();
+    m_softwareStartTime = monotonicTimeMs();
 
     // User Config default values
     researcherName = "";
@@ -1164,6 +1165,7 @@ void backEnd::setupDataSaver()
                                             miniscope[i]->getFrameBufferPointer(),
                                             miniscope[i]->getTimeStampBufferPointer(),
                                             miniscope[i]->getBNOBufferPointer(),
+                                            miniscope[i]->getDaqFrameNumBufferPointer(),
                                             miniscope[i]->getBufferSize(),
                                             miniscope[i]->getFreeFramesPointer(),
                                             miniscope[i]->getUsedFramesPointer(),
@@ -1177,7 +1179,8 @@ void backEnd::setupDataSaver()
         dataSaver->setFrameBufferParameters(behavCam[i]->getDeviceName(),
                                             behavCam[i]->getFrameBufferPointer(),
                                             behavCam[i]->getTimeStampBufferPointer(),
-                                            nullptr,
+                                            nullptr,   // no BNO on behavior cams
+                                            nullptr,   // no DAQ frame counter on behavior cams
                                             behavCam[i]->getBufferSize(),
                                             behavCam[i]->getFreeFramesPointer(),
                                             behavCam[i]->getUsedFramesPointer(),

--- a/source/datasaver.cpp
+++ b/source/datasaver.cpp
@@ -21,6 +21,8 @@
 #include <QMetaType>
 #include <QStorageInfo>
 
+#include "monotonicclock.h"
+
 // Fail-loudly disk guards: refuse to start a recording without this much free
 // space, and stop an active one before the disk is completely full - a full
 // disk turns every subsequent frame/CSV write into silent data loss.
@@ -100,6 +102,7 @@ void DataSaver::setFrameBufferParameters(QString name,
                                          cv::Mat *frameBuf,
                                          qint64 *tsBuffer,
                                          float *bnoBuf,
+                                         qint64 *daqFrameNumBuf,
                                          int bufSize,
                                          QSemaphore *freeFrames,
                                          QSemaphore *usedFrames,
@@ -108,6 +111,7 @@ void DataSaver::setFrameBufferParameters(QString name,
     frameBuffer[name] = frameBuf;
     timeStampBuffer[name] = tsBuffer;
     bnoBuffer[name] = bnoBuf;
+    daqFrameNumBuffer[name] = daqFrameNumBuf;
     bufferSize[name] = bufSize;
     freeCount[name] = freeFrames;
     usedCount[name] = usedFrames;
@@ -164,14 +168,10 @@ void DataSaver::startRunning()
 
     m_running = true;
     int i, j;
-    int bufPosition;
     int poseBufPosition;
-    int fileNum;
-    bool isColor;
 
     QString poseData;
 
-    QString tempStr;
     QStringList names;
     while(m_running) {
         // For Behavior Tracker
@@ -195,97 +195,102 @@ void DataSaver::startRunning()
         names = frameBuffer.keys();
         for (i = 0; i < frameBuffer.size(); i++) {
             while (usedCount[names[i]]->tryAcquire()) {
-                // grad info from buffer in a threadsafe way
-                if (m_recording) {
-                    // save frame to file
-                    if ((savedFrameCount[names[i]] % framesPerFile[names[i]]) == 0) {
-                        // Create first as well as new video files
-                        fileNum = (int) (savedFrameCount[names[i]] / framesPerFile[names[i]]);
-                        tempStr = deviceDirectory[names[i]] + "/" + QString::number(fileNum) + ".avi";
-                        videoWriter[names[i]]->release(); // release full file
-                        if (frameBuffer[names[i]][0].channels() == 1)
-                            isColor = false;
-                        else
-                            isColor = true;
-                        // TODO: Add compression options here
-                        // A device that never got setROI() must record
-                        // un-trimmed, not crash on the null pointer.
-                        const int *roi = ROI.value(names[i], nullptr);
-                        bool videoFileOpened;
-                        if (roi && roi[0] >= 0 && roi[1] >= 0 && roi[2] >= 0 && roi[3] >= 0) {
-                            // Need to trim frame to ROI
-                            videoFileOpened = videoWriter[names[i]]->open(tempStr.toUtf8().constData(),
-                                    dataCompressionFourCC[names[i]], 60,
-                                    cv::Size(roi[2], roi[3]), isColor); // color should be set to false?
-                        }
-                        else {
-                            videoFileOpened = videoWriter[names[i]]->open(tempStr.toUtf8().constData(),
-                                    dataCompressionFourCC[names[i]], 60,
-                                    cv::Size(frameBuffer[names[i]][0].cols, frameBuffer[names[i]][0].rows), isColor); // color should be set to false?
-                        }
-                        if (!videoFileOpened) {
-                            // Without this check every subsequent write() would
-                            // silently discard frames while the UI says Recording.
-                            sendMessage("Error: " + names[i] + " could not create video file "
-                                        + tempStr + " (full disk? missing codec?). Recording stopped; "
-                                        + "data recorded so far is saved.");
-                            stopRecording();
-                            emit recordingFailed();
-                        }
-                    }
+                // grab info from buffer in a threadsafe way
+                if (m_recording && !writeBufferedFrame(names[i])) {
+                    // Could not create the next video file / disk nearly full
+                    // (already reported). Stop cleanly: data so far is saved.
+                    stopRecording();
+                    emit recordingFailed();
                 }
-                if (m_recording) {
-                    bufPosition = frameCount[names[i]] % bufferSize[names[i]];
-                    *csvStream[names[i]] << savedFrameCount[names[i]] << ","
-                                         << (timeStampBuffer[names[i]][bufPosition] - recordStartDateTime.toMSecsSinceEpoch()) << ","
-                                         << usedCount[names[i]]->available() << Qt::endl;
-
-                    if (headOrientationStreamState[names[i]] == true && bnoBuffer[names[i]] != nullptr) {
-                        if (headOrientationFilterState[names[i]] && bnoBuffer[names[i]][bufPosition*5 + 4] >= 0.05) { // norm is below 0.98. Should be 1 ideally
-                            // Filter bad data and current data is bad
-                        }
-                        else {
-                            *headOriStream[names[i]] << (timeStampBuffer[names[i]][bufPosition] - recordStartDateTime.toMSecsSinceEpoch()) << ","
-                                                     << bnoBuffer[names[i]][bufPosition*5 + 0] << ","
-                                                     << bnoBuffer[names[i]][bufPosition*5 + 1] << ","
-                                                     << bnoBuffer[names[i]][bufPosition*5 + 2] << ","
-                                                     << bnoBuffer[names[i]][bufPosition*5 + 3] << Qt::endl;
-                        }
-
-                    }
-
-                    // TODO: Increment video file if reach max frame number per file
-                    const int *roi = ROI.value(names[i], nullptr);
-                    if (roi && roi[0] >= 0 && roi[1] >= 0 && roi[2] >= 0 && roi[3] >= 0) {
-                        videoWriter[names[i]]->write(frameBuffer[names[i]][bufPosition](cv::Rect(roi[0], roi[1], roi[2], roi[3])));
-
-                    }
-                    else
-                        videoWriter[names[i]]->write(frameBuffer[names[i]][bufPosition]);
-
-                    savedFrameCount[names[i]]++;
-
-                    // Stop cleanly before the disk fills: a full disk makes
-                    // every write above a silent no-op. Checked every
-                    // kDiskCheckFrameInterval frames (one statfs call).
-                    if ((savedFrameCount[names[i]] % kDiskCheckFrameInterval) == 0) {
-                        const qint64 bytesFree = QStorageInfo(baseDirectory).bytesAvailable();
-                        if (bytesFree >= 0 && bytesFree < kMinFreeBytesToContinue) {
-                            sendMessage("Error: disk holding " + baseDirectory + " is nearly full ("
-                                        + QString::number(bytesFree / (1024 * 1024))
-                                        + " MB free). Recording stopped; data recorded so far is saved.");
-                            stopRecording();
-                            emit recordingFailed();
-                        }
-                    }
-                }
-
                 frameCount[names[i]]++;
                 freeCount[names[i]]->release(1);
             }
         }
         QCoreApplication::processEvents(); // Is there a better way to do this. This is against best practices
     }
+}
+
+// Write the frame at this device's current ring-buffer position to disk
+// (rolling the video file every framesPerFile frames), plus its
+// timeStamps.csv row and head-orientation row. Returns false when the
+// recording cannot continue (video file creation failed, disk nearly full);
+// the cause has then already been reported via sendMessage.
+bool DataSaver::writeBufferedFrame(const QString &name)
+{
+    if ((savedFrameCount[name] % framesPerFile[name]) == 0) {
+        // Create first as well as new video files
+        int fileNum = (int) (savedFrameCount[name] / framesPerFile[name]);
+        QString fileName = deviceDirectory[name] + "/" + QString::number(fileNum) + ".avi";
+        videoWriter[name]->release(); // release full file
+        bool isColor = frameBuffer[name][0].channels() != 1;
+        // TODO: Add compression options here
+        // A device that never got setROI() must record un-trimmed, not crash
+        // on the null pointer.
+        const int *roi = ROI.value(name, nullptr);
+        bool videoFileOpened;
+        if (roi && roi[0] >= 0 && roi[1] >= 0 && roi[2] >= 0 && roi[3] >= 0) {
+            // Need to trim frame to ROI
+            videoFileOpened = videoWriter[name]->open(fileName.toUtf8().constData(),
+                    dataCompressionFourCC[name], 60,
+                    cv::Size(roi[2], roi[3]), isColor); // color should be set to false?
+        }
+        else {
+            videoFileOpened = videoWriter[name]->open(fileName.toUtf8().constData(),
+                    dataCompressionFourCC[name], 60,
+                    cv::Size(frameBuffer[name][0].cols, frameBuffer[name][0].rows), isColor); // color should be set to false?
+        }
+        if (!videoFileOpened) {
+            // Without this check every subsequent write() would silently
+            // discard frames while the UI says Recording.
+            sendMessage("Error: " + name + " could not create video file "
+                        + fileName + " (full disk? missing codec?). Recording stopped; "
+                        + "data recorded so far is saved.");
+            return false;
+        }
+    }
+
+    const int bufPosition = frameCount[name] % bufferSize[name];
+    *csvStream[name] << savedFrameCount[name] << ","
+                     << (timeStampBuffer[name][bufPosition] - recordStartTimeMs) << ","
+                     << usedCount[name]->available();
+    if (daqFrameNumBuffer.value(name, nullptr) != nullptr)
+        *csvStream[name] << "," << daqFrameNumBuffer[name][bufPosition];
+    *csvStream[name] << Qt::endl;
+
+    if (headOrientationStreamState[name] == true && bnoBuffer[name] != nullptr) {
+        if (headOrientationFilterState[name] && bnoBuffer[name][bufPosition*5 + 4] >= 0.05) { // norm is below 0.98. Should be 1 ideally
+            // Filter bad data and current data is bad
+        }
+        else {
+            *headOriStream[name] << (timeStampBuffer[name][bufPosition] - recordStartTimeMs) << ","
+                                 << bnoBuffer[name][bufPosition*5 + 0] << ","
+                                 << bnoBuffer[name][bufPosition*5 + 1] << ","
+                                 << bnoBuffer[name][bufPosition*5 + 2] << ","
+                                 << bnoBuffer[name][bufPosition*5 + 3] << Qt::endl;
+        }
+    }
+
+    const int *roi = ROI.value(name, nullptr);
+    if (roi && roi[0] >= 0 && roi[1] >= 0 && roi[2] >= 0 && roi[3] >= 0)
+        videoWriter[name]->write(frameBuffer[name][bufPosition](cv::Rect(roi[0], roi[1], roi[2], roi[3])));
+    else
+        videoWriter[name]->write(frameBuffer[name][bufPosition]);
+
+    savedFrameCount[name]++;
+
+    // Stop cleanly before the disk fills: a full disk makes every write above
+    // a silent no-op. Checked every kDiskCheckFrameInterval frames (one
+    // statfs call).
+    if ((savedFrameCount[name] % kDiskCheckFrameInterval) == 0) {
+        const qint64 bytesFree = QStorageInfo(baseDirectory).bytesAvailable();
+        if (bytesFree >= 0 && bytesFree < kMinFreeBytesToContinue) {
+            sendMessage("Error: disk holding " + baseDirectory + " is nearly full ("
+                        + QString::number(bytesFree / (1024 * 1024))
+                        + " MB free). Recording stopped; data recorded so far is saved.");
+            return false;
+        }
+    }
+    return true;
 }
 
 void DataSaver::startRecording(QMap<QString,QVariant> ucInfo)
@@ -312,6 +317,7 @@ void DataSaver::startRecording(QMap<QString,QVariant> ucInfo)
     }
     QJsonDocument jDoc;
     recordStartDateTime = QDateTime::currentDateTime();
+    recordStartTimeMs = monotonicTimeMs();   // frame stamps use the same monotonic clock
     if (setupFilePaths()) {
         // Refuse to start a recording that is about to run into a full disk.
         const qint64 bytesFree = QStorageInfo(baseDirectory).bytesAvailable();
@@ -394,7 +400,14 @@ void DataSaver::startRecording(QMap<QString,QVariant> ucInfo)
             csvFile[keys[i]] = new QFile(deviceDirectory[keys[i]] + "/timeStamps.csv");
             if (openForWrite(csvFile[keys[i]])) {
                 csvStream[keys[i]] = new QTextStream(csvFile[keys[i]]);
-                *csvStream[keys[i]] << "Frame Number,Time Stamp (ms),Buffer Index" << Qt::endl;
+                *csvStream[keys[i]] << "Frame Number,Time Stamp (ms),Buffer Index";
+                if (daqFrameNumBuffer.value(keys[i], nullptr) != nullptr) {
+                    // The DAQ hardware's own frame counter, logged per frame so
+                    // frames lost between the DAQ and the software are
+                    // detectable (counter jump) and TTL-alignable post-hoc.
+                    *csvStream[keys[i]] << ",DAQ Frame Number";
+                }
+                *csvStream[keys[i]] << Qt::endl;
             }
 
             if (headOrientationStreamState[keys[i]] == true && bnoBuffer[keys[i]] != nullptr) {
@@ -445,6 +458,20 @@ void DataSaver::stopRecording()
         return;
     }
     m_recording = false;
+
+    // Drain frames already acquired into the ring buffer so the tail of the
+    // recording is saved instead of silently dropped.
+    QStringList names = frameBuffer.keys();
+    for (int i = 0; i < names.length(); i++) {
+        bool ok = true;
+        while (usedCount[names[i]]->tryAcquire()) {
+            if (ok)
+                ok = writeBufferedFrame(names[i]);
+            frameCount[names[i]]++;
+            freeCount[names[i]]->release(1);
+        }
+    }
+
     QStringList keys = videoWriter.keys();
     for (int i = 0; i < keys.length(); i++) {
         videoWriter[keys[i]]->release();
@@ -503,7 +530,7 @@ void DataSaver::takeNote(QString note)
     // Writes note to file submitted through control panel
     // Only write notes when recording
     if (m_recording) {
-        *noteStream << QDateTime().currentMSecsSinceEpoch() - recordStartDateTime.toMSecsSinceEpoch() << "," << note << Qt::endl;
+        *noteStream << monotonicTimeMs() - recordStartTimeMs << "," << note << Qt::endl;
     }
 }
 

--- a/source/datasaver.h
+++ b/source/datasaver.h
@@ -27,7 +27,7 @@ public:
     void setUserConfig(QJsonObject userConfig) { m_userConfig = userConfig; }
     bool setupFilePaths();
     void setRecord(bool input) {m_recording = input;}
-    void setFrameBufferParameters(QString name, cv::Mat* frameBuf, qint64 *tsBuffer, float *bnoBuf, int bufSize, QSemaphore* freeFrames, QSemaphore* usedFrames, QAtomicInt* acqFrame);
+    void setFrameBufferParameters(QString name, cv::Mat* frameBuf, qint64 *tsBuffer, float *bnoBuf, qint64 *daqFrameNumBuf, int bufSize, QSemaphore* freeFrames, QSemaphore* usedFrames, QAtomicInt* acqFrame);
     void setHeadOrientationConfig(QString name, bool enable, bool filter) {headOrientationStreamState[name] = enable; headOrientationFilterState[name] = filter; }
     void setupBaseDirectory();
     void setROI(QString name, int *bbox);
@@ -58,12 +58,14 @@ public slots:
     void setDataCompression(QString name, QString type);
 
 private:
+    bool writeBufferedFrame(const QString &name);
     QJsonDocument constructBaseDirectoryMetaData();
     QJsonDocument constructDeviceMetaData(QString type, QString deviceName);
     void saveJson(QJsonDocument document, QString fileName);
     QJsonObject m_userConfig;
     QString baseDirectory;
     QDateTime recordStartDateTime;
+    qint64 recordStartTimeMs = 0;   // monotonic clock base for all CSV times
     QMap<QString,QString> deviceDirectory;
 
     QMap<QString, QMap<QString, QVariant>> deviceProperties;
@@ -76,6 +78,7 @@ private:
     QMap<QString, quint32> savedFrameCount;
     QMap<QString, quint32> frameCount;
     QMap<QString, float*> bnoBuffer;
+    QMap<QString, qint64*> daqFrameNumBuffer;
     QMap<QString, bool> headOrientationStreamState;
     QMap<QString, bool> headOrientationFilterState;
     QMap<QString, qint64*> timeStampBuffer;

--- a/source/monotonicclock.h
+++ b/source/monotonicclock.h
@@ -1,0 +1,21 @@
+#ifndef MONOTONICCLOCK_H
+#define MONOTONICCLOCK_H
+
+#include <QElapsedTimer>
+
+// Process-wide monotonic millisecond clock for frame timestamps and trace
+// time axes. Unlike QDateTime::currentMSecsSinceEpoch(), it can never jump
+// (NTP sync, DST, manual clock change) mid-recording - a jump would corrupt
+// every inter-frame interval in timeStamps.csv. Absolute wall-clock time is
+// recorded once per recording in metaData.json ("recordingStartTime").
+inline qint64 monotonicTimeMs()
+{
+    static const QElapsedTimer timer = [] {
+        QElapsedTimer t;
+        t.start();
+        return t;
+    }();
+    return timer.elapsed();
+}
+
+#endif // MONOTONICCLOCK_H

--- a/source/tracedisplay.cpp
+++ b/source/tracedisplay.cpp
@@ -1,4 +1,5 @@
 #include "tracedisplay.h"
+#include "monotonicclock.h"
 #include "newquickview.h"
 
 #include <QObject>
@@ -302,7 +303,7 @@ TraceDisplayRenderer::TraceDisplayRenderer(QObject *parent, QSize displayWindowS
     scale[0] = 1.0f; scale[1] = 1.0f;
     magnify[0] = 1.0f; magnify[1] = 1.0f;
 
-    startTime =  QDateTime().currentMSecsSinceEpoch(); //time software started up
+    startTime = monotonicTimeMs(); //time software started up
     m_lastTimeDisplayed = startTime;
 
     initPrograms();
@@ -908,7 +909,7 @@ void TraceDisplayRenderer::handleWheelEvent(int scrollAmount, QVector<Qt::Key> k
 
 void TraceDisplayRenderer::paint()
 {
-    currentTime =  QDateTime().currentMSecsSinceEpoch();
+    currentTime = monotonicTimeMs();
 
     // Qt6: bracket all raw OpenGL with begin/endExternalCommands (replaces resetOpenGLState).
     m_window->beginExternalCommands();

--- a/source/videodevice.cpp
+++ b/source/videodevice.cpp
@@ -118,6 +118,7 @@ VideoDevice::VideoDevice(QObject *parent, QJsonObject ucDevice, qint64 softwareS
         deviceStream->setBufferParameters(frameBuffer,
                                              timeStampBuffer,
                                              bnoBuffer,
+                                             daqFrameNumBuffer,
                                              FRAME_BUFFER_SIZE,
                                              freeFrames,
                                              usedFrames,

--- a/source/videodevice.h
+++ b/source/videodevice.h
@@ -67,6 +67,7 @@ public:
     QString getCompressionType();
     cv::Mat* getFrameBufferPointer(){return frameBuffer;}
     qint64* getTimeStampBufferPointer(){return timeStampBuffer;}
+    qint64* getDaqFrameNumBufferPointer(){return daqFrameNumBuffer;}
     int getBufferSize() {return FRAME_BUFFER_SIZE;}
     QSemaphore* getFreeFramesPointer(){return freeFrames;}
     QSemaphore* getUsedFramesPointer(){return usedFrames;}
@@ -142,6 +143,7 @@ private:
     QThread *videoStreamThread;
     cv::Mat frameBuffer[FRAME_BUFFER_SIZE];
     qint64 timeStampBuffer[FRAME_BUFFER_SIZE];
+    qint64 daqFrameNumBuffer[FRAME_BUFFER_SIZE];
     // float bnoBuffer[FRAME_BUFFER_SIZE*5]; //w,x,y,z,norm
     QSemaphore *freeFrames;
     QSemaphore *usedFrames;

--- a/source/videostreambase.h
+++ b/source/videostreambase.h
@@ -35,7 +35,11 @@ public:
     explicit VideoStreamBase(QObject *parent = nullptr) : QObject(parent) {}
     ~VideoStreamBase() override = default;
 
+    // daqFrameNumBuf: per-slot copy of the DAQ hardware frame counter at the
+    // moment each frame was acquired, so DataSaver can log it per frame in
+    // timeStamps.csv (makes USB frame loss detectable post-hoc).
     virtual void setBufferParameters(cv::Mat *frameBuf, qint64 *tsBuf, float *bnoBuf,
+                                     qint64 *daqFrameNumBuf,
                                      int bufferSize, QSemaphore *freeFramesS, QSemaphore *usedFramesS,
                                      QAtomicInt *acqFrameNum, QAtomicInt *daqFrameNumber) = 0;
     virtual int connect2Camera(int cameraID) = 0;

--- a/source/videostreamlibuvc.cpp
+++ b/source/videostreamlibuvc.cpp
@@ -3,6 +3,7 @@
 #ifdef HAVE_LIBUVC
 
 #include "miniscopeprotocol.h"
+#include "monotonicclock.h"
 #include "uvcrequest.h"
 
 using namespace MiniscopeProtocol;   // SEL_* selectors, kProcessingUnitId, VID/PID
@@ -35,6 +36,7 @@ VideoStreamLibUVC::VideoStreamLibUVC(QObject *parent, int width, int height, dou
     m_isColor(false),
     frameBuffer(nullptr),
     timeStampBuffer(nullptr),
+    daqFrameNumBuffer(nullptr),
     bnoBuffer(nullptr),
     freeFrames(nullptr),
     usedFrames(nullptr),
@@ -72,11 +74,13 @@ void VideoStreamLibUVC::closeDevice()
 }
 
 void VideoStreamLibUVC::setBufferParameters(cv::Mat *frameBuf, qint64 *tsBuf, float *bnoBuf,
+                                            qint64 *daqFrameNumBuf,
                                             int bufferSize, QSemaphore *freeFramesS, QSemaphore *usedFramesS,
                                             QAtomicInt *acqFrameNum, QAtomicInt *daqFrameNumber)
 {
     frameBuffer = frameBuf;
     timeStampBuffer = tsBuf;
+    daqFrameNumBuffer = daqFrameNumBuf;
     bnoBuffer = bnoBuf;
     frameBufferSize = bufferSize;
     freeFrames = freeFramesS;
@@ -290,7 +294,7 @@ void VideoStreamLibUVC::startStream()
             }
         } else {
             const int bufIdx = idx % frameBufferSize;
-            timeStampBuffer[bufIdx] = QDateTime::currentMSecsSinceEpoch();
+            timeStampBuffer[bufIdx] = monotonicTimeMs();
 
             // libuvc gives raw YUYV; the Y plane is the Miniscope image.
             cv::Mat yuyv((int)frame->height, (int)frame->width, CV_8UC2, frame->data);
@@ -328,6 +332,8 @@ void VideoStreamLibUVC::startStream()
                 if (*m_acqFrameNum == 0)
                     daqFrameNumOffset = *daqFrameNum - 1;
             }
+            if (daqFrameNumBuffer != nullptr)
+                daqFrameNumBuffer[bufIdx] = (daqFrameNum != nullptr) ? qint64(daqFrameNum->loadRelaxed()) : qint64(-1);
 
             m_acqFrameNum->operator++();
             idx++;

--- a/source/videostreamlibuvc.h
+++ b/source/videostreamlibuvc.h
@@ -25,6 +25,7 @@ public:
     ~VideoStreamLibUVC() override;
 
     void setBufferParameters(cv::Mat *frameBuf, qint64 *tsBuf, float *bnoBuf,
+                             qint64 *daqFrameNumBuf,
                              int bufferSize, QSemaphore *freeFramesS, QSemaphore *usedFramesS,
                              QAtomicInt *acqFrameNum, QAtomicInt *daqFrameNumber) override;
     int connect2Camera(int cameraID) override;
@@ -72,6 +73,7 @@ private:
 
     cv::Mat *frameBuffer;
     qint64 *timeStampBuffer;
+    qint64 *daqFrameNumBuffer;
     float *bnoBuffer;
     QSemaphore *freeFrames;
     QSemaphore *usedFrames;

--- a/source/videostreammac.cpp
+++ b/source/videostreammac.cpp
@@ -1,4 +1,5 @@
 #include "videostreammac.h"
+#include "monotonicclock.h"
 
 #include <QDebug>
 #include <QCoreApplication>
@@ -25,6 +26,7 @@ VideoStreamMac::VideoStreamMac(QObject *parent, int width, int height, double pi
     m_isColor(false),
     frameBuffer(nullptr),
     timeStampBuffer(nullptr),
+    daqFrameNumBuffer(nullptr),
     bnoBuffer(nullptr),
     freeFrames(nullptr),
     usedFrames(nullptr),
@@ -47,11 +49,13 @@ VideoStreamMac::~VideoStreamMac()
 }
 
 void VideoStreamMac::setBufferParameters(cv::Mat *frameBuf, qint64 *tsBuf, float *bnoBuf,
+                                         qint64 *daqFrameNumBuf,
                                          int bufferSize, QSemaphore *freeFramesS, QSemaphore *usedFramesS,
                                          QAtomicInt *acqFrameNum, QAtomicInt *daqFrameNumber)
 {
     frameBuffer = frameBuf;
     timeStampBuffer = tsBuf;
+    daqFrameNumBuffer = daqFrameNumBuf;
     bnoBuffer = bnoBuf;
     frameBufferSize = bufferSize;
     freeFrames = freeFramesS;
@@ -274,7 +278,7 @@ void VideoStreamMac::startStream()
                 QThread::msleep(100);
             }
         } else {
-            timeStampBuffer[idx % frameBufferSize] = QDateTime().currentMSecsSinceEpoch();
+            timeStampBuffer[idx % frameBufferSize] = monotonicTimeMs();
 
             if (m_isColor)
                 frame.copyTo(frameBuffer[idx % frameBufferSize]);
@@ -317,6 +321,8 @@ void VideoStreamMac::startStream()
                         << " daqFrameCounter=" << (*daqFrameNum + daqFrameNumOffset)
                         << " ts=" << timeStampBuffer[idx % frameBufferSize];
             }
+            if (daqFrameNumBuffer != nullptr)
+                daqFrameNumBuffer[idx % frameBufferSize] = (daqFrameNum != nullptr) ? qint64(daqFrameNum->loadRelaxed()) : qint64(-1);
 
             m_acqFrameNum->operator++();
             idx++;

--- a/source/videostreammac.h
+++ b/source/videostreammac.h
@@ -35,6 +35,7 @@ public:
     ~VideoStreamMac() override;
 
     void setBufferParameters(cv::Mat *frameBuf, qint64 *tsBuf, float *bnoBuf,
+                             qint64 *daqFrameNumBuf,
                              int bufferSize, QSemaphore *freeFramesS, QSemaphore *usedFramesS,
                              QAtomicInt *acqFrameNum, QAtomicInt *daqFrameNumber) override;
     int connect2Camera(int cameraID) override;
@@ -75,6 +76,7 @@ private:
 
     cv::Mat *frameBuffer;
     qint64 *timeStampBuffer;
+    qint64 *daqFrameNumBuffer;
     float *bnoBuffer;
     QSemaphore *freeFrames;
     QSemaphore *usedFrames;

--- a/source/videostreamocv.cpp
+++ b/source/videostreamocv.cpp
@@ -1,5 +1,6 @@
 #include "videostreamocv.h"
 #include "miniscopeprotocol.h"
+#include "monotonicclock.h"
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/opencv.hpp>
@@ -97,10 +98,12 @@ int VideoStreamOCV::connect2Video(QString folderPath, QString filePrefix, float 
 }
 
 void VideoStreamOCV::setBufferParameters(cv::Mat *frameBuf, qint64 *tsBuf, float *bnoBuf,
+                                         qint64 *daqFrameNumBuf,
                                          int bufferSize, QSemaphore *freeFramesS, QSemaphore *usedFramesS,
                                          QAtomicInt *acqFrameNum, QAtomicInt *daqFrameNumber){
     frameBuffer = frameBuf;
     timeStampBuffer = tsBuf;
+    daqFrameNumBuffer = daqFrameNumBuf;
     frameBufferSize = bufferSize;
     bnoBuffer = bnoBuf;
     freeFrames = freeFramesS;
@@ -155,7 +158,7 @@ void VideoStreamOCV::startStream()
                 }
                 else {
                     // Grab successful
-                    timestamp = QDateTime::currentMSecsSinceEpoch();
+                    timestamp = monotonicTimeMs();
                     if (!cam->retrieve(frame)) {
                         // Retrieve failed
                         status = false;
@@ -177,7 +180,7 @@ void VideoStreamOCV::startStream()
             }
             else if (m_connectionType == "videoFile") {
                 QThread::msleep(1000.0/m_playbackFPS);
-                timestamp = QDateTime::currentMSecsSinceEpoch();
+                timestamp = monotonicTimeMs();
                 if (!cam->read(frame)) {
                     // Try next file before fully giving up. End playback with
                     // a break, not a return: break falls through to the
@@ -254,6 +257,8 @@ void VideoStreamOCV::startStream()
                         if (*m_acqFrameNum == 0) // Used to initially sync daqFrameNum with acqFrameNum
                             daqFrameNumOffset = *daqFrameNum - 1;
                     }
+                    if (daqFrameNumBuffer != nullptr)
+                        daqFrameNumBuffer[bufIdx] = (daqFrameNum != nullptr) ? qint64(daqFrameNum->loadRelaxed()) : qint64(-1);
 
                     m_acqFrameNum->operator++();
                     idx++;

--- a/source/videostreamocv.h
+++ b/source/videostreamocv.h
@@ -24,6 +24,7 @@ public:
     ~VideoStreamOCV() override;
 //    void setCameraID(int cameraID);
     void setBufferParameters(cv::Mat *frameBuf, qint64 *tsBuf, float *bnoBuf,
+                             qint64 *daqFrameNumBuf,
                              int bufferSize, QSemaphore *freeFramesS, QSemaphore *usedFramesS,
                              QAtomicInt *acqFrameNum, QAtomicInt *daqFrameNumber) override;
     int connect2Camera(int cameraID) override;
@@ -54,6 +55,7 @@ private:
     bool m_isColor;
     cv::Mat *frameBuffer;
     qint64 *timeStampBuffer;
+    qint64 *daqFrameNumBuffer;
     float *bnoBuffer;
     QSemaphore *freeFrames;
     QSemaphore *usedFrames;

--- a/tests/tst_datasaver.cpp
+++ b/tests/tst_datasaver.cpp
@@ -128,13 +128,118 @@ private slots:
         qint64 timestamps[1] = {0};
         QSemaphore freeFrames(1), usedFrames;
         QAtomicInt acqFrame;
-        saver.setFrameBufferParameters("Cam", frames, timestamps, nullptr, 1,
+        saver.setFrameBufferParameters("Cam", frames, timestamps, nullptr, nullptr, 1,
                                        &freeFrames, &usedFrames, &acqFrame);
 
         QSignalSpy failed(&saver, &DataSaver::recordingFailed);
         saver.startRecording({});
         QVERIFY(!saver.isRecording());
         QCOMPARE(failed.count(), 1);
+    }
+
+    void stopRecordingDrainsBufferAndLogsDaqColumn()
+    {
+        // Three frames sit acquired-but-unsaved in the ring buffer when the
+        // recording stops. stopRecording() must drain them to disk, and the
+        // timeStamps.csv of a device WITH a DAQ counter must carry the
+        // per-frame "DAQ Frame Number" column (a jump in it is the on-disk
+        // evidence of USB frame loss).
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+
+        QJsonObject config = deviceFreeConfig(dir.path());
+        QJsonObject camera;
+        camera["deviceType"] = "Miniscope";
+        QJsonObject miniscopes;
+        miniscopes["Scope"] = camera;
+        QJsonObject devices;
+        devices["miniscopes"] = miniscopes;
+        config["devices"] = devices;
+
+        DataSaver saver;
+        saver.setUserConfig(config);
+        saver.setDataCompression("Scope", "MJPG");
+
+        const int bufSize = 4;
+        cv::Mat frames[bufSize];
+        qint64 timestamps[bufSize] = {0};
+        qint64 daqNums[bufSize] = {0};
+        QSemaphore freeFrames(bufSize), usedFrames;
+        QAtomicInt acqFrame;
+        saver.setFrameBufferParameters("Scope", frames, timestamps, nullptr, daqNums,
+                                       bufSize, &freeFrames, &usedFrames, &acqFrame);
+
+        saver.startRecording({});
+        QVERIFY(saver.isRecording());
+
+        // Simulate the capture backend: fill 3 slots, DAQ counter shows a
+        // dropped hardware frame between the 2nd and 3rd (6 -> 8).
+        const qint64 daqValues[3] = {5, 6, 8};
+        for (int i = 0; i < 3; i++) {
+            QVERIFY(freeFrames.tryAcquire());
+            frames[i] = cv::Mat(48, 64, CV_8UC3, cv::Scalar(i * 40, 0, 0));
+            timestamps[i] = 1000 + i * 33;
+            daqNums[i] = daqValues[i];
+            usedFrames.release();
+        }
+
+        saver.stopRecording();
+        QVERIFY(!saver.isRecording());
+
+        QFile csv(dir.path() + "/Scope/timeStamps.csv");
+        QVERIFY(csv.open(QFile::ReadOnly | QFile::Text));
+        const QStringList lines = QString::fromUtf8(csv.readAll())
+                                      .split('\n', Qt::SkipEmptyParts);
+        QCOMPARE(lines.size(), 4); // header + 3 drained frames
+        QCOMPARE(lines[0], QStringLiteral("Frame Number,Time Stamp (ms),Buffer Index,DAQ Frame Number"));
+        for (int i = 0; i < 3; i++) {
+            const QStringList cols = lines[i + 1].split(',');
+            QCOMPARE(cols.size(), 4);
+            QCOMPARE(cols[0].toInt(), i);
+            QCOMPARE(cols[3].toLongLong(), daqValues[i]);
+        }
+
+        // The drained frames must be in the video file, too.
+        cv::VideoCapture readBack((dir.path() + "/Scope/0.avi").toStdString());
+        QVERIFY(readBack.isOpened());
+        QCOMPARE(int(readBack.get(cv::CAP_PROP_FRAME_COUNT)), 3);
+    }
+
+    void devicesWithoutDaqCounterKeepThreeColumnCsv()
+    {
+        // Behavior webcams have no DAQ counter (nullptr buffer): their CSV
+        // format must stay exactly as it always was.
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+
+        QJsonObject config = deviceFreeConfig(dir.path());
+        QJsonObject camera;
+        camera["deviceType"] = "WebCam";
+        QJsonObject cameras;
+        cameras["Cam"] = camera;
+        QJsonObject devices;
+        devices["cameras"] = cameras;
+        config["devices"] = devices;
+
+        DataSaver saver;
+        saver.setUserConfig(config);
+        saver.setDataCompression("Cam", "MJPG");
+
+        cv::Mat frames[2];
+        qint64 timestamps[2] = {0};
+        QSemaphore freeFrames(2), usedFrames;
+        QAtomicInt acqFrame;
+        saver.setFrameBufferParameters("Cam", frames, timestamps, nullptr, nullptr,
+                                       2, &freeFrames, &usedFrames, &acqFrame);
+
+        saver.startRecording({});
+        QVERIFY(saver.isRecording());
+        saver.stopRecording();
+
+        QFile csv(dir.path() + "/Cam/timeStamps.csv");
+        QVERIFY(csv.open(QFile::ReadOnly | QFile::Text));
+        const QString header = QString::fromUtf8(csv.readLine()).trimmed();
+        QCOMPARE(header, QStringLiteral("Frame Number,Time Stamp (ms),Buffer Index"));
     }
 
 private:


### PR DESCRIPTION
PR C of the modernization series (R2, recorded-data quality) — the undetectable-frame-loss fix. **Stacked on #92** (changelog); merge that first and GitHub retargets this automatically.

## Why
The DAQ hardware counts every frame it acquires and emits a TTL pulse per frame. Every capture backend already reads that counter every frame — but it was never written to disk. So when a frame was lost between the DAQ hardware and the software (USB pressure, full ring buffer), nothing in the recording showed it, and the saved frames could not be reliably aligned to the hardware TTL train that other rigs record.

## What changes on disk
**Miniscope `timeStamps.csv`** gains one column, appended last so existing parsers that index columns 0–2 keep working:

```
Frame Number,Time Stamp (ms),Buffer Index,DAQ Frame Number
0,2,47,1
1,35,47,2
2,68,47,4   <- hardware frame 3 never reached the software: visible, alignable
```

Behavior-camera CSVs are byte-for-byte unchanged (they have no DAQ counter).

**Timestamps** switch from the wall clock to a process-wide monotonic clock (`source/monotonicclock.h`). An NTP sync/DST shift/manual clock change mid-recording can no longer corrupt inter-frame intervals. Semantics are unchanged (ms since recording start); absolute wall-clock start stays in `metaData.json`. The trace display and software start time move to the same clock, so every time axis in the app agrees.

**Stop now drains the buffer**: frames already acquired into the ring buffer when you hit Stop are written out instead of silently dropped. The per-frame save logic is extracted into `DataSaver::writeBufferedFrame()`, shared by the run loop and the drain (and this removes the duplicated fail-loudly checks from #91's loop).

## Plumbing
Each ring-buffer slot carries the DAQ counter captured with its frame: new `qint64` per-slot buffer in `VideoDevice`, wired through `setBufferParameters` in all three backends (OpenCV / libuvc / macOS) and into DataSaver. Miniscopes pass the buffer; behavior cams pass `nullptr`.

## Tests
`tst_datasaver`: 12 cases (was 10). The drain test simulates a stop with 3 unsaved frames and a dropped hardware frame (counter 5→6→8) and verifies all 3 land in both the 4-column CSV and the video file; a companion test pins the unchanged 3-column format for DAQ-less devices. All 8 suites pass locally; libuvc backend syntax-checked and compiled for real by Linux CI.
