### PR TITLE
Version has one source of truth (fixes DMG still named 2.1.0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,10 @@ qt_add_executable(MiniscopeDAQ
     source/qml.qrc
 )
 
+# Single source of truth for the app version: the project() line above. The
+# UI (main.cpp) and the packaging scripts all derive from it.
+target_compile_definitions(MiniscopeDAQ PRIVATE MINISCOPE_VERSION="${PROJECT_VERSION}")
+
 if(APPLE)
     target_link_libraries(MiniscopeDAQ PRIVATE uvccontrol_mac avfenumerator_mac avfgrabber_mac)
 

--- a/packaging/linux/build-appimage.sh
+++ b/packaging/linux/build-appimage.sh
@@ -79,7 +79,7 @@ chmod +x "$APPDIR/usr/bin/MiniscopeDAQ"
 
 echo "### package AppImage"
 mkdir -p "$DIST"
-VER="$(sed -nE 's/.*VERSION_NUMBER\s+"([^"]+)".*/\1/p' "$REPO/source/main.cpp" | head -1)"
+VER="$(sed -nE 's/^project\(MiniscopeDAQ\s+VERSION\s+([0-9.]+).*/\1/p' "$REPO/CMakeLists.txt" | head -1)"
 OUT="Miniscope_DAQ${VER:+-$VER}-x86_64.AppImage"
 ( cd "$DIST" && ARCH=x86_64 OUTPUT="$OUT" "$LD" --appdir "$APPDIR" --output appimage )
 echo "### DONE -> $DIST/$OUT"

--- a/packaging/macos/build-dmg.sh
+++ b/packaging/macos/build-dmg.sh
@@ -44,7 +44,7 @@ codesign --verify --deep --strict "$APP"
 
 echo "### package DMG"
 mkdir -p "$DIST"
-VER="$(sed -nE 's/.*VERSION_NUMBER[[:space:]]+"([^"]+)".*/\1/p' "$REPO/source/main.cpp" | head -1)"
+VER="$(sed -nE 's/^project\(MiniscopeDAQ[[:space:]]+VERSION[[:space:]]+([0-9.]+).*/\1/p' "$REPO/CMakeLists.txt" | head -1)"
 ARCH="$(uname -m)"
 OUT="Miniscope-DAQ${VER:+-$VER}-macOS-$ARCH.dmg"
 STAGE="$BUILD/dmg-stage"

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -24,7 +24,12 @@
 #include <patchlevel.h>   // PY_VERSION (e.g. "3.12.7"); pure macro header, safe alone
 #endif
 
-#define VERSION_NUMBER "2.1.0"
+// The app version comes from the project() line in CMakeLists.txt (passed in
+// as MINISCOPE_VERSION) so it cannot drift from the packaged artifact names.
+#ifndef MINISCOPE_VERSION
+#define MINISCOPE_VERSION "unknown"
+#endif
+#define VERSION_NUMBER MINISCOPE_VERSION
 // TODO: have exit button close everything
 
 // For Window's deployment


### PR DESCRIPTION
Building the first post-#92 DMG exposed a second, hardcoded copy of the version: `#define VERSION_NUMBER "2.1.0"` in main.cpp, which feeds the About box and is what `build-dmg.sh` / `build-appimage.sh` parsed for artifact names. Result: a DMG named `2.1.0` built from v2.0.0 code.

Now the `project(MiniscopeDAQ VERSION 2.0.0)` line in CMakeLists is the only place the version exists:
- CMake passes it into the app as `MINISCOPE_VERSION` (About box shows it)
- both packaging scripts parse the `project()` line directly
- bundle/installer metadata already derived from `PROJECT_VERSION`

Verified the sed extraction prints `2.0.0`, and a local DMG build from this branch produces `Miniscope-DAQ-2.0.0-macOS-arm64.dmg`.