### PR TITLE
R3: orderly shutdown — join worker threads, saver exit path, no per-recording leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,13 @@ published together from CI.
   display window only opens when configured.
 
 ### Fixed
+- Quitting the app now stops and joins every worker thread (capture loops,
+  data saver, behavior tracker) in order — previously no thread was ever
+  joined, so exit raced still-running threads against object teardown.
+- The data-saver loop no longer busy-spins a full CPU core for the lifetime
+  of the app; it sleeps when idle and has a proper exit path.
+- Each record/stop cycle leaked every file handle and video writer it
+  created; they are now released when the recording stops.
 - Head-orientation CSV was silently never written when `filterBadData` was
   `false` (enable flag overwritten by a copy-paste bug) ([#90](https://github.com/Aharoni-Lab/Miniscope-DAQ-QT-Software/pull/90)).
 - Frames could be corrupted while the ring buffer was full: all capture

--- a/source/backend.cpp
+++ b/source/backend.cpp
@@ -94,6 +94,8 @@ backEnd::backEnd(QObject *parent) :
     ucTraceDisplay["type"] = "None";
 
     dataSaver = new DataSaver();
+    dataSaverThread = nullptr;   // created in setupDataSaver(); quitting before
+                                 // any config loads must not touch a wild pointer
 
 #ifdef USE_USB
     testLibusb();
@@ -1095,9 +1097,44 @@ void backEnd::onRecordClicked()
 
 void backEnd::exitClicked()
 {
-    // TODO: Do other exit stuff such as stop recording???
+    shutdownThreads();
     emit closeAll();
+}
 
+// Orderly teardown, called from both quit paths (Exit button and main-window
+// close) before the QML engine quits. Without this no worker thread was ever
+// joined: the process exited while capture/saver threads were still touching
+// buffers and Qt objects - a use-after-free lottery on every quit.
+void backEnd::shutdownThreads()
+{
+    if (m_threadsShutdown)
+        return;
+    m_threadsShutdown = true;
+
+    // 1. A recording in progress stops properly first: drains the ring
+    //    buffers and closes every file. Blocking invoke so the files are
+    //    complete before the pipeline is torn down.
+    if (dataSaverThread && dataSaverThread->isRunning() && dataSaver->isRecording())
+        QMetaObject::invokeMethod(dataSaver, "stopRecording", Qt::BlockingQueuedConnection);
+
+    // 2. Stop the capture loops and join their threads (frame producers go
+    //    quiet before their consumers are stopped).
+    for (int i = 0; i < miniscope.length(); i++)
+        miniscope[i]->stopAndJoinStream();
+    for (int i = 0; i < behavCam.length(); i++)
+        behavCam[i]->stopAndJoinStream();
+
+    // 3. Then the saver loop and its thread.
+    if (dataSaverThread && dataSaverThread->isRunning()) {
+        QMetaObject::invokeMethod(dataSaver, "stopRunning", Qt::QueuedConnection);
+        dataSaverThread->quit();
+        if (!dataSaverThread->wait(3000))
+            qWarning() << "DataSaver thread did not stop within 3s; leaking it";
+    }
+
+    // 4. Behavior-tracker worker, if one was started.
+    if (behavTracker)
+        behavTracker->stopAndJoinWorker();
 }
 
 void backEnd::handleUserConfigFileNameChanged()

--- a/source/backend.h
+++ b/source/backend.h
@@ -163,6 +163,10 @@ public slots:
 private:
     void connectSnS();
     void setupDataSaver();
+    // Stop capture/saver/tracker threads and join them; idempotent. Runs
+    // before the QML engine quits so no thread outlives the objects it uses.
+    void shutdownThreads();
+    bool m_threadsShutdown = false;
 
     void testCodecSupport();
 

--- a/source/behaviortracker.cpp
+++ b/source/behaviortracker.cpp
@@ -523,6 +523,17 @@ void BehaviorTracker::close()
     //    view->close();
 }
 
+void BehaviorTracker::stopAndJoinWorker()
+{
+    if (workerThread == nullptr)
+        return;
+    emit closeWorker();
+    workerThread->quit();
+    if (!workerThread->wait(3000))
+        qWarning() << "Behavior tracker worker thread did not stop within 3s; leaking it";
+    workerThread = nullptr;
+}
+
 void BehaviorTracker::handleAddNewTracePose(int poseIdx, QString type, bool sameOffset)
 {
 //    m_traceColors[0][0] = &colors[0];

--- a/source/behaviortracker.h
+++ b/source/behaviortracker.h
@@ -181,6 +181,8 @@ public slots:
     void sendNewFrame();
     void startRunning(); // Slot gets called when thread starts
     void close();
+    // Orderly shutdown: ask the worker to stop, then join its thread.
+    void stopAndJoinWorker();
     void handleAddNewTracePose(int poseIdx, QString type, bool sameOffset);
 
 private:

--- a/source/datasaver.cpp
+++ b/source/datasaver.cpp
@@ -20,6 +20,7 @@
 #include <QVariant>
 #include <QMetaType>
 #include <QStorageInfo>
+#include <QThread>
 
 #include "monotonicclock.h"
 
@@ -34,12 +35,21 @@ static constexpr int    kDiskCheckFrameInterval = 100;
 DataSaver::DataSaver(QObject *parent) :
     QObject(parent),
     baseDirectory(""),
+    behavTrackerFile(nullptr),
+    behavTrackerStream(nullptr),
+    noteFile(nullptr),
+    noteStream(nullptr),
     m_recording(false),
     behaviorTrackerEnabled(false),
     m_running(false)
 
 {
 
+}
+
+DataSaver::~DataSaver()
+{
+    releaseRecordingFiles();
 }
 
 bool DataSaver::setupFilePaths()
@@ -169,14 +179,17 @@ void DataSaver::startRunning()
     m_running = true;
     int i, j;
     int poseBufPosition;
+    bool idle;
 
     QString poseData;
 
     QStringList names;
     while(m_running) {
+        idle = true;
         // For Behavior Tracker
         if (behaviorTrackerEnabled) {
             while (usedPoses->tryAcquire()) {
+                idle = false;
                 if (m_recording) {
                     poseBufPosition = btPoseCount % poseBufferSize;
                     poseData.clear();
@@ -195,6 +208,7 @@ void DataSaver::startRunning()
         names = frameBuffer.keys();
         for (i = 0; i < frameBuffer.size(); i++) {
             while (usedCount[names[i]]->tryAcquire()) {
+                idle = false;
                 // grab info from buffer in a threadsafe way
                 if (m_recording && !writeBufferedFrame(names[i])) {
                     // Could not create the next video file / disk nearly full
@@ -207,7 +221,21 @@ void DataSaver::startRunning()
             }
         }
         QCoreApplication::processEvents(); // Is there a better way to do this. This is against best practices
+
+        // Nothing arrived this pass: sleep 1ms instead of busy-spinning a
+        // full core. The ring buffers are deep (128 slots), so this adds no
+        // meaningful save latency.
+        if (idle && m_running)
+            QThread::msleep(1);
     }
+}
+
+void DataSaver::stopRunning()
+{
+    // Delivered as a queued slot: the run loop's processEvents() call picks
+    // it up, the loop exits, and startRunning() returns so the DataSaver
+    // thread can finish and be joined.
+    m_running = false;
 }
 
 // Write the frame at this device's current ring-buffer position to disk
@@ -316,6 +344,7 @@ void DataSaver::startRecording(QMap<QString,QVariant> ucInfo)
         return;
     }
     QJsonDocument jDoc;
+    releaseRecordingFiles();   // free the previous recording's (or a failed attempt's) handles
     recordStartDateTime = QDateTime::currentDateTime();
     recordStartTimeMs = monotonicTimeMs();   // frame stamps use the same monotonic clock
     if (setupFilePaths()) {
@@ -335,7 +364,6 @@ void DataSaver::startRecording(QMap<QString,QVariant> ucInfo)
 
         // Every file in the save path must open, or the recording must not
         // claim to be running - a silently unwritable CSV is total data loss.
-        QVector<QFile *> openedFiles;
         bool openFailed = false;
         auto openForWrite = [&](QFile *file) {
             if (openFailed)
@@ -346,7 +374,6 @@ void DataSaver::startRecording(QMap<QString,QVariant> ucInfo)
                 openFailed = true;
                 return false;
             }
-            openedFiles.append(file);
             return true;
         };
 
@@ -436,8 +463,7 @@ void DataSaver::startRecording(QMap<QString,QVariant> ucInfo)
         }
 
         if (openFailed) {
-            for (QFile *file : openedFiles)
-                file->close();
+            releaseRecordingFiles();
             emit recordingFailed();
             return;
         }
@@ -472,20 +498,55 @@ void DataSaver::stopRecording()
         }
     }
 
-    QStringList keys = videoWriter.keys();
-    for (int i = 0; i < keys.length(); i++) {
-        videoWriter[keys[i]]->release();
-        csvFile[keys[i]]->close();
+    releaseRecordingFiles();
+}
 
-        if (headOrientationStreamState[keys[i]] == true && bnoBuffer[keys[i]] != nullptr)
-            if (headOriFile[keys[i]]->isOpen())
-                headOriFile[keys[i]]->close();
+// Close and free everything startRecording() allocated. Called when a
+// recording stops, before a new one starts (clears leftovers from a failed
+// attempt), and on destruction - each record/stop cycle used to leak every
+// QFile/QTextStream/VideoWriter it created.
+void DataSaver::releaseRecordingFiles()
+{
+    for (cv::VideoWriter *writer : videoWriter) {
+        if (writer)
+            writer->release();
+        delete writer;
     }
-    if (!m_userConfig["behaviorTracker"].toObject().isEmpty()) {
-        if (behavTrackerFile->isOpen())
-            behavTrackerFile->close();
+    videoWriter.clear();
+
+    // Streams are deleted before their files: QTextStream flushes on
+    // destruction, which must happen while the QFile is still alive.
+    qDeleteAll(csvStream);
+    csvStream.clear();
+    for (QFile *file : csvFile) {
+        if (file)
+            file->close();
+        delete file;
     }
-    noteFile->close();
+    csvFile.clear();
+
+    qDeleteAll(headOriStream);
+    headOriStream.clear();
+    for (QFile *file : headOriFile) {
+        if (file)
+            file->close();
+        delete file;
+    }
+    headOriFile.clear();
+
+    delete behavTrackerStream;
+    behavTrackerStream = nullptr;
+    if (behavTrackerFile)
+        behavTrackerFile->close();
+    delete behavTrackerFile;
+    behavTrackerFile = nullptr;
+
+    delete noteStream;
+    noteStream = nullptr;
+    if (noteFile)
+        noteFile->close();
+    delete noteFile;
+    noteFile = nullptr;
 }
 
 void DataSaver::devicePropertyChanged(QString deviceName, QString propName, QVariant propValue)

--- a/source/datasaver.h
+++ b/source/datasaver.h
@@ -24,6 +24,7 @@ class DataSaver : public QObject
     Q_OBJECT
 public:
     explicit DataSaver(QObject *parent = nullptr);
+    ~DataSaver() override;
     void setUserConfig(QJsonObject userConfig) { m_userConfig = userConfig; }
     bool setupFilePaths();
     void setRecord(bool input) {m_recording = input;}
@@ -50,6 +51,7 @@ signals:
 
 public slots:
     void startRunning();
+    void stopRunning();
     void startRecording(QMap<QString,QVariant> ucInfo);
     void stopRecording();
     void devicePropertyChanged(QString deviceName, QString propName, QVariant propValue);
@@ -59,6 +61,7 @@ public slots:
 
 private:
     bool writeBufferedFrame(const QString &name);
+    void releaseRecordingFiles();
     QJsonDocument constructBaseDirectoryMetaData();
     QJsonDocument constructDeviceMetaData(QString type, QString deviceName);
     void saveJson(QJsonDocument document, QString fileName);

--- a/source/videodevice.cpp
+++ b/source/videodevice.cpp
@@ -849,3 +849,18 @@ void VideoDevice::close()
         view->close();
 }
 
+void VideoDevice::stopAndJoinStream()
+{
+    if (!m_camConnected || deviceStream == nullptr || videoStreamThread == nullptr)
+        return;
+    // Direct call from the GUI thread: stopSteam() only sets the (atomic)
+    // stop flag, so this is safe and does not depend on the stream thread's
+    // event processing. The stream loop then exits and the thread finishes.
+    deviceStream->stopSteam();
+    videoStreamThread->quit();
+    if (!videoStreamThread->wait(3000))
+        qWarning() << m_deviceName << "stream thread did not stop within 3s; leaking it";
+    // The thread deletes itself via its finished() -> deleteLater() connection.
+    videoStreamThread = nullptr;
+}
+

--- a/source/videodevice.h
+++ b/source/videodevice.h
@@ -61,6 +61,9 @@ public:
     bool getHeadOrienataionFilterState() { return m_headOrientationFilterState;}
     void createView();
     void connectSnS();
+    // Orderly shutdown: stop the capture loop and join its thread. Safe to
+    // call from the GUI thread; no-op if the device never connected.
+    void stopAndJoinStream();
     void defineDeviceAddrs();
     void parseUserConfigDevice();
     void sendInitCommands();

--- a/source/videostreamlibuvc.h
+++ b/source/videostreamlibuvc.h
@@ -7,6 +7,7 @@
 // frame counter and BNO head-orientation registers can be read on Linux).
 #ifdef HAVE_LIBUVC
 
+#include <atomic>
 #include <QSemaphore>
 #include <QAtomicInt>
 #include <QVector>
@@ -65,8 +66,8 @@ private:
     uvc_stream_handle_t *m_strmh;
     int m_negotiatedFps;
 
-    bool m_isStreaming;
-    bool m_stopStreaming;
+    std::atomic<bool> m_isStreaming;
+    std::atomic<bool> m_stopStreaming;
     bool m_headOrientationStreamState;
     bool m_headOrientationFilterState;
     bool m_isColor;

--- a/source/videostreammac.h
+++ b/source/videostreammac.h
@@ -16,6 +16,7 @@
 // exactly like the other backends - frame counter always (1 read/frame), BNO
 // only when head orientation is enabled, trigger state only when tracking.
 
+#include <atomic>
 #include <QSemaphore>
 #include <QAtomicInt>
 #include <QVector>
@@ -70,7 +71,7 @@ private:
     AvfFrameGrabber m_grabber;
     UVCControlMac m_control;
 
-    bool m_stopStreaming;
+    std::atomic<bool> m_stopStreaming;
     bool m_headOrientationStreamState;
     bool m_isColor;
 

--- a/source/videostreamocv.h
+++ b/source/videostreamocv.h
@@ -1,6 +1,7 @@
 #ifndef VIDEOSTREAMOCV_H
 #define VIDEOSTREAMOCV_H
 
+#include <atomic>
 #include <QObject>
 #include <QSemaphore>
 #include <QString>
@@ -48,8 +49,8 @@ private:
     int m_cameraID;
     QString m_deviceName;
     cv::VideoCapture *cam;
-    bool m_isStreaming;
-    bool m_stopStreaming;
+    std::atomic<bool> m_isStreaming;
+    std::atomic<bool> m_stopStreaming;
     bool m_headOrientationStreamState;
     bool m_headOrientationFilterState;
     bool m_isColor;

--- a/tests/tst_datasaver.cpp
+++ b/tests/tst_datasaver.cpp
@@ -16,6 +16,7 @@
 #include <QSemaphore>
 #include <QSignalSpy>
 #include <QTemporaryDir>
+#include <QThread>
 
 #include "datasaver.h"
 
@@ -240,6 +241,54 @@ private slots:
         QVERIFY(csv.open(QFile::ReadOnly | QFile::Text));
         const QString header = QString::fromUtf8(csv.readLine()).trimmed();
         QCOMPARE(header, QStringLiteral("Frame Number,Time Stamp (ms),Buffer Index"));
+    }
+
+    void stopRunningExitsRunLoop()
+    {
+        // startRunning() blocks its thread in the save loop; stopRunning()
+        // (delivered through the loop's processEvents) must let it return so
+        // the thread can be joined. Before R3 there was NO exit path: the
+        // loop ran (and busy-spun a core) until process death.
+        QThread thread;
+        DataSaver saver;
+        saver.moveToThread(&thread);
+        connect(&thread, &QThread::started, &saver, &DataSaver::startRunning);
+        thread.start();
+        QTest::qWait(100); // let the loop spin up
+
+        QMetaObject::invokeMethod(&saver, "stopRunning", Qt::QueuedConnection);
+        thread.quit();
+        QVERIFY(thread.wait(3000));
+        saver.moveToThread(QThread::currentThread());
+    }
+
+    void backToBackRecordingsReuseCleanly()
+    {
+        // Each record/stop cycle allocates fresh files/writers; the previous
+        // cycle's must be released, not leaked, and the second cycle must
+        // work end to end.
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+
+        DataSaver saver;
+        saver.setUserConfig(deviceFreeConfig(dir.path()));
+        QSignalSpy failed(&saver, &DataSaver::recordingFailed);
+
+        for (int cycle = 0; cycle < 2; cycle++) {
+            saver.startRecording({});
+            QVERIFY2(saver.isRecording(), qPrintable(QStringLiteral("cycle %1").arg(cycle)));
+            saver.takeNote(QStringLiteral("note in cycle %1").arg(cycle));
+            saver.stopRecording();
+            QVERIFY(!saver.isRecording());
+        }
+        QCOMPARE(failed.count(), 0);
+
+        // The second cycle re-truncated notes.csv: header + its one note.
+        QFile notes(dir.path() + "/notes.csv");
+        QVERIFY(notes.open(QFile::ReadOnly | QFile::Text));
+        const QString contents = QString::fromUtf8(notes.readAll());
+        QVERIFY(contents.contains("note in cycle 1"));
+        QVERIFY(!contents.contains("note in cycle 0"));
     }
 
 private:


### PR DESCRIPTION
PR D of the modernization series (R3, teardown/lifetimes). No behavior or format changes — this makes quitting clean and stops wasting a core.

## The problems
1. **No worker thread was ever joined.** Both quit paths just emitted `closeAll()` and let the process die while capture threads, the DataSaver thread, and the behavior-tracker worker were potentially mid-write — a use-after-free race on every exit (the QML `TypeError` spam in Marcel's bench logs was one visible symptom of teardown disorder).
2. **DataSaver busy-spun a core.** `startRunning()` was `while(m_running)` with no sleep and nothing ever set `m_running = false` — 100% of one core from app start to process death, even idle.
3. **Per-recording leaks.** Every `startRecording()` allocated fresh `QFile`/`QTextStream`/`cv::VideoWriter` objects per device; `stopRecording()` closed but never freed them, so every record/stop cycle leaked the full set.
4. `dataSaverThread` was an uninitialized pointer until the first config loaded — quit-before-config-load read garbage.

## The shape of the fix
`backEnd::shutdownThreads()` — idempotent, called from both quit paths before the QML engine quits — runs the teardown in dependency order: stop an active recording (blocking invoke → buffers drain, files close) → stop and join every capture thread → stop and join the saver → stop and join the tracker worker. Each join has a 3 s timeout that warns and leaks rather than hangs the exit.

Supporting pieces:
- The `m_stopStreaming` flags in all three backends are now `std::atomic<bool>`, so `stopAndJoinStream()` can set them directly from the GUI thread without depending on the stream thread's event processing.
- `DataSaver::stopRunning()` provides the missing exit path, and the run loop sleeps 1 ms on idle passes (128-deep ring buffers make that latency invisible).
- `releaseRecordingFiles()` frees everything a recording allocated — on stop, before the next start (covering failed attempts), and in the new destructor. Streams are deleted before their files so `QTextStream`'s destructor flush still lands.

## Tests
`tst_datasaver`: 14 cases (was 12). New: `stopRunningExitsRunLoop` (the saver thread actually joins within a timeout — this test hangs forever on the old code) and `backToBackRecordingsReuseCleanly` (two record/stop cycles, second one fully functional).

Suggested 30-second manual check when convenient: load the webcam config, Run, Record a few seconds, quit via the window close button — app should exit promptly with no crash dialog, and the recording should be intact.