### PR TITLE
macOS: pin behavior webcams to their physical camera (uniqueID)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,11 @@ published together from CI.
 - Multi-scope safety: with more than one Miniscope attached, the control
   channel refuses to guess which device to drive when the configured ID can't
   be resolved ([#88](https://github.com/Aharoni-Lab/Miniscope-DAQ-QT-Software/pull/88)).
+- macOS behavior cameras are now **pinned to the physical camera** (its
+  AVFoundation uniqueID), resolved once from the config's `deviceID` at
+  connect. Reconnects after a drop only ever rebind the same physical camera —
+  previously a reconnect reopened by list index, which could silently switch
+  to a different camera (e.g. the built-in one) mid-session.
 
 **Recorded-data quality**
 - Miniscope `timeStamps.csv` files gain a **`DAQ Frame Number`** column: the

--- a/source/avfenumeratormac.h
+++ b/source/avfenumeratormac.h
@@ -2,6 +2,7 @@
 #define AVFENUMERATORMAC_H
 
 #include <QString>
+#include <QStringList>
 #include <QVector>
 #include <QtGlobal>
 
@@ -42,6 +43,40 @@ struct ControlTarget {
 ControlTarget resolveControlTarget(const QVector<AvfCameraInfo> &cameras, int cameraID,
                                    quint16 expectedVid, quint16 expectedPid,
                                    const QVector<quint32> &attachedLocations);
+
+// Behavior cameras (webcams) are configured by deviceID = AVFoundation list
+// index. Resolve the index to the camera's stable uniqueID ONCE at connect;
+// after that the capture session is pinned to the uniqueID and reconnects
+// re-resolve by uniqueID only, never by index - list positions shift whenever
+// cameras come and go, and an index reopen can silently bind a DIFFERENT
+// physical camera (the "ghost reconnect" observed on the bench).
+struct WebcamTarget {
+    bool ok = false;
+    QString uniqueID;
+    QString name;      // localizedName, for user-facing messages
+    QString error;     // the reason, when !ok
+};
+
+inline WebcamTarget resolveWebcamTarget(const QVector<AvfCameraInfo> &cameras, int cameraID)
+{
+    WebcamTarget target;
+    if (cameras.isEmpty()) {
+        target.error = QStringLiteral("no cameras are visible to macOS.");
+        return target;
+    }
+    if (cameraID < 0 || cameraID >= cameras.size()) {
+        QStringList names;
+        for (int i = 0; i < cameras.size(); i++)
+            names.append(QStringLiteral("deviceID %1: %2").arg(i).arg(cameras[i].name));
+        target.error = QStringLiteral("deviceID %1 is out of range - %2 camera(s) connected (%3).")
+                           .arg(cameraID).arg(cameras.size()).arg(names.join(QStringLiteral(", ")));
+        return target;
+    }
+    target.ok = true;
+    target.uniqueID = cameras[cameraID].uniqueID;
+    target.name = cameras[cameraID].name;
+    return target;
+}
 
 // The stable AVFoundation uniqueID of the camera with this USB locationID
 // (empty when absent) - what the frame grabber pins its capture session to,

--- a/source/videostreamocv.cpp
+++ b/source/videostreamocv.cpp
@@ -1,6 +1,9 @@
 #include "videostreamocv.h"
 #include "miniscopeprotocol.h"
 #include "monotonicclock.h"
+#ifdef Q_OS_MACOS
+#include "avfenumeratormac.h"
+#endif
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/opencv.hpp>
@@ -16,7 +19,9 @@
 
 VideoStreamOCV::VideoStreamOCV(QObject *parent, int width, int height, double pixelClock) :
     VideoStreamBase(parent),
+    m_cameraID(-1),
     m_deviceName(""),
+    cam(nullptr),
     m_stopStreaming(false),
     m_headOrientationStreamState(false),
     m_headOrientationFilterState(false),
@@ -32,13 +37,43 @@ VideoStreamOCV::VideoStreamOCV(QObject *parent, int width, int height, double pi
 
 VideoStreamOCV::~VideoStreamOCV() {
     qDebug() << "Closing video stream";
-    if (cam->isOpened())
+    if (cam != nullptr && cam->isOpened())
         cam->release();
+#ifdef Q_OS_MACOS
+    m_grabber.release();
+#endif
 }
 
 int VideoStreamOCV::connect2Camera(int cameraID) {
     int connectionState = 0;
     m_cameraID = cameraID;
+
+#ifdef Q_OS_MACOS
+    // OpenCV's AVFoundation backend can only open a camera by LIST INDEX, and
+    // macOS reshuffles that list as devices come and go - after a disconnect,
+    // an index reopen can silently bind a different physical camera. Resolve
+    // the config's deviceID to the camera's stable uniqueID once, here, and
+    // pin the capture session to it (same approach as the Miniscope's hybrid
+    // backend in videostreammac.cpp).
+    const WebcamTarget target = resolveWebcamTarget(enumerateAvfCameras(), cameraID);
+    if (!target.ok) {
+        sendMessage("Error: " + m_deviceName + ": " + target.error);
+        qDebug() << m_deviceName << "webcam resolve failed:" << target.error;
+        return 0;
+    }
+    if (!m_grabber.open(target.uniqueID, qMax(0, m_expectedWidth), qMax(0, m_expectedHeight))) {
+        sendMessage("Error: could not open the video stream for " + m_deviceName +
+                    " (" + m_grabber.lastError() + ")");
+        return 0;
+    }
+    m_avfUniqueID = target.uniqueID;
+    m_avfName = target.name;
+    m_connectionType = "AVF";
+    qDebug().nospace() << m_deviceName << " pinned to \"" << m_avfName
+                       << "\" uniqueID " << m_avfUniqueID;
+    return 1;
+#endif
+
     cam = new cv::VideoCapture;
 
     auto apiPreference = cv::CAP_ANY;
@@ -126,7 +161,14 @@ void VideoStreamOCV::startStream()
 
     m_stopStreaming = false;
 
-    if (cam->isOpened()) {
+    bool streamOpen = (cam != nullptr && cam->isOpened());
+#ifdef Q_OS_MACOS
+    int reconnectAttempts = 0;
+    if (m_connectionType == "AVF")
+        streamOpen = m_grabber.isOpened();
+#endif
+
+    if (streamOpen) {
         m_isStreaming = true;
         forever {
 
@@ -137,6 +179,34 @@ void VideoStreamOCV::startStream()
 
             status = true;
             // Get new frame and handle disconnects
+#ifdef Q_OS_MACOS
+            if (m_connectionType == "AVF") {
+                if (!m_grabber.read(frame)) {
+                    status = false;
+                    // Message on the FIRST failure of a stall episode; later
+                    // attempts back off quietly (a device that fell off the
+                    // bus can take a while to come back).
+                    if (reconnectAttempts == 0)
+                        sendMessage("Warning: " + m_deviceName + " grab frame failed. Attempting to reconnect.");
+                    reconnectAttempts++;
+                    m_grabber.release();
+                    QThread::msleep(qMin(1000 * reconnectAttempts, 5000));
+                    QCoreApplication::processEvents();   // keep stopSteam() deliverable while down
+                    if (m_stopStreaming)
+                        continue;
+                    if (attemptReconnect()) {
+                        sendMessage("Warning: " + m_deviceName + " reconnected (after " +
+                                    QString::number(reconnectAttempts) + " attempts).");
+                        reconnectAttempts = 0;
+                    }
+                }
+                else {
+                    timestamp = monotonicTimeMs();
+                    reconnectAttempts = 0;
+                }
+            }
+            else
+#endif
             if (m_connectionType != "videoFile") {
                 // Try to get frame from camera
                 if (!cam->grab()) {
@@ -221,7 +291,10 @@ void VideoStreamOCV::startStream()
                         cv::cvtColor(frame, frameBuffer[bufIdx], cv::COLOR_BGR2GRAY);
                     }
 
-                    if (m_trackExtTrigger) {
+                    // Control-property reads below go through cv::VideoCapture;
+                    // in the AVF path there is none (cam stays nullptr) and
+                    // AVFoundation exposes no UVC controls anyway.
+                    if (m_trackExtTrigger && cam != nullptr) {
                         if (extTriggerLast == -1) {
                             // first time grabbing trigger state.
                             extTriggerLast = cam->get(cv::CAP_PROP_GAMMA);
@@ -243,7 +316,7 @@ void VideoStreamOCV::startStream()
                         }
                     }
 
-                    if (m_headOrientationStreamState) {
+                    if (m_headOrientationStreamState && cam != nullptr) {
                         // BNO output is a unit quaternion after 2^14 division
                         MiniscopeProtocol::unpackBnoQuaternion(
                             static_cast<qint16>(cam->get(cv::CAP_PROP_SATURATION)),
@@ -252,7 +325,7 @@ void VideoStreamOCV::startStream()
                             static_cast<qint16>(cam->get(cv::CAP_PROP_BRIGHTNESS)),
                             &bnoBuffer[bufIdx*5]);
                     }
-                    if (daqFrameNum != nullptr) {
+                    if (daqFrameNum != nullptr && cam != nullptr) {
                         *daqFrameNum = cam->get(cv::CAP_PROP_CONTRAST) - daqFrameNumOffset;
                         if (*m_acqFrameNum == 0) // Used to initially sync daqFrameNum with acqFrameNum
                             daqFrameNumOffset = *daqFrameNum - 1;
@@ -271,7 +344,11 @@ void VideoStreamOCV::startStream()
             if (!m_commandQueue.isEmpty())
                 sendCommands(); // Send last of each control property events that arrived on this processEvent() call then removes it from queue
         }
-        cam->release();
+        if (cam != nullptr)
+            cam->release();
+#ifdef Q_OS_MACOS
+        m_grabber.release();
+#endif
     }
     else {
         sendMessage("Error: Could not connect to video stream " + QString::number(m_cameraID));
@@ -297,21 +374,21 @@ void VideoStreamOCV::setExtTriggerTrackingState(bool state)
 
 void VideoStreamOCV::startRecording()
 {
-    if (cam->isOpened()){
+    if (cam != nullptr && cam->isOpened()){
         cam->set(cv::CAP_PROP_SATURATION, 0x0001);
     }
 }
 
 void VideoStreamOCV::stopRecording()
 {
-    if (cam->isOpened()){
+    if (cam != nullptr && cam->isOpened()){
         cam->set(cv::CAP_PROP_SATURATION, 0x0000);
     }
 }
 
 void VideoStreamOCV::openCamPropsDialog()
 {
-    if (cam->isOpened()){
+    if (cam != nullptr && cam->isOpened()){
         cam->set(cv::CAP_PROP_SETTINGS, 0);
     }
 }
@@ -348,6 +425,14 @@ static int capPropForSelector(quint8 selector)
 
 void VideoStreamOCV::sendCommands()
 {
+    if (cam == nullptr) {
+        // AVF path: AVFoundation exposes no UVC controls, so there is no
+        // control channel to deliver queued commands to. Empty the queue
+        // rather than leave it growing.
+        m_commandQueue.flush([](quint8, quint16) { return true; });
+        qDebug() << m_deviceName << "dropped queued device commands (no control channel on this backend)";
+        return;
+    }
     if (!m_commandQueue.flush([this](quint8 sel, quint16 word) {
             return camSetProperty(cam, capPropForSelector(sel), word);
         }))
@@ -356,6 +441,30 @@ void VideoStreamOCV::sendCommands()
 
 bool VideoStreamOCV::attemptReconnect()
 {
+#ifdef Q_OS_MACOS
+    if (m_connectionType == "AVF") {
+        // Re-resolve by uniqueID, NEVER by index: the camera list may have
+        // reshuffled while we were down, and an index reopen can bind a
+        // different physical camera. Either the same physical camera is back
+        // (replug on the same port keeps its uniqueID) or we keep failing
+        // loudly until it is.
+        const auto cameras = enumerateAvfCameras();
+        bool present = false;
+        for (const AvfCameraInfo &c : cameras) {
+            if (c.uniqueID == m_avfUniqueID) {
+                present = true;
+                break;
+            }
+        }
+        if (!present) {
+            qDebug().nospace() << m_deviceName << ": camera \"" << m_avfName
+                               << "\" (uniqueID " << m_avfUniqueID
+                               << ") is no longer connected; waiting for it to return.";
+            return false;
+        }
+        return m_grabber.open(m_avfUniqueID, qMax(0, m_expectedWidth), qMax(0, m_expectedHeight));
+    }
+#endif
     // TODO: handle quitting nicely when stuck in this loop
     if (m_connectionType == "DSHOW") {
         if (!cam->open(m_cameraID, cv::CAP_DSHOW))

--- a/source/videostreamocv.h
+++ b/source/videostreamocv.h
@@ -16,6 +16,10 @@
 #include "miniscopeprotocol.h"
 #include "videostreambase.h"
 
+#ifdef Q_OS_MACOS
+#include "avfframegrabbermac.h"
+#endif
+
 
 class VideoStreamOCV : public VideoStreamBase
 {
@@ -74,6 +78,15 @@ private:
     double m_pixelClock;
 
     QString m_connectionType;
+
+#ifdef Q_OS_MACOS
+    // Live cameras on macOS stream through AVFoundation pinned to the
+    // device's uniqueID (m_connectionType == "AVF"); cv::VideoCapture is only
+    // used for video-file playback there. See connect2Camera.
+    AvfFrameGrabber m_grabber;
+    QString m_avfUniqueID;
+    QString m_avfName;
+#endif
 
     double m_playbackFPS;
     QString m_playbackFolderPath;

--- a/tests/tst_avfenumerator.cpp
+++ b/tests/tst_avfenumerator.cpp
@@ -20,6 +20,9 @@ private slots:
     void resolveRefusesToGuessAmongSeveral();
     void resolveFailsWithNoneAttached();
     void uniqueIdForLocationIgnoresListOrder();
+    void webcamTargetResolvesByIndex();
+    void webcamTargetFailsOutOfRange();
+    void webcamTargetFailsWithNoCameras();
 };
 
 void TestAvfEnumerator::parseUsbUniqueId()
@@ -170,6 +173,57 @@ void TestAvfEnumerator::uniqueIdForLocationIgnoresListOrder()
     // Unknown location / no location resolved -> empty (caller errors out).
     QVERIFY(avfUniqueIdForLocation(shifted, 0x00990000).isEmpty());
     QVERIFY(avfUniqueIdForLocation(shifted, 0).isEmpty());
+}
+
+// --- resolveWebcamTarget: behavior-webcam deviceID -> uniqueID pin -----------
+// Behavior cams are configured by list index; the resolve happens ONCE at
+// connect and every reconnect is by uniqueID. These pin the index->uniqueID
+// step; the never-rebind-by-index property is enforced in
+// VideoStreamOCV::attemptReconnect (only reopens m_avfUniqueID).
+
+void TestAvfEnumerator::webcamTargetResolvesByIndex()
+{
+    AvfCameraInfo builtin;
+    builtin.name = QStringLiteral("FaceTime HD Camera");
+    builtin.uniqueID = QStringLiteral("1F06D5FF-4C76-410E-9770-C04C467C1317");
+    const QVector<AvfCameraInfo> cams = {builtin,
+                                         usbCam("HD Web Camera", 0x00100000, 0x05a3, 0x9331)};
+    // uniqueID assigned after usbCam(): the helper doesn't set one.
+    QVector<AvfCameraInfo> full = cams;
+    full[1].uniqueID = QStringLiteral("0x0010000005a39331");
+
+    const auto t0 = resolveWebcamTarget(full, 0);
+    QVERIFY(t0.ok);
+    QCOMPARE(t0.uniqueID, builtin.uniqueID);
+    QCOMPARE(t0.name, builtin.name);
+
+    const auto t1 = resolveWebcamTarget(full, 1);
+    QVERIFY(t1.ok);
+    QCOMPARE(t1.uniqueID, QStringLiteral("0x0010000005a39331"));
+}
+
+void TestAvfEnumerator::webcamTargetFailsOutOfRange()
+{
+    // A stale deviceID (camera unplugged since the config was written) must
+    // fail loudly with the currently-visible cameras listed - never fall back
+    // to "whatever is at another index".
+    QVector<AvfCameraInfo> cams = {usbCam("HD Web Camera", 0x00100000, 0x05a3, 0x9331)};
+    cams[0].uniqueID = QStringLiteral("0x0010000005a39331");
+
+    const auto high = resolveWebcamTarget(cams, 3);
+    QVERIFY(!high.ok);
+    QVERIFY(high.error.contains(QStringLiteral("out of range")));
+    QVERIFY(high.error.contains(QStringLiteral("HD Web Camera")));
+
+    const auto negative = resolveWebcamTarget(cams, -1);
+    QVERIFY(!negative.ok);
+}
+
+void TestAvfEnumerator::webcamTargetFailsWithNoCameras()
+{
+    const auto t = resolveWebcamTarget({}, 0);
+    QVERIFY(!t.ok);
+    QVERIFY(!t.error.isEmpty());
 }
 
 QTEST_MAIN(TestAvfEnumerator)


### PR DESCRIPTION
## What

Behavior cameras on macOS now stream through the same AVFoundation frame grabber the Miniscope hybrid backend uses, pinned to the camera's stable `uniqueID` instead of opened by OpenCV list index.

- The config's `deviceID` (an index into the AVFoundation camera list — same order `Scan Devices` shows) is resolved to the camera's `uniqueID` **once at connect** (`resolveWebcamTarget`, unit-tested).
- Reconnects after a drop re-resolve **by uniqueID only, never by index**: either the same physical camera is back (a replug on the same port keeps its uniqueID) or the stream keeps reporting `camera ... is no longer connected; waiting for it to return`.
- A stale/out-of-range `deviceID` fails loudly at connect, listing the cameras that *are* visible.
- Video-file playback keeps the OpenCV path; Windows/Linux behavior is unchanged.

## Why

macOS reshuffles the camera list whenever devices come and go (hot-plugs, iPhone Continuity Camera). The old reconnect-by-index could silently rebind to a **different physical camera** — the "ghost reconnect" where a session quietly continues on the built-in camera after a behavior cam hiccup.

Also fixes a latent crash: `cam` was never null-initialized, so destroying a `VideoStreamOCV` that never connected dereferenced a garbage pointer.

## Bench validation (this machine, HD Web Camera + built-in FaceTime as decoy)

- deviceID 1 pinned to `"HD Web Camera" uniqueID 0x210000005a39331` — not the built-in camera at index 0
- Unplugged mid-recording: honest `no longer connected; waiting for it to return`, **no rebind** to the FaceTime camera
- Replugged same port: stream resumed into the same recording — 111 CSV rows == 111 avi frames, outage visible as an 11.3 s timestamp gap
- Separate run on the built-in camera (opaque non-USB UUID): 348 CSV rows == 348 avi frames at the requested 640×480

## Tests

Three new cases in `tst_avfenumerator`: index resolves to the right uniqueID/name, out-of-range deviceID fails with the visible cameras listed, empty camera list fails. Full suite: 8/8 pass.