### PR TITLE
QML: null-guard backend and parent bindings (R7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,10 @@ published together from CI.
   selected; stale mouse handlers removed.
 - macOS: leaked an IOKit service handle when a device exposed multiple
   VideoControl interfaces ([#85](https://github.com/Aharoni-Lab/Miniscope-DAQ-QT-Software/pull/85)).
+- Quitting (and window creation) no longer spams QML `TypeError` messages to
+  the console: every declarative `backend`/`parent` binding is null-guarded
+  against the teardown/startup window where the referenced object doesn't
+  exist yet or anymore.
 
 ## [1.11] and earlier
 

--- a/source/AddDeviceDialog.qml
+++ b/source/AddDeviceDialog.qml
@@ -77,8 +77,8 @@ Dialog {
             // Only the types valid for the category chosen above, filtered by the
             // backend from deviceConfigs/videoDevices.json. Re-evaluates whenever
             // the category changes.
-            model: backend.deviceTypesForCategory(
-                       catCombo.currentText === "Miniscope" ? "miniscopes" : "cameras")
+            model: backend ? backend.deviceTypesForCategory(
+                       catCombo.currentText === "Miniscope" ? "miniscopes" : "cameras") : []
         }
 
         Label { text: "Device ID"; font.pointSize: 12 }

--- a/source/ControlPanel.qml
+++ b/source/ControlPanel.qml
@@ -5,8 +5,10 @@ import QtQuick.Layouts 1.12
 Item {
     id: root
     objectName: "root"
-    width: parent.width
-    height: parent.height
+    // parent is briefly null while the QQuickView wires the root item up
+    // (and again at teardown); unguarded parent.width spammed TypeErrors.
+    width: parent ? parent.width : 0
+    height: parent ? parent.height : 0
 
     property double currentRecordTime: 0
     property double ucRecordLength: 1
@@ -209,7 +211,9 @@ Item {
                                     property var validAll : RegularExpressionValidator{}  // Qt6: RegExpValidator removed
                                     width: parent.width - 10
                                     height:30
-                                    text: root.ucValues[index]
+                                    // undefined while ucValues is still being
+                                    // populated ("Unable to assign [undefined]").
+                                    text: root.ucValues[index] === undefined ? "" : "" + root.ucValues[index]
                                     anchors.horizontalCenter: parent.horizontalCenter
                                     anchors.top: parent.top
                                     anchors.topMargin: 25

--- a/source/Miniscope_V3.qml
+++ b/source/Miniscope_V3.qml
@@ -7,8 +7,8 @@ import QtQuick.Layouts 1.3
 Item {
     id: root
     objectName: "root"
-    width: parent.width
-    height: parent.height
+    width: parent ? parent.width : 0
+    height: parent ? parent.height : 0
     state: "controlsShown"
     focus: true
     signal vidPropChangedSignal(string name, double displayValue, double i2cValue, double i2cValue2)

--- a/source/Miniscope_V4.qml
+++ b/source/Miniscope_V4.qml
@@ -7,8 +7,8 @@ import QtQuick.Layouts 1.3
 Item {
     id: root
     objectName: "root"
-    width: parent.width
-    height: parent.height
+    width: parent ? parent.width : 0
+    height: parent ? parent.height : 0
     state: "controlsShown"
     focus: true
     signal vidPropChangedSignal(string name, double displayValue, double i2cValue)

--- a/source/Miniscope_V4_BNO.qml
+++ b/source/Miniscope_V4_BNO.qml
@@ -7,8 +7,8 @@ import QtQuick.Layouts 1.3
 Item {
     id: root
     objectName: "root"
-    width: parent.width
-    height: parent.height
+    width: parent ? parent.width : 0
+    height: parent ? parent.height : 0
     state: "controlsShown"
     focus: true
     signal vidPropChangedSignal(string name, double displayValue, double i2cValue, double i2cValue2)

--- a/source/TraceDisplayWindow.qml
+++ b/source/TraceDisplayWindow.qml
@@ -7,8 +7,8 @@ import QtQuick.Layouts 1.3
 Item {
     id: root
     objectName: "root"
-    width: parent.width
-    height: parent.height
+    width: parent ? parent.width : 0
+    height: parent ? parent.height : 0
 //    focus: true
 //    Keys.onPressed: {
 //        if (event.key == Qt.Key_Left) {

--- a/source/TreeViewerJSON.qml
+++ b/source/TreeViewerJSON.qml
@@ -209,7 +209,10 @@ TreeView {
                     anchors.bottom: parent.bottom
                     font.pointSize: 10
                     // Options: codecs for "compression", colormaps for "lut".
-                    readonly property var choices: valueCell.isLut ? backend.availableLUTs
+                    // backend nulls during app teardown while delegates still
+                    // re-evaluate; guard so quitting doesn't spam TypeErrors.
+                    readonly property var choices: !backend ? []
+                                                  : valueCell.isLut ? backend.availableLUTs
                                                                     : backend.availableCodecs
                     // Current stored value; coerce to string in case the model hands
                     // back a non-string.

--- a/source/behaviorCam.qml
+++ b/source/behaviorCam.qml
@@ -8,8 +8,10 @@ import QtQuick.Layouts 1.3
 Item {
     id: root
     objectName: "root"
-    width: parent.width
-    height: parent.height
+    // parent is briefly null while the QQuickView wires the root item up
+    // (and again at teardown); unguarded parent.width spammed TypeErrors.
+    width: parent ? parent.width : 0
+    height: parent ? parent.height : 0
     state: "controlsShown"
     focus: true
     signal vidPropChangedSignal(string name, double displayValue, double i2cValue, double i2cValue2)

--- a/source/behaviorTracker.qml
+++ b/source/behaviorTracker.qml
@@ -6,8 +6,8 @@ import QtQuick.Layouts 1.3
 Item {
     id: root
     objectName: "root"
-    width: parent.width
-    height: parent.height
+    width: parent ? parent.width : 0
+    height: parent ? parent.height : 0
     focus: true
 
     TrackerDisplay {

--- a/source/main.qml
+++ b/source/main.qml
@@ -67,8 +67,11 @@ Window {
             anchors.fill: parent
 
             TextArea {
-                text: "Miniscope DAQ Software version " + backend.versionNumber + "<br/>" +
-                      "<font color='#555555'>" + backend.buildInfo + "</font><br/> <br/>" +
+                // "backend ? ..." guards on every declarative backend binding in
+                // this file: the context property nulls during app teardown while
+                // bindings can still re-evaluate, which spammed TypeErrors on quit.
+                text: "Miniscope DAQ Software version " + (backend ? backend.versionNumber : "") + "<br/>" +
+                      "<font color='#555555'>" + (backend ? backend.buildInfo : "") + "</font><br/> <br/>" +
                       "Developed by the <a href='https://aharoni-lab.github.io/'>Aharoni Lab</a>, UCLA <br/> " +
                       "Overview of the UCLA Miniscope project: <a href='http://www.miniscope.org'>click here</a> <br/>" +
                       "Miniscope Wiki for newest projects: <a href='https://github.com/Aharoni-Lab/Miniscope-v4/wiki'>click here</a> <br/>" +
@@ -122,7 +125,7 @@ Window {
     MessageDialog {
         id: errorMessageDialogCompression
         title: "User Config File Error"
-        text: "The selected user configuration file contains video compression(s) that are not supported by your computer. Please edit the file so each 'compression' entry is a supported option from the following list: " + backend.availableCodecList
+        text: "The selected user configuration file contains video compression(s) that are not supported by your computer. Please edit the file so each 'compression' entry is a supported option from the following list: " + (backend ? backend.availableCodecList : "")
         onAccepted: {
             visible = false
         }
@@ -265,7 +268,7 @@ Window {
                 font.bold: true
                 font.weight: Font.Normal
                 radius: 10
-                enabled: backend.userConfigOK
+                enabled: backend ? backend.userConfigOK : false
 
                 Layout.minimumWidth: 100
                 Layout.preferredWidth: 200
@@ -371,7 +374,7 @@ Window {
             TreeViewerJSON {
                 id: treeView
                 objectName: "treeView"
-                model: backend.jsonTreeModel
+                model: backend ? backend.jsonTreeModel : null
 
                 visible: false
                 Layout.rowSpan: 4
@@ -432,7 +435,7 @@ Window {
 
             TextArea {
                 id: taConfigDesc
-                text: backend.userConfigDisplay
+                text: backend ? backend.userConfigDisplay : ""
 //                wrapMode: Text.NoWrap
                                 wrapMode: Text.WrapAtWordBoundaryOrAnywhere
                                 //                anchors.fill: parent
@@ -470,7 +473,7 @@ Window {
             radius: 10
             text: "Run"
             // Need a valid config AND at least one device (miniscope or camera).
-            enabled: backend.userConfigOK && backend.hasDevices
+            enabled: backend ? (backend.userConfigOK && backend.hasDevices) : false
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             Layout.preferredHeight: 40
             font.family: "Arial"


### PR DESCRIPTION
## What

Silences the QML `TypeError` spam that appeared on every quit (and a few at startup):

- Every **declarative `backend.*` binding** (`main.qml`, `TreeViewerJSON.qml`, `AddDeviceDialog.qml`) now guards on `backend` — the context property nulls during app teardown while bindings still re-evaluate. The worst offender was the tree editor's per-delegate `availableCodecs` binding (65 errors per quit).
- **Window-root items** (`ControlPanel`, `behaviorCam`, `Miniscope_V3/V4/V4_BNO`, `behaviorTracker`, `TraceDisplayWindow`) guard `parent.width/height` — a QQuickView root's parent is briefly null during window wiring and teardown.
- ControlPanel's `ucValues[index]` text binding coerces `undefined` to `""` (the "Unable to assign [undefined] to QString" x15).

Imperative handlers (onClicked etc.) are untouched — they only run while the backend is alive.

## Validation

Live cycle on macOS (launch → load config → Run → webcam window → quit): **0** TypeError / "Unable to assign" lines in the console, versus ~25 per session before. Exit code 0, clean teardown.