### PR TITLE
R4: consolidate the three capture backends onto a shared stream pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,13 @@ published together from CI.
   `DAQ Frame Number` CSV column so the gap is visible post-hoc.
 - Linux cameras on the OpenCV backend could never reconnect after a drop
   (the V4L2 case was missing from the reconnect path, which retried forever).
+- Quitting while a device was mid-reconnect could crash: the reconnect wait
+  slept longer than shutdown waits for the capture thread, which could then
+  wake and write into freed buffers. The wait now checks the stop flag every
+  100 ms.
+- Control commands issued while a device was disconnected no longer flush
+  ahead of the SERDES mode packets when it reconnects (the mode must be the
+  first traffic on the link; device state is re-sent right after anyway).
 - Device connection errors (wrong `deviceID`, device busy, resolve failures)
   now appear in the message console — they used to be emitted before the
   message log was listening, so only a generic "cannot connect" ever showed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,14 @@ published together from CI.
 - Compiler warnings are on (`-Wall -Wextra` / `/W4`) and the build is
   warning-clean; removed the stale qmake `.pro` file, the tracked
   `My User Configs/` folder, and dead libusb test code.
+- The three capture backends (OpenCV, libuvc, macOS hybrid) now share one
+  per-frame pipeline and one reconnect policy in a common base class instead
+  of three drifting copies. All backends reconnect with **backoff** (1 s
+  doubling to a 5 s cap, one warning per outage instead of one per second —
+  the Windows/Linux paths previously retried in a fixed 1 s spam loop).
+- A camera that starts delivering a different frame size mid-stream (e.g. a
+  reconnect that renegotiated the resolution) has those frames dropped with
+  an error message instead of writing mixed-size frames into the recording.
 
 ### Fixed
 - Quitting the app now stops and joins every worker thread (capture loops,
@@ -146,6 +154,17 @@ published together from CI.
   the console: every declarative `backend`/`parent` binding is null-guarded
   against the teardown/startup window where the referenced object doesn't
   exist yet or anymore.
+- A failed UVC control read used to be indistinguishable from reading the
+  value 0: it could fake an external-trigger edge, fabricate an all-zero
+  head-orientation quaternion, and corrupt the DAQ frame-counter offset for
+  the whole recording if it happened on the first frame. Failed reads are now
+  skipped (trigger), hold the last good value (BNO), and log `-1` in the
+  `DAQ Frame Number` CSV column so the gap is visible post-hoc.
+- Linux cameras on the OpenCV backend could never reconnect after a drop
+  (the V4L2 case was missing from the reconnect path, which retried forever).
+- Device connection errors (wrong `deviceID`, device busy, resolve failures)
+  now appear in the message console — they used to be emitted before the
+  message log was listening, so only a generic "cannot connect" ever showed.
 
 ## [1.11] and earlier
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ set(SOURCES
     source/tracedisplay.cpp
     source/videodevice.cpp
     source/videodisplay.cpp
+    source/videostreambase.cpp
     source/videostreamocv.cpp
     source/videostreamlibuvc.cpp
 )

--- a/source/backend.cpp
+++ b/source/backend.cpp
@@ -1518,6 +1518,10 @@ void backEnd::constructUserConfigGUI()
 
         // Connect send and receive message to textbox in controlPanel
         QObject::connect(miniscope.last(), SIGNAL(sendMessage(QString)), controlPanel, SLOT( receiveMessage(QString)));
+        // Relay messages the constructor emitted before this wiring existed
+        // (connect failures name their cause there).
+        for (const QString &msg : miniscope.last()->takeEarlyMessages())
+            sendMessage(msg);
         // Qt6: connecting to a null receiver dereferences it (r->d_func() reads
         // offset 8 of nullptr) and crashes. traceDisplay is null unless a trace
         // display is configured + enabled, so guard the connection.
@@ -1545,6 +1549,10 @@ void backEnd::constructUserConfigGUI()
 
         // Connect send and receive message to textbox in controlPanel
         QObject::connect(behavCam.last(), SIGNAL(sendMessage(QString)), controlPanel, SLOT( receiveMessage(QString)));
+        // Relay messages the constructor emitted before this wiring existed
+        // (connect failures name their cause there).
+        for (const QString &msg : behavCam.last()->takeEarlyMessages())
+            sendMessage(msg);
 
         if (behavCam.last()->getErrors() != 0) {
             // Errors have occured in creating this object

--- a/source/miniscopeprotocol.h
+++ b/source/miniscopeprotocol.h
@@ -90,6 +90,12 @@ public:
 
     bool isEmpty() const { return m_order.isEmpty(); }
 
+    void clear()
+    {
+        m_order.clear();
+        m_queue.clear();
+    }
+
     // writeWord(selector, word) -> success. Returns false if any write failed.
     template <typename WriteWordFn>
     bool flush(WriteWordFn writeWord)

--- a/source/videodevice.cpp
+++ b/source/videodevice.cpp
@@ -37,6 +37,13 @@ VideoDevice::VideoDevice(QObject *parent, QJsonObject ucDevice, qint64 softwareS
     m_softwareStartTime(softwareStartTime)
 
 {
+    // Hold messages emitted before the backend wires sendMessage to the
+    // control panel - see takeEarlyMessages().
+    QObject::connect(this, &VideoDevice::sendMessage, this, [this](QString msg) {
+        if (m_holdEarlyMessages)
+            m_earlyMessages.append(msg);
+    });
+
     m_roiBoundingBox[0] = -1;
     m_roiBoundingBox[1] = -1;
     m_roiBoundingBox[2] = -1;
@@ -83,6 +90,12 @@ VideoDevice::VideoDevice(QObject *parent, QJsonObject ucDevice, qint64 softwareS
     if (deviceStream == nullptr)
         deviceStream = new VideoStreamOCV(nullptr, devWidth, devHeight, devPixelClock);
     deviceStream->setDeviceName(m_deviceName);
+
+    // Pass send message signal through. Wired BEFORE connect2Camera/connect2Video
+    // so connect-time errors (wrong deviceID, device busy, resolve failures)
+    // actually reach the UI instead of vanishing - historically only the
+    // generic "cannot connect" message ever showed.
+    QObject::connect(deviceStream, &VideoStreamBase::sendMessage, this, &VideoDevice::sendMessage);
 
     // Checks to make sure user config and miniscope device type are supporting BNO streaming
     if (m_ucDevice.contains("headOrientation")) {
@@ -137,9 +150,6 @@ VideoDevice::VideoDevice(QObject *parent, QJsonObject ucDevice, qint64 softwareS
     //    QObject::connect(miniscopeStream, SIGNAL (finished()), videoStreamThread, SLOT (quit()));
     //    QObject::connect(miniscopeStream, SIGNAL (finished()), miniscopeStream, SLOT (deleteLater()));
         QObject::connect(videoStreamThread, SIGNAL (finished()), videoStreamThread, SLOT (deleteLater()));
-
-        // Pass send message signal through
-        QObject::connect(deviceStream, &VideoStreamBase::sendMessage, this, &VideoDevice::sendMessage);
 
         // Handle request for reinitialization of commands
         QObject::connect(deviceStream, &VideoStreamBase::requestInitCommands, this, &VideoDevice::handleInitCommandsRequest);
@@ -273,7 +283,7 @@ void VideoDevice::createView()
         // Link up Add Trace ROI signal and slot
         QObject::connect(vidDisplay, &VideoDisplay::newAddTraceROISignal, this, &VideoDevice::handleAddNewTraceROI);
 
-        QObject::connect(view, &NewQuickView::closing, deviceStream, &VideoStreamBase::stopSteam);
+        QObject::connect(view, &NewQuickView::closing, deviceStream, &VideoStreamBase::stopStream);
         QObject::connect(vidDisplay->window(), &QQuickWindow::beforeRendering, this, &VideoDevice::sendNewFrame);
 
         // Keep the ROI overlay tracking the video as the window is resized.
@@ -849,14 +859,22 @@ void VideoDevice::close()
         view->close();
 }
 
+QStringList VideoDevice::takeEarlyMessages()
+{
+    m_holdEarlyMessages = false;
+    const QStringList messages = m_earlyMessages;
+    m_earlyMessages.clear();
+    return messages;
+}
+
 void VideoDevice::stopAndJoinStream()
 {
     if (!m_camConnected || deviceStream == nullptr || videoStreamThread == nullptr)
         return;
-    // Direct call from the GUI thread: stopSteam() only sets the (atomic)
+    // Direct call from the GUI thread: stopStream() only sets the (atomic)
     // stop flag, so this is safe and does not depend on the stream thread's
     // event processing. The stream loop then exits and the thread finishes.
-    deviceStream->stopSteam();
+    deviceStream->stopStream();
     videoStreamThread->quit();
     if (!videoStreamThread->wait(3000))
         qWarning() << m_deviceName << "stream thread did not stop within 3s; leaking it";

--- a/source/videodevice.h
+++ b/source/videodevice.h
@@ -15,6 +15,7 @@
 #include <QQuickItem>
 #include <QVariant>
 #include <QString>
+#include <QStringList>
 
 #include "videostreambase.h"
 #include "videostreamocv.h"
@@ -79,6 +80,12 @@ public:
     QString getDeviceName(){return m_deviceName;}
     int getErrors() { return m_errors; }
     QSize getResolution() {return m_resolution;}
+
+    // Messages emitted during construction (connect2Camera failures etc.)
+    // fire before the backend has wired sendMessage to the control panel, so
+    // the constructor holds them here. The backend takes them right after
+    // wiring and relays them; from then on messages flow directly.
+    QStringList takeEarlyMessages();
 
     virtual void handleNewDisplayFrame(qint64 timeStamp, cv::Mat frame, int f, VideoDisplay* vidDisp);
 
@@ -189,6 +196,10 @@ private:
 
     qint64 m_softwareStartTime;
     bool m_traceDisplayStatus;
+
+    // See takeEarlyMessages().
+    QStringList m_earlyMessages;
+    bool m_holdEarlyMessages = true;
 
     // Display LUT (colormap) selected in the user config: 1=green, 2=red,
     // 3=inferno; the on-window switch toggles between this and 0 (grayscale).

--- a/source/videostreambase.cpp
+++ b/source/videostreambase.cpp
@@ -1,0 +1,223 @@
+#include "videostreambase.h"
+
+#include <QAtomicInt>
+#include <QCoreApplication>
+#include <QDebug>
+#include <QSemaphore>
+#include <QThread>
+
+#include <opencv2/imgproc.hpp>
+
+using namespace MiniscopeProtocol;
+
+VideoStreamBase::VideoStreamBase(QObject *parent, int width, int height, double pixelClock) :
+    QObject(parent),
+    m_expectedWidth(width),
+    m_expectedHeight(height),
+    m_pixelClock(pixelClock)
+{
+    resetStreamState();
+}
+
+void VideoStreamBase::setBufferParameters(cv::Mat *frameBuf, qint64 *tsBuf, float *bnoBuf,
+                                          qint64 *daqFrameNumBuf,
+                                          int bufferSize, QSemaphore *freeFramesS, QSemaphore *usedFramesS,
+                                          QAtomicInt *acqFrameNum, QAtomicInt *daqFrameNumber)
+{
+    frameBuffer = frameBuf;
+    timeStampBuffer = tsBuf;
+    daqFrameNumBuffer = daqFrameNumBuf;
+    bnoBuffer = bnoBuf;
+    frameBufferSize = bufferSize;
+    freeFrames = freeFramesS;
+    usedFrames = usedFramesS;
+    m_acqFrameNum = acqFrameNum;
+    daqFrameNum = daqFrameNumber;
+}
+
+int VideoStreamBase::connect2Video(QString, QString, float)
+{
+    sendMessage("Error: video playback is not supported by this capture backend.");
+    return 0;
+}
+
+void VideoStreamBase::convertToSlot(const cv::Mat &frame, cv::Mat &slot)
+{
+    if (m_isColor)
+        frame.copyTo(slot);
+    else
+        cv::cvtColor(frame, slot, cv::COLOR_BGR2GRAY);
+}
+
+void VideoStreamBase::onFrameCommitted(int, const cv::Mat &, qint64)
+{
+}
+
+void VideoStreamBase::sendCommands()
+{
+    if (!m_commandQueue.flush([this](quint8 sel, quint16 word) { return writeControlWord(sel, word); }))
+        qDebug() << "Send setting failed";
+}
+
+void VideoStreamBase::sendSerdesModeCommands()
+{
+    const auto packets = serdesModePackets(m_pixelClock);
+    if (packets.isEmpty())
+        return;
+    for (int i = 0; i < packets.size(); i++)
+        setPropertyI2C(i, packets[i]);
+    sendCommands();
+    QThread::msleep(500);
+}
+
+void VideoStreamBase::resetStreamState()
+{
+    m_stopStreaming = false;
+    m_streamIdx = 0;
+    m_daqFrameNumOffset = 0;
+    m_daqOffsetSeeded = false;
+    m_extTriggerLast = -1;
+    m_lockedFrameSize = cv::Size();
+    m_sizeMismatchWarned = false;
+    // Zero quaternion with normError 1: frames committed before the first
+    // successful BNO read are flagged corrupted, not passed off as valid.
+    m_lastBnoQuat[0] = m_lastBnoQuat[1] = m_lastBnoQuat[2] = m_lastBnoQuat[3] = 0.0f;
+    m_lastBnoQuat[4] = 1.0f;
+}
+
+void VideoStreamBase::commitFrame(const cv::Mat &frame, qint64 timestampMs)
+{
+    // The ring buffer's consumers (DataSaver, the display path) assume every
+    // slot has the same geometry, so the stream is locked to the size of the
+    // first frame it delivers. A mid-stream size change (e.g. a reconnect
+    // that renegotiated a different resolution) drops frames loudly instead
+    // of corrupting the recording.
+    if (m_lockedFrameSize.empty()) {
+        m_lockedFrameSize = frame.size();
+        if ((m_expectedWidth > 0 && frame.cols != m_expectedWidth) ||
+            (m_expectedHeight > 0 && frame.rows != m_expectedHeight))
+            sendMessage("Warning: " + m_deviceName + " delivers " +
+                        QString::number(frame.cols) + "x" + QString::number(frame.rows) +
+                        " but the config expects " +
+                        QString::number(m_expectedWidth) + "x" + QString::number(m_expectedHeight) +
+                        ". Using the delivered size.");
+    } else if (frame.size() != m_lockedFrameSize) {
+        if (!m_sizeMismatchWarned) {
+            sendMessage("Error: " + m_deviceName + " delivered a " +
+                        QString::number(frame.cols) + "x" + QString::number(frame.rows) +
+                        " frame mid-stream (stream is " +
+                        QString::number(m_lockedFrameSize.width) + "x" +
+                        QString::number(m_lockedFrameSize.height) +
+                        "). Dropping mismatched frames.");
+            m_sizeMismatchWarned = true;
+        }
+        return;
+    } else {
+        m_sizeMismatchWarned = false;
+    }
+
+    // Reserve the ring-buffer slot BEFORE any per-frame work: when the buffer
+    // is full, m_streamIdx % frameBufferSize is the oldest unconsumed slot,
+    // which DataSaver may be reading right now - writing first corrupts the
+    // frame being saved. Acquiring first also skips the per-frame control
+    // reads (~6 ms each on some transports) for frames we are about to drop.
+    if (!freeFrames->tryAcquire()) {
+        // No free slot: this frame is thrown away.
+        if (freeFrames->available() == 0) {
+            sendMessage("Error: " + m_deviceName + " frame buffer is full. Frames will be lost!");
+            QThread::msleep(100);
+        }
+        return;
+    }
+
+    const int bufIdx = m_streamIdx % frameBufferSize;
+    timeStampBuffer[bufIdx] = timestampMs;
+    convertToSlot(frame, frameBuffer[bufIdx]);
+
+    if (m_trackExtTrigger) {
+        quint16 trigger = 0;
+        // A failed read is skipped entirely - treating it as 0 would fake a
+        // trigger edge.
+        if (readControl(SEL_GAMMA, &trigger)) {
+            if (m_extTriggerLast < 0) {
+                m_extTriggerLast = trigger;   // first read only primes the edge detector
+            } else if (m_extTriggerLast != trigger) {
+                emit extTriggered(m_extTriggerLast == 0);
+                m_extTriggerLast = trigger;
+            }
+        }
+    }
+
+    if (m_headOrientationStreamState) {
+        // BNO output is a unit quaternion after a 2^14 division.
+        quint16 quat[4];   // w, x, y, z per kBnoSelectors order
+        bool ok = true;
+        for (int i = 0; i < 4 && ok; i++)
+            ok = readControl(kBnoSelectors[i], &quat[i]);
+        if (ok)
+            unpackBnoQuaternion(qint16(quat[0]), qint16(quat[1]),
+                                qint16(quat[2]), qint16(quat[3]), m_lastBnoQuat);
+        // Failed reads keep the last good quaternion rather than fabricating
+        // an all-zero one.
+        for (int i = 0; i < 5; i++)
+            bnoBuffer[bufIdx * 5 + i] = m_lastBnoQuat[i];
+    }
+
+    bool daqCounterValid = false;
+    if (daqFrameNum != nullptr) {
+        quint16 counter = 0;
+        if (readControl(SEL_CONTRAST, &counter)) {
+            daqCounterValid = true;
+            *daqFrameNum = int(qint16(counter)) - m_daqFrameNumOffset;
+            if (!m_daqOffsetSeeded) {
+                // Sync the DAQ counter to the acquisition count on the first
+                // SUCCESSFUL read (not blindly on frame 0: a failed read there
+                // would poison the offset for the whole recording).
+                m_daqFrameNumOffset = *daqFrameNum - 1;
+                m_daqOffsetSeeded = true;
+            }
+        }
+        // On failure *daqFrameNum keeps its last value; the CSV gets -1 below.
+    }
+    if (daqFrameNumBuffer != nullptr)
+        daqFrameNumBuffer[bufIdx] = (daqFrameNum != nullptr && daqCounterValid)
+                                        ? qint64(daqFrameNum->loadRelaxed())
+                                        : qint64(-1);
+
+    m_acqFrameNum->operator++();
+    const int committedIdx = m_streamIdx;
+    m_streamIdx++;
+    emit newFrameAvailable(m_deviceName, *m_acqFrameNum);
+    usedFrames->release();
+
+    onFrameCommitted(committedIdx, frame, timestampMs);
+}
+
+bool VideoStreamBase::runReconnectCycle(ReconnectBackoff &backoff, const QString &what)
+{
+    if (backoff.firstFailure()) {
+        sendMessage("Warning: " + m_deviceName + " " + what + " failed. Attempting to reconnect.");
+        diagnoseStreamFailure();
+    }
+    QThread::msleep(ulong(backoff.nextDelayMs()));
+    QCoreApplication::processEvents();   // keep stopStream() deliverable while the device is down
+    if (m_stopStreaming)
+        return false;
+    if (attemptReconnect()) {
+        sendMessage("Warning: " + m_deviceName + " reconnected (after " +
+                    QString::number(backoff.attempts()) + " attempts).");
+        qDebug() << "Reconnect to camera" << m_cameraID;
+        backoff.reset();
+        return true;
+    }
+    return false;
+}
+
+void VideoStreamBase::serviceCommandQueue()
+{
+    // Deliver queued cross-thread slot calls (setPropertyI2C, stopStream when
+    // signalled) that arrived while this loop iteration ran.
+    QCoreApplication::processEvents();
+    if (!m_commandQueue.isEmpty())
+        sendCommands();
+}

--- a/source/videostreambase.cpp
+++ b/source/videostreambase.cpp
@@ -64,6 +64,11 @@ void VideoStreamBase::sendSerdesModeCommands()
     const auto packets = serdesModePackets(m_pixelClock);
     if (packets.isEmpty())
         return;
+    // The SERDES mode must be the FIRST traffic after a (re)connect. Drop
+    // anything still queued - e.g. control changes made while the device was
+    // down, which would otherwise flush ahead of these packets - the
+    // requestInitCommands() that follows a reconnect restores device state.
+    m_commandQueue.clear();
     for (int i = 0; i < packets.size(); i++)
         setPropertyI2C(i, packets[i]);
     sendCommands();
@@ -168,7 +173,11 @@ void VideoStreamBase::commitFrame(const cv::Mat &frame, qint64 timestampMs)
         quint16 counter = 0;
         if (readControl(SEL_CONTRAST, &counter)) {
             daqCounterValid = true;
-            *daqFrameNum = int(qint16(counter)) - m_daqFrameNumOffset;
+            // The counter is an UNSIGNED 16-bit register (UVC CONTRAST is
+            // unsigned, unlike the signed BNO registers) - the historical
+            // OpenCV/Windows behavior. Interpreting it as signed would flip
+            // recorded values negative halfway through the wrap period.
+            *daqFrameNum = int(counter) - m_daqFrameNumOffset;
             if (!m_daqOffsetSeeded) {
                 // Sync the DAQ counter to the acquisition count on the first
                 // SUCCESSFUL read (not blindly on frame 0: a failed read there
@@ -199,10 +208,18 @@ bool VideoStreamBase::runReconnectCycle(ReconnectBackoff &backoff, const QString
         sendMessage("Warning: " + m_deviceName + " " + what + " failed. Attempting to reconnect.");
         diagnoseStreamFailure();
     }
-    QThread::msleep(ulong(backoff.nextDelayMs()));
-    QCoreApplication::processEvents();   // keep stopStream() deliverable while the device is down
-    if (m_stopStreaming)
-        return false;
+    // Interruptible backoff: sleep in short slices, delivering queued events
+    // (so a window-close stopStream() lands) and checking the stop flag each
+    // slice. One blind 5 s sleep would outlive stopAndJoinStream()'s 3 s join
+    // timeout, leaving this thread to wake and write into buffers the GUI
+    // thread may already have freed during shutdown.
+    const int delayMs = backoff.nextDelayMs();
+    for (int slept = 0; slept < delayMs; slept += 100) {
+        QThread::msleep(100);
+        QCoreApplication::processEvents();
+        if (m_stopStreaming)
+            return false;
+    }
     if (attemptReconnect()) {
         sendMessage("Warning: " + m_deviceName + " reconnected (after " +
                     QString::number(backoff.attempts()) + " attempts).");

--- a/source/videostreambase.cpp
+++ b/source/videostreambase.cpp
@@ -225,6 +225,14 @@ bool VideoStreamBase::runReconnectCycle(ReconnectBackoff &backoff, const QString
                     QString::number(backoff.attempts()) + " attempts).");
         qDebug() << "Reconnect to camera" << m_cameraID;
         backoff.reset();
+        // The device may have power-cycled, resetting its hardware frame
+        // counter - a stale offset would leave the CSV's DAQ Frame Number
+        // column nonsensical (e.g. negative) for the rest of the recording.
+        // Re-seed on the next successful read, exactly like at stream start:
+        // the column restarts at the raw value then counts 2, 3, ... and the
+        // reset stays visible post-hoc at the reconnect boundary.
+        m_daqOffsetSeeded = false;
+        m_daqFrameNumOffset = 0;
         return true;
     }
     return false;

--- a/source/videostreambase.cpp
+++ b/source/videostreambase.cpp
@@ -10,6 +10,8 @@
 
 using namespace MiniscopeProtocol;
 
+Q_LOGGING_CATEGORY(msDiag, "miniscope.diag")
+
 VideoStreamBase::VideoStreamBase(QObject *parent, int width, int height, double pixelClock) :
     QObject(parent),
     m_expectedWidth(width),
@@ -49,8 +51,19 @@ void VideoStreamBase::convertToSlot(const cv::Mat &frame, cv::Mat &slot)
         cv::cvtColor(frame, slot, cv::COLOR_BGR2GRAY);
 }
 
-void VideoStreamBase::onFrameCommitted(int, const cv::Mat &, qint64)
+void VideoStreamBase::onFrameCommitted(int streamIdx, const cv::Mat &frame, qint64 timestampMs)
 {
+    // Heartbeat every 100 frames: proves the loop is alive in lab logs and
+    // gives a per-frame-rate DAQ counter sample without any extra register
+    // traffic. Skipped for devices with no counter (video playback, webcams
+    // without a control channel).
+    if (streamIdx % 100 != 0 || daqFrameNum == nullptr)
+        return;
+    qCInfo(msDiag).nospace()
+        << m_deviceName << (streamIdx == 0 ? " first frame: " : " heartbeat: ")
+        << frame.cols << "x" << frame.rows << " acqFrame=" << streamIdx
+        << " daqFrameCounter=" << (daqFrameNum->loadRelaxed() + m_daqFrameNumOffset)
+        << " ts=" << timestampMs;
 }
 
 void VideoStreamBase::sendCommands()

--- a/source/videostreambase.h
+++ b/source/videostreambase.h
@@ -1,9 +1,9 @@
 #ifndef VIDEOSTREAMBASE_H
 #define VIDEOSTREAMBASE_H
 
+#include <atomic>
 #include <QObject>
 #include <QString>
-#include <QThread>
 #include <QVector>
 #include <opencv2/core/core.hpp>
 
@@ -12,41 +12,84 @@
 class QSemaphore;
 class QAtomicInt;
 
+// Reconnect pacing shared by every backend's stream loop: message/diagnose on
+// the FIRST failure of an episode only, then back off 1 s, 2 s, ... capped at
+// 5 s (a device that fell off the bus can take a while to come back, and every
+// retry already logs). Pure state - pinned down in tst_videostreambase.
+class ReconnectBackoff
+{
+public:
+    bool firstFailure() const { return m_attempts == 0; }
+    int attempts() const { return m_attempts; }
+    // Registers one failed attempt and returns how long to sleep before retrying.
+    int nextDelayMs()
+    {
+        m_attempts++;
+        return m_attempts < 5 ? 1000 * m_attempts : 5000;
+    }
+    void reset() { m_attempts = 0; }
+
+private:
+    int m_attempts = 0;
+};
+
 // Abstract capture-backend interface for a single video device.
 //
-// Two concrete backends implement this:
+// Three concrete backends implement this:
 //   * VideoStreamOCV     - OpenCV VideoCapture (V4L2 on Linux, DirectShow on
-//                          Windows). Used for all devices on Windows and for
-//                          webcam / behaviour cameras everywhere.
+//                          Windows). Used for all devices on Windows, for
+//                          behaviour cameras everywhere, and for video-file
+//                          playback. On macOS live cameras stream through an
+//                          AVFoundation grabber pinned to the device uniqueID.
 //   * VideoStreamLibUVC  - libuvc/libusb direct UVC access (Linux only). Used
 //                          for Miniscopes on Linux, where the kernel uvcvideo
 //                          driver caches UVC control reads and so cannot return
 //                          the live frame counter / BNO head-orientation
 //                          registers that the Miniscope streams back through
 //                          GET_CUR. A fresh libuvc GET_CUR bypasses that cache.
+//   * VideoStreamMac     - AVFoundation frames + IOKit pipe-0 control
+//                          requests (macOS only). Used for Miniscopes on
+//                          macOS, where AVFoundation exposes no UVC controls
+//                          and owning the whole device needs root.
 //
 // VideoDevice owns one of these, moves it to its own QThread, and talks to it
 // purely through this interface (direct calls + queued signals/slots), so the
 // backend is interchangeable.
+//
+// The backends differ only in transport: how a frame is acquired, how a UVC
+// Processing-Unit control is read/written, and how a dead device is reopened.
+// Everything that happens between acquiring a frame and handing it to the
+// rest of the app - ring-buffer slot bookkeeping, timestamps, external
+// trigger edges, BNO quaternion capture, the DAQ hardware frame counter -
+// lives here in commitFrame(), so it cannot drift between platforms again.
 class VideoStreamBase : public QObject
 {
     Q_OBJECT
 public:
-    explicit VideoStreamBase(QObject *parent = nullptr) : QObject(parent) {}
+    explicit VideoStreamBase(QObject *parent = nullptr,
+                             int width = 0, int height = 0, double pixelClock = 0);
     ~VideoStreamBase() override = default;
 
     // daqFrameNumBuf: per-slot copy of the DAQ hardware frame counter at the
     // moment each frame was acquired, so DataSaver can log it per frame in
-    // timeStamps.csv (makes USB frame loss detectable post-hoc).
-    virtual void setBufferParameters(cv::Mat *frameBuf, qint64 *tsBuf, float *bnoBuf,
-                                     qint64 *daqFrameNumBuf,
-                                     int bufferSize, QSemaphore *freeFramesS, QSemaphore *usedFramesS,
-                                     QAtomicInt *acqFrameNum, QAtomicInt *daqFrameNumber) = 0;
+    // timeStamps.csv (makes USB frame loss detectable post-hoc). Slots whose
+    // counter could not be read hold -1.
+    void setBufferParameters(cv::Mat *frameBuf, qint64 *tsBuf, float *bnoBuf,
+                             qint64 *daqFrameNumBuf,
+                             int bufferSize, QSemaphore *freeFramesS, QSemaphore *usedFramesS,
+                             QAtomicInt *acqFrameNum, QAtomicInt *daqFrameNumber);
     virtual int connect2Camera(int cameraID) = 0;
-    virtual int connect2Video(QString folderPath, QString filePrefix, float playbackFPS) = 0;
-    virtual void setHeadOrientationConfig(bool enableState, bool filterState) = 0;
-    virtual void setIsColor(bool isColor) = 0;
-    virtual void setDeviceName(QString name) = 0;
+    // Default: not supported (video-file playback always uses the OpenCV
+    // backend, which overrides this).
+    virtual int connect2Video(QString folderPath, QString filePrefix, float playbackFPS);
+    // filterState is consumed by DataSaver, not the capture backends.
+    void setHeadOrientationConfig(bool enableState, bool filterState)
+    {
+        m_headOrientationStreamState = enableState;
+        Q_UNUSED(filterState);
+    }
+    void setIsColor(bool isColor) { m_isColor = isColor; }
+    void setDeviceName(QString name) { m_deviceName = name; }
 
 signals:
     void sendMessage(QString msg);
@@ -56,31 +99,102 @@ signals:
 
 public slots:
     virtual void startStream() = 0;
-    virtual void stopSteam() = 0;
-    virtual void setPropertyI2C(long preambleKey, QVector<quint8> packet) = 0;
-    virtual void setExtTriggerTrackingState(bool state) = 0;
+    void stopStream() { m_stopStreaming = true; }
+    // A newer packet for the same preamble key replaces the unsent older one.
+    void setPropertyI2C(long preambleKey, QVector<quint8> packet)
+    {
+        m_commandQueue.set(preambleKey, packet);
+    }
+    void setExtTriggerTrackingState(bool state) { m_trackExtTrigger = state; }
     virtual void startRecording() = 0;
     virtual void stopRecording() = 0;
-    virtual void openCamPropsDialog() = 0;
+    // OpenCV/DirectShow-only feature (behaviour cameras); no-op elsewhere.
+    virtual void openCamPropsDialog() {}
 
 protected:
-    // Flush queued I2C command packets to the device (transport-specific:
-    // UVC SET_CUR on libuvc/macOS, CAP_PROP passthrough on OpenCV).
-    virtual void sendCommands() = 0;
+    // ---- per-backend transport hooks -------------------------------------
+    // Write one 16-bit word to a UVC Processing-Unit control (the I2C tunnel).
+    virtual bool writeControlWord(quint8 selector, quint16 word) = 0;
+    // Fresh GET_CUR of a Processing-Unit control. MUST return false when the
+    // value could not be read - a fabricated 0 is indistinguishable from data
+    // (it fakes trigger edges and corrupts the DAQ counter offset).
+    virtual bool readControl(quint8 selector, quint16 *value) = 0;
+    // Reopen a dead device, restoring SERDES mode and init commands. Called
+    // from runReconnectCycle after the backoff sleep.
+    virtual bool attemptReconnect() = 0;
+    // Write the acquired frame into a ring-buffer slot. Default handles the
+    // BGR backends (copy when color, BGR2GRAY otherwise); libuvc overrides
+    // for its raw-YUYV frames.
+    virtual void convertToSlot(const cv::Mat &frame, cv::Mat &slot);
+    // Called once per committed frame, after the slot is published. Backends
+    // may log diagnostics here (never issue a control read for it - reuse
+    // daqFrameNum / m_daqFrameNumOffset).
+    virtual void onFrameCommitted(int streamIdx, const cv::Mat &frame, qint64 timestampMs);
+    // Called on the first failure of a reconnect episode, right after the
+    // user-facing warning. Backends may run stall diagnostics here.
+    virtual void diagnoseStreamFailure() {}
+
+    // ---- shared machinery -------------------------------------------------
+    // Flush queued I2C command packets through writeControlWord.
+    virtual void sendCommands();
 
     // Queue + flush the pixel-clock dependent SERDES setup packets, then let
     // the video link settle. One shared copy of this order-critical connect
     // ritual - the pre-refactor code had four inline copies that had drifted.
-    void sendSerdesModeCommands(double pixelClock)
-    {
-        const auto packets = MiniscopeProtocol::serdesModePackets(pixelClock);
-        if (packets.isEmpty())
-            return;
-        for (int i = 0; i < packets.size(); i++)
-            setPropertyI2C(i, packets[i]);
-        sendCommands();
-        QThread::msleep(500);
-    }
+    void sendSerdesModeCommands();
+
+    // Reset all per-run stream-loop state. Call at the top of startStream().
+    void resetStreamState();
+
+    // The shared per-frame block: enforce the frame size, reserve a ring-buffer
+    // slot, stamp/convert/read into it, publish it. Safe to call with any
+    // frame the backend acquired; drops (with a message) when the buffer is
+    // full or the size stops matching the locked stream size.
+    void commitFrame(const cv::Mat &frame, qint64 timestampMs);
+
+    // One reconnect attempt with shared pacing: first-failure message +
+    // diagnoseStreamFailure(), backoff sleep, keep the event loop alive so
+    // stopStream() can land, then attemptReconnect(). Returns true when the
+    // device is back. `what` names the failed operation ("grab frame").
+    bool runReconnectCycle(ReconnectBackoff &backoff, const QString &what);
+
+    // Deliver queued cross-thread calls (setPropertyI2C etc.) and flush the
+    // command queue. Call once per loop iteration.
+    void serviceCommandQueue();
+
+    // ---- shared state -----------------------------------------------------
+    QString m_deviceName;
+    int m_cameraID = -1;
+
+    std::atomic<bool> m_stopStreaming{false};
+    bool m_headOrientationStreamState = false;
+    bool m_isColor = false;
+    bool m_trackExtTrigger = false;
+
+    int m_expectedWidth;
+    int m_expectedHeight;
+    double m_pixelClock;
+
+    cv::Mat *frameBuffer = nullptr;
+    qint64 *timeStampBuffer = nullptr;
+    qint64 *daqFrameNumBuffer = nullptr;
+    float *bnoBuffer = nullptr;
+    QSemaphore *freeFrames = nullptr;
+    QSemaphore *usedFrames = nullptr;
+    int frameBufferSize = 0;
+    QAtomicInt *m_acqFrameNum = nullptr;
+    QAtomicInt *daqFrameNum = nullptr;
+
+    I2CCommandQueue m_commandQueue;
+
+    // Per-run stream-loop state (owned by commitFrame; reset by resetStreamState).
+    int m_streamIdx = 0;               // frames committed this run (ring-buffer cursor)
+    int m_daqFrameNumOffset = 0;
+    bool m_daqOffsetSeeded = false;
+    int m_extTriggerLast = -1;         // -1 = not primed yet
+    cv::Size m_lockedFrameSize;        // locked to the first committed frame
+    bool m_sizeMismatchWarned = false;
+    float m_lastBnoQuat[5];            // last good {w,x,y,z,normError}
 };
 
 #endif // VIDEOSTREAMBASE_H

--- a/source/videostreambase.h
+++ b/source/videostreambase.h
@@ -2,12 +2,18 @@
 #define VIDEOSTREAMBASE_H
 
 #include <atomic>
+#include <QLoggingCategory>
 #include <QObject>
 #include <QString>
 #include <QVector>
 #include <opencv2/core/core.hpp>
 
 #include "miniscopeprotocol.h"
+
+// Bench diagnostics (per-frame heartbeats, stall verdicts, pin lines) shared
+// by every backend. On by default; silence with
+// QT_LOGGING_RULES="miniscope.diag=false".
+Q_DECLARE_LOGGING_CATEGORY(msDiag)
 
 class QSemaphore;
 class QAtomicInt;
@@ -126,9 +132,10 @@ protected:
     // BGR backends (copy when color, BGR2GRAY otherwise); libuvc overrides
     // for its raw-YUYV frames.
     virtual void convertToSlot(const cv::Mat &frame, cv::Mat &slot);
-    // Called once per committed frame, after the slot is published. Backends
-    // may log diagnostics here (never issue a control read for it - reuse
-    // daqFrameNum / m_daqFrameNumOffset).
+    // Called once per committed frame, after the slot is published. The
+    // default logs a heartbeat to msDiag every 100 frames, reusing the DAQ
+    // counter read commitFrame already did (never issue a control read from
+    // here - they cost ~6 ms on some transports).
     virtual void onFrameCommitted(int streamIdx, const cv::Mat &frame, qint64 timestampMs);
     // Called on the first failure of a reconnect episode, right after the
     // user-facing warning. Backends may run stall diagnostics here.

--- a/source/videostreamlibuvc.cpp
+++ b/source/videostreamlibuvc.cpp
@@ -9,10 +9,8 @@
 using namespace MiniscopeProtocol;   // SEL_* selectors, kProcessingUnitId, VID/PID
 
 #include <QDebug>
-#include <QCoreApplication>
-#include <QDateTime>
+#include <QString>
 #include <QThread>
-#include <QtMath>
 #include <opencv2/imgproc.hpp>
 
 #include <cstdio>
@@ -21,33 +19,12 @@ using namespace MiniscopeProtocol;   // SEL_* selectors, kProcessingUnitId, VID/
 #include <unistd.h>
 
 VideoStreamLibUVC::VideoStreamLibUVC(QObject *parent, int width, int height, double pixelClock) :
-    VideoStreamBase(parent),
-    m_cameraID(-1),
-    m_deviceName(""),
+    VideoStreamBase(parent, width > 0 ? width : 608, height > 0 ? height : 608, pixelClock),
     m_ctx(nullptr),
     m_dev(nullptr),
     m_devh(nullptr),
     m_strmh(nullptr),
-    m_negotiatedFps(0),
-    m_isStreaming(false),
-    m_stopStreaming(false),
-    m_headOrientationStreamState(false),
-    m_headOrientationFilterState(false),
-    m_isColor(false),
-    frameBuffer(nullptr),
-    timeStampBuffer(nullptr),
-    daqFrameNumBuffer(nullptr),
-    bnoBuffer(nullptr),
-    freeFrames(nullptr),
-    usedFrames(nullptr),
-    frameBufferSize(0),
-    m_acqFrameNum(nullptr),
-    daqFrameNum(nullptr),
-    m_trackExtTrigger(false),
-    m_expectedWidth(width > 0 ? width : 608),
-    m_expectedHeight(height > 0 ? height : 608),
-    m_pixelClock(pixelClock),
-    m_connectionType("")
+    m_negotiatedFps(0)
 {
 }
 
@@ -71,22 +48,6 @@ void VideoStreamLibUVC::closeDevice()
     if (m_devh) { uvc_close(m_devh); m_devh = nullptr; } // re-attaches kernel driver
     if (m_dev)  { uvc_unref_device(m_dev); m_dev = nullptr; }
     if (m_ctx)  { uvc_exit(m_ctx); m_ctx = nullptr; }
-}
-
-void VideoStreamLibUVC::setBufferParameters(cv::Mat *frameBuf, qint64 *tsBuf, float *bnoBuf,
-                                            qint64 *daqFrameNumBuf,
-                                            int bufferSize, QSemaphore *freeFramesS, QSemaphore *usedFramesS,
-                                            QAtomicInt *acqFrameNum, QAtomicInt *daqFrameNumber)
-{
-    frameBuffer = frameBuf;
-    timeStampBuffer = tsBuf;
-    daqFrameNumBuffer = daqFrameNumBuf;
-    bnoBuffer = bnoBuf;
-    frameBufferSize = bufferSize;
-    freeFrames = freeFramesS;
-    usedFrames = usedFramesS;
-    m_acqFrameNum = acqFrameNum;
-    daqFrameNum = daqFrameNumber;
 }
 
 // Resolve /dev/video{cameraID} to its USB bus/address by walking sysfs, so we
@@ -193,51 +154,39 @@ int VideoStreamLibUVC::connect2Camera(int cameraID)
         closeDevice();
         return 0;
     }
-    m_connectionType = "libuvc";
-    sendSerdesModeCommands(m_pixelClock);
+    sendSerdesModeCommands();
     return 1;
 }
 
-int VideoStreamLibUVC::connect2Video(QString, QString, float)
-{
-    // Video-file playback always uses the OpenCV backend; not supported here.
-    sendMessage("Error: video playback is not supported by the libuvc backend.");
-    return 0;
-}
-
-bool VideoStreamLibUVC::setPU(quint8 selector, quint16 value)
+bool VideoStreamLibUVC::writeControlWord(quint8 selector, quint16 word)
 {
     uint8_t buf[2];
-    UVCRequest::encodeLE16(value, buf);
+    UVCRequest::encodeLE16(word, buf);
     int r = uvc_set_ctrl(m_devh, kProcessingUnitId, selector, buf, 2);
     usleep(kCtrlSettleUs);   // let the DAQ's slow control endpoint clear the write
     return r == 2;
 }
 
-int VideoStreamLibUVC::getPU(quint8 selector)
+bool VideoStreamLibUVC::readControl(quint8 selector, quint16 *value)
 {
     uint8_t buf[2] = {0, 0};
     int r = uvc_get_ctrl(m_devh, kProcessingUnitId, selector, buf, 2, UVC_GET_CUR);
-    if (r < 0)
-        return 0;
-    return static_cast<qint16>(UVCRequest::decodeLE16(buf));
+    if (r != 2)
+        return false;
+    *value = UVCRequest::decodeLE16(buf);
+    return true;
 }
 
-// Flush queued I2C packets to the device via UVC SET_CUR.
-void VideoStreamLibUVC::sendCommands()
+void VideoStreamLibUVC::convertToSlot(const cv::Mat &frame, cv::Mat &slot)
 {
-    if (!m_commandQueue.flush([this](quint8 sel, quint16 word) { return setPU(sel, word); }))
-        qDebug() << "Send setting failed";
+    // libuvc gives raw YUYV; the Y plane is the Miniscope image.
+    cv::cvtColor(frame, slot, m_isColor ? cv::COLOR_YUV2BGR_YUYV : cv::COLOR_YUV2GRAY_YUYV);
 }
 
 void VideoStreamLibUVC::startStream()
 {
-    int idx = 0;
-    int daqFrameNumOffset = 0;
-    double extTriggerLast = -1;
-    double extTrigger;
-
-    m_stopStreaming = false;
+    resetStreamState();
+    ReconnectBackoff backoff;
 
     if (!m_devh) {
         sendMessage("Error: Could not connect to video stream " + QString::number(m_cameraID));
@@ -255,14 +204,11 @@ void VideoStreamLibUVC::startStream()
     // Enable continuous DAQ data/BNO register refresh (the app gates this on the
     // Record button via SATURATION=1; on Linux we need it live during Run so the
     // head-orientation registers update every frame, not just while recording).
-    setPU(SEL_SATURATION, 0x0001);
+    writeControlWord(SEL_SATURATION, 0x0001);
 
-    m_isStreaming = true;
     forever {
-        if (m_stopStreaming) {
-            m_isStreaming = false;
+        if (m_stopStreaming)
             break;
-        }
 
         uvc_frame_t *frame = nullptr;
         // Timeout in us; ~2 frame periods, min 100ms.
@@ -270,85 +216,19 @@ void VideoStreamLibUVC::startStream()
         uvc_error_t res = uvc_stream_get_frame(m_strmh, &frame, timeoutUs);
 
         if (res < 0 || frame == nullptr || frame->data == nullptr || frame->data_bytes == 0) {
-            // Grab failed - attempt to reconnect, like the OpenCV backend.
-            sendMessage("Warning: " + m_deviceName + " grab frame failed. Attempting to reconnect.");
             closeStream();
-            QThread::msleep(1000);
-            if (attemptReconnect()) {
-                sendMessage("Warning: " + m_deviceName + " reconnected.");
-                qDebug() << "Reconnect to camera" << m_cameraID;
-            }
+            runReconnectCycle(backoff, "grab frame");
             continue;
         }
+        backoff.reset();
 
-        // Reserve a buffer slot BEFORE writing anything into it: when the
-        // buffer is full, idx%frameBufferSize is the oldest unconsumed slot,
-        // which DataSaver may be reading right now - writing first corrupts
-        // the frame being saved. Acquiring first also skips the per-frame
-        // control reads for frames we are about to drop.
-        if (!freeFrames->tryAcquire()) {
-            // No free slot: this frame is thrown away
-            if (freeFrames->available() == 0) {
-                sendMessage("Error: " + m_deviceName + " frame buffer is full. Frames will be lost!");
-                QThread::msleep(100);
-            }
-        } else {
-            const int bufIdx = idx % frameBufferSize;
-            timeStampBuffer[bufIdx] = monotonicTimeMs();
-
-            // libuvc gives raw YUYV; the Y plane is the Miniscope image.
-            cv::Mat yuyv((int)frame->height, (int)frame->width, CV_8UC2, frame->data);
-            if (m_isColor)
-                cv::cvtColor(yuyv, frameBuffer[bufIdx], cv::COLOR_YUV2BGR_YUYV);
-            else
-                cv::cvtColor(yuyv, frameBuffer[bufIdx], cv::COLOR_YUV2GRAY_YUYV);
-
-            if (m_trackExtTrigger) {
-                if (extTriggerLast == -1) {
-                    extTriggerLast = getPU(SEL_GAMMA);
-                } else {
-                    extTrigger = getPU(SEL_GAMMA);
-                    if (extTriggerLast != extTrigger) {
-                        if (extTriggerLast == 0)
-                            emit extTriggered(true);
-                        else
-                            emit extTriggered(false);
-                    }
-                    extTriggerLast = extTrigger;
-                }
-            }
-
-            if (m_headOrientationStreamState) {
-                // BNO output is a unit quaternion after a 2^14 division.
-                qint16 quat[4];   // w, x, y, z per kBnoSelectors order
-                for (int i = 0; i < 4; i++)
-                    quat[i] = static_cast<qint16>(getPU(kBnoSelectors[i]));
-                MiniscopeProtocol::unpackBnoQuaternion(quat[0], quat[1], quat[2], quat[3],
-                                                       &bnoBuffer[bufIdx * 5]);
-            }
-
-            if (daqFrameNum != nullptr) {
-                *daqFrameNum = getPU(SEL_CONTRAST) - daqFrameNumOffset;
-                if (*m_acqFrameNum == 0)
-                    daqFrameNumOffset = *daqFrameNum - 1;
-            }
-            if (daqFrameNumBuffer != nullptr)
-                daqFrameNumBuffer[bufIdx] = (daqFrameNum != nullptr) ? qint64(daqFrameNum->loadRelaxed()) : qint64(-1);
-
-            m_acqFrameNum->operator++();
-            idx++;
-            emit newFrameAvailable(m_deviceName, *m_acqFrameNum);
-            usedFrames->release();
-        }
-
-        // Process queued control changes (setPropertyI2C) and flush them.
-        QCoreApplication::processEvents();
-        if (!m_commandQueue.isEmpty())
-            sendCommands();
+        const cv::Mat yuyv(int(frame->height), int(frame->width), CV_8UC2, frame->data);
+        commitFrame(yuyv, monotonicTimeMs());
+        serviceCommandQueue();
     }
-    // Stream loop only exits on stopSteam() (device window closing). Release the
-    // device so uvc_close re-attaches the kernel uvcvideo driver and /dev/videoN
-    // comes back for the next run / for Scan Devices.
+    // Stream loop only exits on stopStream() (device window closing). Release
+    // the device so uvc_close re-attaches the kernel uvcvideo driver and
+    // /dev/videoN comes back for the next run / for Scan Devices.
     closeStream();
     closeDevice();
 }
@@ -361,49 +241,29 @@ bool VideoStreamLibUVC::attemptReconnect()
         return false;
     if (!negotiateFormat())
         return false;
-    sendSerdesModeCommands(m_pixelClock);
+    sendSerdesModeCommands();
     if (uvc_stream_open_ctrl(m_devh, &m_strmh, &m_streamCtrl) < 0 ||
         uvc_stream_start(m_strmh, nullptr, nullptr, 0) < 0) {
         closeStream();
         return false;
     }
-    setPU(SEL_SATURATION, 0x0001);
+    writeControlWord(SEL_SATURATION, 0x0001);
     QThread::msleep(500);
     emit requestInitCommands();
     return true;
-}
-
-void VideoStreamLibUVC::stopSteam()
-{
-    m_stopStreaming = true;
-}
-
-void VideoStreamLibUVC::setPropertyI2C(long preambleKey, QVector<quint8> packet)
-{
-    m_commandQueue.set(preambleKey, packet);
-}
-
-void VideoStreamLibUVC::setExtTriggerTrackingState(bool state)
-{
-    m_trackExtTrigger = state;
 }
 
 void VideoStreamLibUVC::startRecording()
 {
     // Data/BNO streaming is already enabled at stream start; nothing extra needed.
     if (m_devh)
-        setPU(SEL_SATURATION, 0x0001);
+        writeControlWord(SEL_SATURATION, 0x0001);
 }
 
 void VideoStreamLibUVC::stopRecording()
 {
     // Intentionally leave SATURATION=1 so head-orientation stays live during Run
     // after a recording stops. The data stream stops when streaming stops.
-}
-
-void VideoStreamLibUVC::openCamPropsDialog()
-{
-    // OpenCV/DirectShow-only feature (behaviour cameras); not applicable here.
 }
 
 #endif // HAVE_LIBUVC

--- a/source/videostreamlibuvc.h
+++ b/source/videostreamlibuvc.h
@@ -7,9 +7,6 @@
 // frame counter and BNO head-orientation registers can be read on Linux).
 #ifdef HAVE_LIBUVC
 
-#include <atomic>
-#include <QSemaphore>
-#include <QAtomicInt>
 #include <QVector>
 #include <opencv2/core/core.hpp>
 
@@ -25,39 +22,25 @@ public:
     explicit VideoStreamLibUVC(QObject *parent = nullptr, int width = 0, int height = 0, double pixelClock = 0);
     ~VideoStreamLibUVC() override;
 
-    void setBufferParameters(cv::Mat *frameBuf, qint64 *tsBuf, float *bnoBuf,
-                             qint64 *daqFrameNumBuf,
-                             int bufferSize, QSemaphore *freeFramesS, QSemaphore *usedFramesS,
-                             QAtomicInt *acqFrameNum, QAtomicInt *daqFrameNumber) override;
     int connect2Camera(int cameraID) override;
-    int connect2Video(QString folderPath, QString filePrefix, float playbackFPS) override;
-    void setHeadOrientationConfig(bool enableState, bool filterState) override { m_headOrientationStreamState = enableState; m_headOrientationFilterState = filterState; }
-    void setIsColor(bool isColor) override { m_isColor = isColor; }
-    void setDeviceName(QString name) override { m_deviceName = name; }
 
 public slots:
     void startStream() override;
-    void stopSteam() override;
-    void setPropertyI2C(long preambleKey, QVector<quint8> packet) override;
-    void setExtTriggerTrackingState(bool state) override;
     void startRecording() override;
     void stopRecording() override;
-    void openCamPropsDialog() override;
+
+protected:
+    bool writeControlWord(quint8 selector, quint16 word) override;   // uvc_set_ctrl + settle
+    bool readControl(quint8 selector, quint16 *value) override;      // fresh uvc_get_ctrl GET_CUR
+    bool attemptReconnect() override;
+    // Frames arrive as raw YUYV; the base's BGR copy/convert doesn't apply.
+    void convertToSlot(const cv::Mat &frame, cv::Mat &slot) override;
 
 private:
-    // UVC selectors / unit ID / VID+PID come from miniscopeprotocol.h (shared
-    // with the macOS IOKit control transport).
     bool openByVideoIndex(int cameraID);   // resolve /dev/videoN -> USB bus/addr, open via libuvc
     bool negotiateFormat();
-    void sendCommands() override;          // flush queued I2C packets as UVC SET_CUR
-    bool setPU(quint8 selector, quint16 value);
-    int  getPU(quint8 selector);           // fresh GET_CUR, returned as signed 16-bit
-    bool attemptReconnect();
     void closeStream();
     void closeDevice();
-
-    int m_cameraID;
-    QString m_deviceName;
 
     uvc_context_t *m_ctx;
     uvc_device_t *m_dev;
@@ -65,31 +48,6 @@ private:
     uvc_stream_ctrl_t m_streamCtrl;
     uvc_stream_handle_t *m_strmh;
     int m_negotiatedFps;
-
-    std::atomic<bool> m_isStreaming;
-    std::atomic<bool> m_stopStreaming;
-    bool m_headOrientationStreamState;
-    bool m_headOrientationFilterState;
-    bool m_isColor;
-
-    cv::Mat *frameBuffer;
-    qint64 *timeStampBuffer;
-    qint64 *daqFrameNumBuffer;
-    float *bnoBuffer;
-    QSemaphore *freeFrames;
-    QSemaphore *usedFrames;
-    int frameBufferSize;
-    QAtomicInt *m_acqFrameNum;
-    QAtomicInt *daqFrameNum;
-
-    I2CCommandQueue m_commandQueue;
-
-    bool m_trackExtTrigger;
-
-    int m_expectedWidth;
-    int m_expectedHeight;
-    double m_pixelClock;
-    QString m_connectionType;
 };
 
 #endif // HAVE_LIBUVC

--- a/source/videostreammac.cpp
+++ b/source/videostreammac.cpp
@@ -3,11 +3,8 @@
 
 #include <QDebug>
 #include <QCoreApplication>
-#include <QDateTime>
 #include <QLoggingCategory>
 #include <QThread>
-
-#include <opencv2/imgproc.hpp>
 
 #include "avfenumeratormac.h"
 
@@ -18,25 +15,7 @@ using namespace MiniscopeProtocol;
 Q_LOGGING_CATEGORY(msDiag, "miniscope.diag")
 
 VideoStreamMac::VideoStreamMac(QObject *parent, int width, int height, double pixelClock) :
-    VideoStreamBase(parent),
-    m_cameraID(-1),
-    m_deviceName(""),
-    m_stopStreaming(false),
-    m_headOrientationStreamState(false),
-    m_isColor(false),
-    frameBuffer(nullptr),
-    timeStampBuffer(nullptr),
-    daqFrameNumBuffer(nullptr),
-    bnoBuffer(nullptr),
-    freeFrames(nullptr),
-    usedFrames(nullptr),
-    frameBufferSize(0),
-    m_acqFrameNum(nullptr),
-    daqFrameNum(nullptr),
-    m_trackExtTrigger(false),
-    m_expectedWidth(width > 0 ? width : 608),
-    m_expectedHeight(height > 0 ? height : 608),
-    m_pixelClock(pixelClock)
+    VideoStreamBase(parent, width > 0 ? width : 608, height > 0 ? height : 608, pixelClock)
 {
     m_control.setWriteSettleUs(kCtrlSettleUs);
 }
@@ -46,22 +25,6 @@ VideoStreamMac::~VideoStreamMac()
     qDebug() << "Closing macOS hybrid video stream";
     m_grabber.release();
     m_control.close();
-}
-
-void VideoStreamMac::setBufferParameters(cv::Mat *frameBuf, qint64 *tsBuf, float *bnoBuf,
-                                         qint64 *daqFrameNumBuf,
-                                         int bufferSize, QSemaphore *freeFramesS, QSemaphore *usedFramesS,
-                                         QAtomicInt *acqFrameNum, QAtomicInt *daqFrameNumber)
-{
-    frameBuffer = frameBuf;
-    timeStampBuffer = tsBuf;
-    daqFrameNumBuffer = daqFrameNumBuf;
-    bnoBuffer = bnoBuf;
-    frameBufferSize = bufferSize;
-    freeFrames = freeFramesS;
-    usedFrames = usedFramesS;
-    m_acqFrameNum = acqFrameNum;
-    daqFrameNum = daqFrameNumber;
 }
 
 // Resolve the AVFoundation/OpenCV device index to the exact USB device and
@@ -148,7 +111,7 @@ int VideoStreamMac::connect2Camera(int cameraID)
         return 0;
     }
 
-    sendSerdesModeCommands(m_pixelClock);   // ends with its own settle sleep
+    sendSerdesModeCommands();   // ends with its own settle sleep
     return 1;
 }
 
@@ -187,42 +150,28 @@ void VideoStreamMac::logStallDiagnosis()
     sendMessage("Diag: " + m_deviceName + " " + msg);
 }
 
-int VideoStreamMac::connect2Video(QString, QString, float)
+void VideoStreamMac::diagnoseStreamFailure()
 {
-    // Video-file playback always uses the OpenCV backend; not supported here.
-    sendMessage("Error: video playback is not supported by the macOS hybrid backend.");
-    return 0;
+    qCInfo(msDiag) << m_deviceName << "no frame at" << m_streamIdx << "("
+                   << m_grabber.lastError() << ") - running stall diagnosis";
+    logStallDiagnosis();
 }
 
-bool VideoStreamMac::setPU(quint8 selector, quint16 value)
+bool VideoStreamMac::writeControlWord(quint8 selector, quint16 word)
 {
-    return m_control.setCur(kProcessingUnitId, selector, value);
+    return m_control.setCur(kProcessingUnitId, selector, word);
 }
 
-int VideoStreamMac::getPU(quint8 selector)
+bool VideoStreamMac::readControl(quint8 selector, quint16 *value)
 {
-    quint16 value = 0;
-    if (!m_control.getCur(kProcessingUnitId, selector, &value))
-        return 0;
-    return static_cast<qint16>(value);
-}
-
-// Flush queued I2C packets to the device via UVC SET_CUR.
-void VideoStreamMac::sendCommands()
-{
-    if (!m_commandQueue.flush([this](quint8 sel, quint16 word) { return setPU(sel, word); }))
-        qDebug() << "Send setting failed";
+    return m_control.getCur(kProcessingUnitId, selector, value);
 }
 
 void VideoStreamMac::startStream()
 {
-    int idx = 0;
-    int daqFrameNumOffset = 0;
-    double extTriggerLast = -1;
-    double extTrigger;
+    resetStreamState();
+    ReconnectBackoff backoff;
     cv::Mat frame;
-
-    m_stopStreaming = false;
 
     if (!m_grabber.isOpened()) {
         sendMessage("Error: Could not connect to video stream " + QString::number(m_cameraID));
@@ -233,110 +182,39 @@ void VideoStreamMac::startStream()
     // Enable continuous DAQ data/BNO register refresh now rather than on the
     // Record button, so head orientation is live during Run (same reasoning
     // as the libuvc backend).
-    setPU(SEL_SATURATION, 0x0001);
+    writeControlWord(SEL_SATURATION, 0x0001);
 
     qCInfo(msDiag) << m_deviceName << "stream loop starting";
 
-    int reconnectAttempts = 0;
     forever {
         if (m_stopStreaming)
             break;
 
         if (!m_grabber.read(frame)) {
-            // Diagnose and message on the FIRST failure of a stall episode;
-            // later attempts back off quietly (a device that fell off the bus
-            // can take a while to come back, and every attempt already logs).
-            if (reconnectAttempts == 0) {
-                qCInfo(msDiag) << m_deviceName << "no frame at" << idx << "("
-                               << m_grabber.lastError() << ") - running stall diagnosis";
-                sendMessage("Warning: " + m_deviceName + " grab frame failed. Attempting to reconnect.");
-                logStallDiagnosis();
-            }
-            reconnectAttempts++;
             m_grabber.release();
-            QThread::msleep(qMin(1000 * reconnectAttempts, 5000));
-            QCoreApplication::processEvents();   // keep stopSteam() deliverable while down
-            if (m_stopStreaming)
-                continue;
-            if (attemptReconnect()) {
-                sendMessage("Warning: " + m_deviceName + " reconnected (after " +
-                            QString::number(reconnectAttempts) + " attempts).");
-                qDebug() << "Reconnect to camera" << m_cameraID;
-                reconnectAttempts = 0;
-            }
+            runReconnectCycle(backoff, "grab frame");
             continue;
         }
+        backoff.reset();
 
-        // Reserve the ring-buffer slot BEFORE any per-frame work: a full
-        // buffer drops this frame anyway, so the USB control reads (~6 ms
-        // each while streaming) and the color conversion would only deepen
-        // the backpressure - and acquiring first guarantees a slot is never
-        // overwritten while DataSaver still owns it.
-        if (!freeFrames->tryAcquire()) {
-            if (freeFrames->available() == 0) {
-                sendMessage("Error: " + m_deviceName + " frame buffer is full. Frames will be lost!");
-                QThread::msleep(100);
-            }
-        } else {
-            timeStampBuffer[idx % frameBufferSize] = monotonicTimeMs();
-
-            if (m_isColor)
-                frame.copyTo(frameBuffer[idx % frameBufferSize]);
-            else
-                cv::cvtColor(frame, frameBuffer[idx % frameBufferSize], cv::COLOR_BGR2GRAY);
-
-            if (m_trackExtTrigger) {
-                if (extTriggerLast == -1) {
-                    extTriggerLast = getPU(SEL_GAMMA);
-                } else {
-                    extTrigger = getPU(SEL_GAMMA);
-                    if (extTriggerLast != extTrigger) {
-                        if (extTriggerLast == 0)
-                            emit extTriggered(true);
-                        else
-                            emit extTriggered(false);
-                    }
-                    extTriggerLast = extTrigger;
-                }
-            }
-
-            if (m_headOrientationStreamState) {
-                // BNO output is a unit quaternion after a 2^14 division.
-                qint16 quat[4];   // w, x, y, z per kBnoSelectors order
-                for (int i = 0; i < 4; i++)
-                    quat[i] = static_cast<qint16>(getPU(kBnoSelectors[i]));
-                unpackBnoQuaternion(quat[0], quat[1], quat[2], quat[3],
-                                    &bnoBuffer[(idx % frameBufferSize) * 5]);
-            }
-
-            if (daqFrameNum != nullptr) {
-                *daqFrameNum = getPU(SEL_CONTRAST) - daqFrameNumOffset;
-                if (*m_acqFrameNum == 0)
-                    daqFrameNumOffset = *daqFrameNum - 1;
-                // Diagnostics reuse this read - never a second GET_CUR.
-                if (idx % 100 == 0)
-                    qCInfo(msDiag).nospace()
-                        << m_deviceName << (idx == 0 ? " first frame: " : " heartbeat: ")
-                        << frame.cols << "x" << frame.rows << " acqFrame=" << idx
-                        << " daqFrameCounter=" << (*daqFrameNum + daqFrameNumOffset)
-                        << " ts=" << timeStampBuffer[idx % frameBufferSize];
-            }
-            if (daqFrameNumBuffer != nullptr)
-                daqFrameNumBuffer[idx % frameBufferSize] = (daqFrameNum != nullptr) ? qint64(daqFrameNum->loadRelaxed()) : qint64(-1);
-
-            m_acqFrameNum->operator++();
-            idx++;
-            emit newFrameAvailable(m_deviceName, *m_acqFrameNum);
-            usedFrames->release();
-        }
-
-        // Process queued control changes (setPropertyI2C) and flush them.
-        QCoreApplication::processEvents();
-        if (!m_commandQueue.isEmpty())
-            sendCommands();
+        commitFrame(frame, monotonicTimeMs());
+        serviceCommandQueue();
     }
     m_grabber.release();
     m_control.close();
+}
+
+void VideoStreamMac::onFrameCommitted(int streamIdx, const cv::Mat &frame, qint64 timestampMs)
+{
+    // Heartbeat every 100 frames. Reuses commitFrame's DAQ counter read -
+    // never a second GET_CUR.
+    if (streamIdx % 100 != 0 || daqFrameNum == nullptr)
+        return;
+    qCInfo(msDiag).nospace()
+        << m_deviceName << (streamIdx == 0 ? " first frame: " : " heartbeat: ")
+        << frame.cols << "x" << frame.rows << " acqFrame=" << streamIdx
+        << " daqFrameCounter=" << (daqFrameNum->loadRelaxed() + m_daqFrameNumOffset)
+        << " ts=" << timestampMs;
 }
 
 bool VideoStreamMac::attemptReconnect()
@@ -349,40 +227,20 @@ bool VideoStreamMac::attemptReconnect()
         return false;
     if (!openFrameStream(cameras))
         return false;
-    sendSerdesModeCommands(m_pixelClock);
-    setPU(SEL_SATURATION, 0x0001);
+    sendSerdesModeCommands();
+    writeControlWord(SEL_SATURATION, 0x0001);
     emit requestInitCommands();
     return true;
-}
-
-void VideoStreamMac::stopSteam()
-{
-    m_stopStreaming = true;
-}
-
-void VideoStreamMac::setPropertyI2C(long preambleKey, QVector<quint8> packet)
-{
-    m_commandQueue.set(preambleKey, packet);
-}
-
-void VideoStreamMac::setExtTriggerTrackingState(bool state)
-{
-    m_trackExtTrigger = state;
 }
 
 void VideoStreamMac::startRecording()
 {
     // Data/BNO streaming is already enabled at stream start; nothing extra needed.
-    setPU(SEL_SATURATION, 0x0001);
+    writeControlWord(SEL_SATURATION, 0x0001);
 }
 
 void VideoStreamMac::stopRecording()
 {
     // Intentionally leave SATURATION=1 so head orientation stays live during
     // Run after a recording stops (matches the libuvc backend).
-}
-
-void VideoStreamMac::openCamPropsDialog()
-{
-    // OpenCV/DirectShow-only feature (behaviour cameras); not applicable here.
 }

--- a/source/videostreammac.cpp
+++ b/source/videostreammac.cpp
@@ -191,7 +191,12 @@ void VideoStreamMac::startStream()
             break;
 
         if (!m_grabber.read(frame)) {
-            m_grabber.release();
+            // The grabber is NOT released here: the stall diagnosis inside
+            // runReconnectCycle polls the DAQ frame counter, which only
+            // advances while the device streams - releasing the session first
+            // would freeze it and flip an "AVF session died" verdict into a
+            // false "scope video pipeline down". attemptReconnect() releases
+            // before reopening.
             runReconnectCycle(backoff, "grab frame");
             continue;
         }
@@ -219,6 +224,7 @@ void VideoStreamMac::onFrameCommitted(int streamIdx, const cv::Mat &frame, qint6
 
 bool VideoStreamMac::attemptReconnect()
 {
+    m_grabber.release();
     m_control.close();
     // Fresh enumeration: the device may have re-enumerated (which can be
     // exactly why we are reconnecting).

--- a/source/videostreammac.cpp
+++ b/source/videostreammac.cpp
@@ -10,10 +10,6 @@
 
 using namespace MiniscopeProtocol;
 
-// Bench diagnostics (heartbeats, stall verdicts, pin lines). On by default;
-// silence with QT_LOGGING_RULES="miniscope.diag=false".
-Q_LOGGING_CATEGORY(msDiag, "miniscope.diag")
-
 VideoStreamMac::VideoStreamMac(QObject *parent, int width, int height, double pixelClock) :
     VideoStreamBase(parent, width > 0 ? width : 608, height > 0 ? height : 608, pixelClock)
 {
@@ -207,19 +203,6 @@ void VideoStreamMac::startStream()
     }
     m_grabber.release();
     m_control.close();
-}
-
-void VideoStreamMac::onFrameCommitted(int streamIdx, const cv::Mat &frame, qint64 timestampMs)
-{
-    // Heartbeat every 100 frames. Reuses commitFrame's DAQ counter read -
-    // never a second GET_CUR.
-    if (streamIdx % 100 != 0 || daqFrameNum == nullptr)
-        return;
-    qCInfo(msDiag).nospace()
-        << m_deviceName << (streamIdx == 0 ? " first frame: " : " heartbeat: ")
-        << frame.cols << "x" << frame.rows << " acqFrame=" << streamIdx
-        << " daqFrameCounter=" << (daqFrameNum->loadRelaxed() + m_daqFrameNumOffset)
-        << " ts=" << timestampMs;
 }
 
 bool VideoStreamMac::attemptReconnect()

--- a/source/videostreammac.h
+++ b/source/videostreammac.h
@@ -43,7 +43,6 @@ protected:
     bool writeControlWord(quint8 selector, quint16 word) override;   // IOKit SET_CUR
     bool readControl(quint8 selector, quint16 *value) override;      // IOKit GET_CUR
     bool attemptReconnect() override;
-    void onFrameCommitted(int streamIdx, const cv::Mat &frame, qint64 timestampMs) override;
     void diagnoseStreamFailure() override;   // frame-counter poll: AVF session vs scope video link
 
 private:

--- a/source/videostreammac.h
+++ b/source/videostreammac.h
@@ -3,22 +3,19 @@
 
 // Hybrid macOS capture backend for Miniscopes - see videostreambase.h.
 //
-// Frames stream through OpenCV's AVFoundation backend like any webcam (the
-// Miniscope enumerates as a standard UVC camera), while device control - the
-// I2C-over-UVC command tunnel, the per-frame DAQ frame counter, and the BNO
-// head-orientation registers - goes through UVCControlMac's IOKit pipe-0
-// requests, which coexist with Apple's streaming driver. Neither half works
-// alone on macOS: AVFoundation exposes no UVC controls, and owning the whole
-// device (the Linux libuvc approach) needs root here.
+// Frames stream through an AVFoundation capture session pinned to the device
+// uniqueID (the Miniscope enumerates as a standard UVC camera), while device
+// control - the I2C-over-UVC command tunnel, the per-frame DAQ frame counter,
+// and the BNO head-orientation registers - goes through UVCControlMac's IOKit
+// pipe-0 requests, which coexist with Apple's streaming driver. Neither half
+// works alone on macOS: AVFoundation exposes no UVC controls, and owning the
+// whole device (the Linux libuvc approach) needs root here.
 //
 // Latency note (measured against real hardware): a pipe-0 GET_CUR costs
 // ~1 ms idle but ~6 ms while the device streams. Reads are therefore gated
 // exactly like the other backends - frame counter always (1 read/frame), BNO
 // only when head orientation is enabled, trigger state only when tracking.
 
-#include <atomic>
-#include <QSemaphore>
-#include <QAtomicInt>
 #include <QVector>
 #include <opencv2/core/core.hpp>
 
@@ -35,63 +32,29 @@ public:
     explicit VideoStreamMac(QObject *parent = nullptr, int width = 0, int height = 0, double pixelClock = 0);
     ~VideoStreamMac() override;
 
-    void setBufferParameters(cv::Mat *frameBuf, qint64 *tsBuf, float *bnoBuf,
-                             qint64 *daqFrameNumBuf,
-                             int bufferSize, QSemaphore *freeFramesS, QSemaphore *usedFramesS,
-                             QAtomicInt *acqFrameNum, QAtomicInt *daqFrameNumber) override;
     int connect2Camera(int cameraID) override;
-    int connect2Video(QString folderPath, QString filePrefix, float playbackFPS) override;
-    void setHeadOrientationConfig(bool enableState, bool) override { m_headOrientationStreamState = enableState; }
-    void setIsColor(bool isColor) override { m_isColor = isColor; }
-    void setDeviceName(QString name) override { m_deviceName = name; }
 
 public slots:
     void startStream() override;
-    void stopSteam() override;
-    void setPropertyI2C(long preambleKey, QVector<quint8> packet) override;
-    void setExtTriggerTrackingState(bool state) override;
     void startRecording() override;
     void stopRecording() override;
-    void openCamPropsDialog() override;
+
+protected:
+    bool writeControlWord(quint8 selector, quint16 word) override;   // IOKit SET_CUR
+    bool readControl(quint8 selector, quint16 *value) override;      // IOKit GET_CUR
+    bool attemptReconnect() override;
+    void onFrameCommitted(int streamIdx, const cv::Mat &frame, qint64 timestampMs) override;
+    void diagnoseStreamFailure() override;   // frame-counter poll: AVF session vs scope video link
 
 private:
     // AVFoundation index -> USB locationID -> UVCControlMac (policy in resolveControlTarget)
     bool openControlForIndex(int cameraID, const QVector<AvfCameraInfo> &cameras);
     // Pin the grabber to the control channel's device via its uniqueID.
     bool openFrameStream(const QVector<AvfCameraInfo> &cameras);
-    void sendCommands() override;             // flush queued I2C packets as UVC SET_CUR
-    bool setPU(quint8 selector, quint16 value);
-    int  getPU(quint8 selector);              // fresh GET_CUR, returned as signed 16-bit; 0 on failure
-    bool attemptReconnect();
-    void logStallDiagnosis();                 // frame-counter poll: AVF session vs scope video link
-
-    int m_cameraID;
-    QString m_deviceName;
+    void logStallDiagnosis();
 
     AvfFrameGrabber m_grabber;
     UVCControlMac m_control;
-
-    std::atomic<bool> m_stopStreaming;
-    bool m_headOrientationStreamState;
-    bool m_isColor;
-
-    cv::Mat *frameBuffer;
-    qint64 *timeStampBuffer;
-    qint64 *daqFrameNumBuffer;
-    float *bnoBuffer;
-    QSemaphore *freeFrames;
-    QSemaphore *usedFrames;
-    int frameBufferSize;
-    QAtomicInt *m_acqFrameNum;
-    QAtomicInt *daqFrameNum;
-
-    I2CCommandQueue m_commandQueue;
-
-    bool m_trackExtTrigger;
-
-    int m_expectedWidth;
-    int m_expectedHeight;
-    double m_pixelClock;
 };
 
 #endif // VIDEOSTREAMMAC_H

--- a/source/videostreamocv.cpp
+++ b/source/videostreamocv.cpp
@@ -5,31 +5,16 @@
 #include "avfenumeratormac.h"
 #endif
 #include <opencv2/core/core.hpp>
-#include <opencv2/highgui/highgui.hpp>
-#include <opencv2/opencv.hpp>
 #include <opencv2/imgproc.hpp>
 #include <opencv2/videoio.hpp>
 #include <QDebug>
-#include <QAtomicInt>
 #include <QCoreApplication>
 #include <QVector>
-#include <QDateTime>
 #include <QThread>
-#include <QtMath>
 
 VideoStreamOCV::VideoStreamOCV(QObject *parent, int width, int height, double pixelClock) :
-    VideoStreamBase(parent),
-    m_cameraID(-1),
-    m_deviceName(""),
+    VideoStreamBase(parent, width, height, pixelClock),
     cam(nullptr),
-    m_stopStreaming(false),
-    m_headOrientationStreamState(false),
-    m_headOrientationFilterState(false),
-    m_isColor(false),
-    m_trackExtTrigger(false),
-    m_expectedWidth(width),
-    m_expectedHeight(height),
-    m_pixelClock(pixelClock),
     m_connectionType("")
 {
 
@@ -101,7 +86,7 @@ int VideoStreamOCV::connect2Camera(int cameraID) {
     }
     // The SERDES mode must be set before any other SERDES traffic (TI 913/914).
     if (connectionState != 0)
-        sendSerdesModeCommands(m_pixelClock);
+        sendSerdesModeCommands();
 
     if (connectionState != 0) {
          cam->set(cv::CAP_PROP_FRAME_WIDTH, m_expectedWidth);
@@ -132,244 +117,91 @@ int VideoStreamOCV::connect2Video(QString folderPath, QString filePrefix, float 
         return 0;
 }
 
-void VideoStreamOCV::setBufferParameters(cv::Mat *frameBuf, qint64 *tsBuf, float *bnoBuf,
-                                         qint64 *daqFrameNumBuf,
-                                         int bufferSize, QSemaphore *freeFramesS, QSemaphore *usedFramesS,
-                                         QAtomicInt *acqFrameNum, QAtomicInt *daqFrameNumber){
-    frameBuffer = frameBuf;
-    timeStampBuffer = tsBuf;
-    daqFrameNumBuffer = daqFrameNumBuf;
-    frameBufferSize = bufferSize;
-    bnoBuffer = bnoBuf;
-    freeFrames = freeFramesS;
-    usedFrames = usedFramesS;
-    m_acqFrameNum = acqFrameNum;
-    daqFrameNum = daqFrameNumber;
-
-}
-
 void VideoStreamOCV::startStream()
 {
-    QString fileName;
-    int idx = 0;
-    int daqFrameNumOffset = 0;
-    double extTriggerLast = -1;
-    double extTrigger;
-    bool status = false;
-    qint64 timestamp = 0;
+    resetStreamState();
+    ReconnectBackoff backoff;
     cv::Mat frame;
-
-    m_stopStreaming = false;
+    qint64 timestamp = 0;
 
     bool streamOpen = (cam != nullptr && cam->isOpened());
 #ifdef Q_OS_MACOS
-    int reconnectAttempts = 0;
     if (m_connectionType == "AVF")
         streamOpen = m_grabber.isOpened();
 #endif
-
-    if (streamOpen) {
-        m_isStreaming = true;
-        forever {
-
-            if (m_stopStreaming == true) {
-                m_isStreaming = false;
-                break;
-            }
-
-            status = true;
-            // Get new frame and handle disconnects
-#ifdef Q_OS_MACOS
-            if (m_connectionType == "AVF") {
-                if (!m_grabber.read(frame)) {
-                    status = false;
-                    // Message on the FIRST failure of a stall episode; later
-                    // attempts back off quietly (a device that fell off the
-                    // bus can take a while to come back).
-                    if (reconnectAttempts == 0)
-                        sendMessage("Warning: " + m_deviceName + " grab frame failed. Attempting to reconnect.");
-                    reconnectAttempts++;
-                    m_grabber.release();
-                    QThread::msleep(qMin(1000 * reconnectAttempts, 5000));
-                    QCoreApplication::processEvents();   // keep stopSteam() deliverable while down
-                    if (m_stopStreaming)
-                        continue;
-                    if (attemptReconnect()) {
-                        sendMessage("Warning: " + m_deviceName + " reconnected (after " +
-                                    QString::number(reconnectAttempts) + " attempts).");
-                        reconnectAttempts = 0;
-                    }
-                }
-                else {
-                    timestamp = monotonicTimeMs();
-                    reconnectAttempts = 0;
-                }
-            }
-            else
-#endif
-            if (m_connectionType != "videoFile") {
-                // Try to get frame from camera
-                if (!cam->grab()) {
-                    // Grab failed
-                    status = false;
-                    sendMessage("Warning: " + m_deviceName + " grab frame failed. Attempting to reconnect.");
-                    if (cam->isOpened()) {
-                        qDebug() << "Grab failed: Releasing cam" << m_cameraID;
-                        cam->release();
-                        qDebug() << "Released cam" << m_cameraID;
-                    }
-                    QThread::msleep(1000);
-
-                    if (attemptReconnect()) {
-                        // TODO: add some timeout here
-                        sendMessage("Warning: " + m_deviceName + " reconnected.");
-                        qDebug() << "Reconnect to camera" << m_cameraID;
-                    }
-                }
-                else {
-                    // Grab successful
-                    timestamp = monotonicTimeMs();
-                    if (!cam->retrieve(frame)) {
-                        // Retrieve failed
-                        status = false;
-                        sendMessage("Warning: " + m_deviceName + " retrieve frame failed. Attempting to reconnect.");
-                        if (cam->isOpened()) {
-                            qDebug() << "Retieve failed: Releasing cam" << m_cameraID;
-                            cam->release();
-                            qDebug() << "Released cam" << m_cameraID;
-                        }
-                        QThread::msleep(1000);
-
-                        if (attemptReconnect()) {
-                            // TODO: add some timeout here
-                            sendMessage("Warning: " + m_deviceName + " reconnected.");
-                            qDebug() << "Reconnect to camera" << m_cameraID;
-                        }
-                    }
-                }
-            }
-            else if (m_connectionType == "videoFile") {
-                QThread::msleep(1000.0/m_playbackFPS);
-                timestamp = monotonicTimeMs();
-                if (!cam->read(frame)) {
-                    // Try next file before fully giving up. End playback with
-                    // a break, not a return: break falls through to the
-                    // cam->release() after the loop, a return leaks the handle.
-                    m_playbackFileIndex++;
-                    qDebug() << "FILE INDEX" << m_playbackFileIndex;
-                    fileName = m_playbackFolderPath + "/" + m_playbackFilePrefix + QString::number(m_playbackFileIndex) + ".avi";
-                    cam->release();
-                    if (!cam->open(fileName.toStdString()) || !cam->read(frame)) {
-                        sendMessage(m_deviceName + " playback reached the end of the recording.");
-                        m_isStreaming = false;
-                        break;
-                    }
-                }
-            }
-            if (status) {
-                // Grab and retrieve successful. Reserve a buffer slot BEFORE
-                // writing anything into it: when the buffer is full,
-                // idx%frameBufferSize is the oldest unconsumed slot, which
-                // DataSaver may be reading right now - writing first corrupts
-                // the frame being saved. Acquiring first also skips the
-                // per-frame control reads for frames we are about to drop.
-                if (!freeFrames->tryAcquire()) {
-                    // No free slot: this frame is thrown away
-                    if (freeFrames->available() == 0) {
-                        // Buffers are full!
-                        sendMessage("Error: " + m_deviceName + " frame buffer is full. Frames will be lost!");
-                        QThread::msleep(100);
-                    }
-                }
-                else {
-                    const int bufIdx = idx % frameBufferSize;
-                    timeStampBuffer[bufIdx] = timestamp;
-                    if (m_isColor) {
-                        frame.copyTo(frameBuffer[bufIdx]);
-                    }
-                    else {
-                        cv::cvtColor(frame, frameBuffer[bufIdx], cv::COLOR_BGR2GRAY);
-                    }
-
-                    // Control-property reads below go through cv::VideoCapture;
-                    // in the AVF path there is none (cam stays nullptr) and
-                    // AVFoundation exposes no UVC controls anyway.
-                    if (m_trackExtTrigger && cam != nullptr) {
-                        if (extTriggerLast == -1) {
-                            // first time grabbing trigger state.
-                            extTriggerLast = cam->get(cv::CAP_PROP_GAMMA);
-                        }
-                        else {
-                            extTrigger = cam->get(cv::CAP_PROP_GAMMA);
-                            if (extTriggerLast != extTrigger) {
-                                // State change
-                                if (extTriggerLast == 0) {
-                                    // Went from 0 to 1
-                                    emit extTriggered(true);
-                                }
-                                else {
-                                    // Went from 1 to 0
-                                    emit extTriggered(false);
-                                }
-                            }
-                            extTriggerLast = extTrigger;
-                        }
-                    }
-
-                    if (m_headOrientationStreamState && cam != nullptr) {
-                        // BNO output is a unit quaternion after 2^14 division
-                        MiniscopeProtocol::unpackBnoQuaternion(
-                            static_cast<qint16>(cam->get(cv::CAP_PROP_SATURATION)),
-                            static_cast<qint16>(cam->get(cv::CAP_PROP_HUE)),
-                            static_cast<qint16>(cam->get(cv::CAP_PROP_GAIN)),
-                            static_cast<qint16>(cam->get(cv::CAP_PROP_BRIGHTNESS)),
-                            &bnoBuffer[bufIdx*5]);
-                    }
-                    if (daqFrameNum != nullptr && cam != nullptr) {
-                        *daqFrameNum = cam->get(cv::CAP_PROP_CONTRAST) - daqFrameNumOffset;
-                        if (*m_acqFrameNum == 0) // Used to initially sync daqFrameNum with acqFrameNum
-                            daqFrameNumOffset = *daqFrameNum - 1;
-                    }
-                    if (daqFrameNumBuffer != nullptr)
-                        daqFrameNumBuffer[bufIdx] = (daqFrameNum != nullptr) ? qint64(daqFrameNum->loadRelaxed()) : qint64(-1);
-
-                    m_acqFrameNum->operator++();
-                    idx++;
-                    emit newFrameAvailable(m_deviceName, *m_acqFrameNum);
-                    usedFrames->release();
-                }
-            }
-            // Get any new events
-            QCoreApplication::processEvents(); // Is there a better way to do this. This is against best practices
-            if (!m_commandQueue.isEmpty())
-                sendCommands(); // Send last of each control property events that arrived on this processEvent() call then removes it from queue
-        }
-        if (cam != nullptr)
-            cam->release();
-#ifdef Q_OS_MACOS
-        m_grabber.release();
-#endif
-    }
-    else {
+    if (!streamOpen) {
         sendMessage("Error: Could not connect to video stream " + QString::number(m_cameraID));
         qDebug() << "Camera " << m_cameraID << " failed to open.";
+        return;
     }
-}
 
-void VideoStreamOCV::stopSteam()
-{
-    m_stopStreaming = true;
-}
+    forever {
+        if (m_stopStreaming)
+            break;
 
-void VideoStreamOCV::setPropertyI2C(long preambleKey, QVector<quint8> packet)
-{
-    // A newer packet for the same preamble key replaces the unsent older one.
-    m_commandQueue.set(preambleKey, packet);
-}
+        // Get new frame and handle disconnects
+#ifdef Q_OS_MACOS
+        if (m_connectionType == "AVF") {
+            if (!m_grabber.read(frame)) {
+                m_grabber.release();
+                runReconnectCycle(backoff, "grab frame");
+                continue;
+            }
+            timestamp = monotonicTimeMs();
+            backoff.reset();
+        }
+        else
+#endif
+        if (m_connectionType != "videoFile") {
+            if (!cam->grab()) {
+                if (cam->isOpened()) {
+                    qDebug() << "Grab failed: Releasing cam" << m_cameraID;
+                    cam->release();
+                    qDebug() << "Released cam" << m_cameraID;
+                }
+                runReconnectCycle(backoff, "grab frame");
+                continue;
+            }
+            timestamp = monotonicTimeMs();
+            if (!cam->retrieve(frame)) {
+                if (cam->isOpened()) {
+                    qDebug() << "Retrieve failed: Releasing cam" << m_cameraID;
+                    cam->release();
+                    qDebug() << "Released cam" << m_cameraID;
+                }
+                runReconnectCycle(backoff, "retrieve frame");
+                continue;
+            }
+            backoff.reset();
+        }
+        else {
+            // Video-file playback: pace to the requested FPS.
+            QThread::msleep(ulong(1000.0 / m_playbackFPS));
+            timestamp = monotonicTimeMs();
+            if (!cam->read(frame)) {
+                // Try next file before fully giving up. End playback with a
+                // break, not a return: break falls through to the
+                // cam->release() after the loop, a return leaks the handle.
+                m_playbackFileIndex++;
+                qDebug() << "FILE INDEX" << m_playbackFileIndex;
+                const QString fileName = m_playbackFolderPath + "/" + m_playbackFilePrefix +
+                                         QString::number(m_playbackFileIndex) + ".avi";
+                cam->release();
+                if (!cam->open(fileName.toStdString()) || !cam->read(frame)) {
+                    sendMessage(m_deviceName + " playback reached the end of the recording.");
+                    break;
+                }
+            }
+        }
 
-void VideoStreamOCV::setExtTriggerTrackingState(bool state)
-{
-    m_trackExtTrigger = state;
+        commitFrame(frame, timestamp);
+        serviceCommandQueue();
+    }
+    if (cam != nullptr)
+        cam->release();
+#ifdef Q_OS_MACOS
+    m_grabber.release();
+#endif
 }
 
 void VideoStreamOCV::startRecording()
@@ -410,17 +242,38 @@ static bool camSetProperty(cv::VideoCapture *cam, int propId, double value)
     return ret;
 }
 
-// The UVC selector each packed word travels on, as this backend's OpenCV
+// The UVC selector each control word travels on, as this backend's OpenCV
 // property. OpenCV property IDs and UVC PU selectors are different vocabularies
-// for the same controls; this is the single translation point.
+// for the same controls; this is the single translation point (both directions:
+// I2C-word writes and the per-frame register reads).
 static int capPropForSelector(quint8 selector)
 {
     switch (selector) {
-    case MiniscopeProtocol::SEL_CONTRAST:  return cv::CAP_PROP_CONTRAST;
-    case MiniscopeProtocol::SEL_GAMMA:     return cv::CAP_PROP_GAMMA;
-    case MiniscopeProtocol::SEL_SHARPNESS: return cv::CAP_PROP_SHARPNESS;
-    default:                               return -1;
+    case MiniscopeProtocol::SEL_BRIGHTNESS: return cv::CAP_PROP_BRIGHTNESS;
+    case MiniscopeProtocol::SEL_CONTRAST:   return cv::CAP_PROP_CONTRAST;
+    case MiniscopeProtocol::SEL_GAIN:       return cv::CAP_PROP_GAIN;
+    case MiniscopeProtocol::SEL_HUE:        return cv::CAP_PROP_HUE;
+    case MiniscopeProtocol::SEL_SATURATION: return cv::CAP_PROP_SATURATION;
+    case MiniscopeProtocol::SEL_SHARPNESS:  return cv::CAP_PROP_SHARPNESS;
+    case MiniscopeProtocol::SEL_GAMMA:      return cv::CAP_PROP_GAMMA;
+    default:                                return -1;
     }
+}
+
+bool VideoStreamOCV::writeControlWord(quint8 selector, quint16 word)
+{
+    return camSetProperty(cam, capPropForSelector(selector), word);
+}
+
+bool VideoStreamOCV::readControl(quint8 selector, quint16 *value)
+{
+    // cv::VideoCapture::get has no failure signal (it returns 0.0 for
+    // unsupported properties), so the only detectable no-control case is the
+    // AVF webcam path, where there is no cv capture at all.
+    if (cam == nullptr)
+        return false;
+    *value = quint16(qint32(cam->get(capPropForSelector(selector))));
+    return true;
 }
 
 void VideoStreamOCV::sendCommands()
@@ -433,10 +286,7 @@ void VideoStreamOCV::sendCommands()
         qDebug() << m_deviceName << "dropped queued device commands (no control channel on this backend)";
         return;
     }
-    if (!m_commandQueue.flush([this](quint8 sel, quint16 word) {
-            return camSetProperty(cam, capPropForSelector(sel), word);
-        }))
-        qDebug() << "Send setting failed";
+    VideoStreamBase::sendCommands();
 }
 
 bool VideoStreamOCV::attemptReconnect()
@@ -466,7 +316,13 @@ bool VideoStreamOCV::attemptReconnect()
     }
 #endif
     // TODO: handle quitting nicely when stuck in this loop
-    if (m_connectionType == "DSHOW") {
+    if (m_connectionType == "V4L") {
+        // Pre-R4 this case was missing entirely, so a Linux camera that
+        // dropped could never reconnect - the loop retried forever.
+        if (!cam->open(m_cameraID, cv::CAP_V4L2))
+            return false;
+    }
+    else if (m_connectionType == "DSHOW") {
         if (!cam->open(m_cameraID, cv::CAP_DSHOW))
             return false;
     }
@@ -477,10 +333,10 @@ bool VideoStreamOCV::attemptReconnect()
     else {
         return false;
     }
-    sendSerdesModeCommands(m_pixelClock);
+    sendSerdesModeCommands();
     cam->set(cv::CAP_PROP_FRAME_WIDTH, m_expectedWidth);
     cam->set(cv::CAP_PROP_FRAME_HEIGHT, m_expectedHeight);
     QThread::msleep(500);
-    requestInitCommands();
+    emit requestInitCommands();
     return true;
 }

--- a/source/videostreamocv.h
+++ b/source/videostreamocv.h
@@ -1,16 +1,10 @@
 #ifndef VIDEOSTREAMOCV_H
 #define VIDEOSTREAMOCV_H
 
-#include <atomic>
 #include <QObject>
-#include <QSemaphore>
 #include <QString>
 #include <opencv2/core/core.hpp>
-#include <opencv2/highgui/highgui.hpp>
-#include <opencv2/opencv.hpp>
-#include <opencv2/imgproc.hpp>
 #include <opencv2/videoio.hpp>
-#include <QAtomicInt>
 #include <QVector>
 
 #include "miniscopeprotocol.h"
@@ -27,55 +21,23 @@ class VideoStreamOCV : public VideoStreamBase
 public:
     explicit VideoStreamOCV(QObject *parent = nullptr, int width = 0, int height = 0, double pixelClock = 0);
     ~VideoStreamOCV() override;
-//    void setCameraID(int cameraID);
-    void setBufferParameters(cv::Mat *frameBuf, qint64 *tsBuf, float *bnoBuf,
-                             qint64 *daqFrameNumBuf,
-                             int bufferSize, QSemaphore *freeFramesS, QSemaphore *usedFramesS,
-                             QAtomicInt *acqFrameNum, QAtomicInt *daqFrameNumber) override;
     int connect2Camera(int cameraID) override;
     int connect2Video(QString folderPath, QString filePrefix, float playbackFPS) override;
-    void setHeadOrientationConfig(bool enableState, bool filterState) override { m_headOrientationStreamState = enableState; m_headOrientationFilterState = filterState; }
-    void setIsColor(bool isColor) override { m_isColor = isColor; }
-    void setDeviceName(QString name) override { m_deviceName = name; }
 
 public slots:
     void startStream() override;
-    void stopSteam() override;
-    void setPropertyI2C(long preambleKey, QVector<quint8> packet) override;
-    void setExtTriggerTrackingState(bool state) override;
     void startRecording() override;
     void stopRecording() override;
     void openCamPropsDialog() override;
 
+protected:
+    void sendCommands() override;   // drops the queue when there is no control channel
+    bool writeControlWord(quint8 selector, quint16 word) override;   // CAP_PROP passthrough
+    bool readControl(quint8 selector, quint16 *value) override;      // CAP_PROP passthrough
+    bool attemptReconnect() override;
+
 private:
-    void sendCommands() override;    // flush queued I2C packets via CAP_PROP passthrough
-    bool attemptReconnect();
-    int m_cameraID;
-    QString m_deviceName;
     cv::VideoCapture *cam;
-    std::atomic<bool> m_isStreaming;
-    std::atomic<bool> m_stopStreaming;
-    bool m_headOrientationStreamState;
-    bool m_headOrientationFilterState;
-    bool m_isColor;
-    cv::Mat *frameBuffer;
-    qint64 *timeStampBuffer;
-    qint64 *daqFrameNumBuffer;
-    float *bnoBuffer;
-    QSemaphore *freeFrames;
-    QSemaphore *usedFrames;
-    int frameBufferSize;
-    QAtomicInt *m_acqFrameNum;
-    QAtomicInt *daqFrameNum;
-
-    // Handles commands sent to video stream device
-    I2CCommandQueue m_commandQueue;
-
-    bool m_trackExtTrigger;
-
-    int m_expectedWidth;
-    int m_expectedHeight;
-    double m_pixelClock;
 
     QString m_connectionType;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,6 +42,16 @@ target_compile_definitions(tst_configvalidator PRIVATE
 target_link_libraries(tst_configvalidator PRIVATE Qt6::Core Qt6::Test)
 add_test(NAME configvalidator COMMAND tst_configvalidator)
 
+# --- Shared capture-backend machinery -------------------------------------------
+# commitFrame (slot reservation, control reads, DAQ counter), the frame-size
+# lock, and the reconnect backoff - via a stub backend with scripted reads.
+qt_add_executable(tst_videostreambase tst_videostreambase.cpp
+    ${CMAKE_SOURCE_DIR}/source/videostreambase.cpp)
+target_include_directories(tst_videostreambase PRIVATE ${CMAKE_SOURCE_DIR}/source
+    ${OpenCV_INCLUDE_DIRS})
+target_link_libraries(tst_videostreambase PRIVATE miniscope_protocol Qt6::Core Qt6::Test ${OpenCV_LIBS})
+add_test(NAME videostreambase COMMAND tst_videostreambase)
+
 # --- macOS IOKit UVC transport (hardware-free smoke tests) ---------------------
 if(APPLE)
     qt_add_executable(tst_uvccontrolmac tst_uvccontrolmac.cpp)

--- a/tests/tst_miniscopeprotocol.cpp
+++ b/tests/tst_miniscopeprotocol.cpp
@@ -33,6 +33,7 @@ private slots:
     void queueFlushesInFirstQueuedOrder();
     void queueSkipsInvalidPackets();
     void queueReportsWriteFailure();
+    void queueClearDropsEverything();
 };
 
 void TestMiniscopeProtocol::packShortPacket()
@@ -208,6 +209,20 @@ void TestMiniscopeProtocol::queueReportsWriteFailure()
     int writes = 0;
     QVERIFY(!queue.flush([&](quint8, quint16) { writes++; return writes != 2; }));
     QCOMPARE(writes, 3);   // a failed word must not stop the remaining words
+}
+
+void TestMiniscopeProtocol::queueClearDropsEverything()
+{
+    // sendSerdesModeCommands relies on this: commands queued while a device
+    // was down must not flush ahead of the SERDES mode packets on reconnect.
+    I2CCommandQueue queue;
+    queue.set(1, {0xC0, 0x01});
+    queue.set(2, {0xC0, 0x02});
+    queue.clear();
+    QVERIFY(queue.isEmpty());
+    int writes = 0;
+    QVERIFY(queue.flush([&](quint8, quint16) { writes++; return true; }));
+    QCOMPARE(writes, 0);
 }
 
 QTEST_APPLESS_MAIN(TestMiniscopeProtocol)

--- a/tests/tst_videostreambase.cpp
+++ b/tests/tst_videostreambase.cpp
@@ -23,6 +23,9 @@ public:
     using VideoStreamBase::VideoStreamBase;
     using VideoStreamBase::commitFrame;
     using VideoStreamBase::resetStreamState;
+    using VideoStreamBase::runReconnectCycle;
+
+    bool reconnectResult = false;
 
     // Scripted control reads: per selector, a FIFO of (ok, value) results.
     // Selectors with no script fall back to (defaultOk, defaultValue).
@@ -38,7 +41,7 @@ public:
 
 protected:
     bool writeControlWord(quint8, quint16) override { return true; }
-    bool attemptReconnect() override { return false; }
+    bool attemptReconnect() override { return reconnectResult; }
     bool readControl(quint8 selector, quint16 *value) override
     {
         controlReads++;
@@ -212,6 +215,31 @@ private slots:
         stream->commitFrame(bgrFrame(), 1);
         QCOMPARE(daqBuf[0], qint64(40000));
         QCOMPARE(daqBuf[1], qint64(2));
+    }
+
+    // A reconnected device may have power-cycled and reset its hardware
+    // counter; the offset re-seeds so the CSV column restarts (raw, 2, 3...)
+    // instead of staying skewed by the stale offset for the rest of the file.
+    void daqCounterReseedsAfterReconnect()
+    {
+        buildStream();
+        stream->script[SEL_CONTRAST] = {{true, 100}, {true, 101}};
+        stream->commitFrame(bgrFrame(), 0);
+        consumeOne();
+        stream->commitFrame(bgrFrame(), 1);
+        consumeOne();
+        QCOMPARE(daqBuf[1], qint64(2));
+
+        stream->reconnectResult = true;
+        ReconnectBackoff backoff;
+        QVERIFY(stream->runReconnectCycle(backoff, "grab frame"));   // ~1 s (first backoff delay)
+
+        stream->script[SEL_CONTRAST] = {{true, 5}, {true, 6}};      // counter reset by power-cycle
+        stream->commitFrame(bgrFrame(), 2);
+        consumeOne();
+        stream->commitFrame(bgrFrame(), 3);
+        QCOMPARE(daqBuf[2], qint64(5));   // fresh seed: raw value, like at stream start
+        QCOMPARE(daqBuf[3], qint64(2));
     }
 
     void noDaqCounterMeansSentinel()

--- a/tests/tst_videostreambase.cpp
+++ b/tests/tst_videostreambase.cpp
@@ -1,0 +1,332 @@
+// Pins the shared capture-backend machinery in VideoStreamBase: the per-frame
+// commitFrame() block (slot reservation, conversions, control-register reads,
+// DAQ counter bookkeeping), the frame-size lock, and the reconnect backoff.
+// This logic used to be triplicated across the OpenCV/libuvc/macOS backends
+// and was untestable; a stub backend with scripted control reads makes every
+// branch reachable without hardware.
+
+#include <QtTest>
+#include <QSemaphore>
+#include <QAtomicInt>
+#include <QSignalSpy>
+
+#include <opencv2/core/core.hpp>
+
+#include "videostreambase.h"
+
+using namespace MiniscopeProtocol;
+
+class StubStream : public VideoStreamBase
+{
+    Q_OBJECT
+public:
+    using VideoStreamBase::VideoStreamBase;
+    using VideoStreamBase::commitFrame;
+    using VideoStreamBase::resetStreamState;
+
+    // Scripted control reads: per selector, a FIFO of (ok, value) results.
+    // Selectors with no script fall back to (defaultOk, defaultValue).
+    QMap<quint8, QList<QPair<bool, quint16>>> script;
+    bool defaultOk = true;
+    quint16 defaultValue = 0;
+    int controlReads = 0;
+
+    int connect2Camera(int) override { return 0; }
+    void startStream() override {}
+    void startRecording() override {}
+    void stopRecording() override {}
+
+protected:
+    bool writeControlWord(quint8, quint16) override { return true; }
+    bool attemptReconnect() override { return false; }
+    bool readControl(quint8 selector, quint16 *value) override
+    {
+        controlReads++;
+        if (script.contains(selector) && !script[selector].isEmpty()) {
+            const auto entry = script[selector].takeFirst();
+            *value = entry.second;
+            return entry.first;
+        }
+        *value = defaultValue;
+        return defaultOk;
+    }
+};
+
+class TestVideoStreamBase : public QObject
+{
+    Q_OBJECT
+
+    static constexpr int kBufSize = 4;
+
+    // Fresh buffer set per test (semaphores cannot be reset in place).
+    StubStream *stream = nullptr;
+    cv::Mat frameBuf[kBufSize];
+    qint64 tsBuf[kBufSize] = {};
+    qint64 daqBuf[kBufSize] = {};
+    float bnoBuf[kBufSize * 5] = {};
+    QSemaphore *freeFrames = nullptr;
+    QSemaphore *usedFrames = nullptr;
+    QAtomicInt *acqNum = nullptr;
+    QAtomicInt *daqNum = nullptr;
+
+    void buildStream(int width = 0, int height = 0, bool withDaqCounter = true)
+    {
+        delete stream;
+        delete freeFrames;
+        delete usedFrames;
+        delete acqNum;
+        delete daqNum;
+        stream = new StubStream(nullptr, width, height, 0);
+        freeFrames = new QSemaphore;
+        usedFrames = new QSemaphore;
+        acqNum = new QAtomicInt(0);
+        daqNum = new QAtomicInt(0);
+        freeFrames->release(kBufSize);
+        for (int i = 0; i < kBufSize; i++)
+            frameBuf[i] = cv::Mat();
+        std::fill(std::begin(tsBuf), std::end(tsBuf), qint64(0));
+        std::fill(std::begin(daqBuf), std::end(daqBuf), qint64(0));
+        std::fill(std::begin(bnoBuf), std::end(bnoBuf), 0.0f);
+        stream->setBufferParameters(frameBuf, tsBuf, bnoBuf, daqBuf, kBufSize,
+                                    freeFrames, usedFrames, acqNum,
+                                    withDaqCounter ? daqNum : nullptr);
+        stream->resetStreamState();
+    }
+
+    static cv::Mat bgrFrame(int w = 4, int h = 4, uchar fill = 100)
+    {
+        return cv::Mat(h, w, CV_8UC3, cv::Scalar(fill, fill, fill));
+    }
+
+    // Simulate the consumer so long sequences of commits never exhaust slots.
+    void consumeOne()
+    {
+        QVERIFY(usedFrames->tryAcquire());
+        freeFrames->release();
+    }
+
+private slots:
+    void cleanupTestCase()
+    {
+        delete stream;
+        delete freeFrames;
+        delete usedFrames;
+        delete acqNum;
+        delete daqNum;
+    }
+
+    void commitPublishesFrame()
+    {
+        buildStream();
+        QSignalSpy newFrame(stream, &VideoStreamBase::newFrameAvailable);
+
+        stream->commitFrame(bgrFrame(), 12345);
+
+        QCOMPARE(acqNum->loadRelaxed(), 1);
+        QCOMPARE(usedFrames->available(), 1);
+        QCOMPARE(freeFrames->available(), kBufSize - 1);
+        QCOMPARE(tsBuf[0], qint64(12345));
+        QCOMPARE(frameBuf[0].channels(), 1);   // default is grayscale conversion
+        QCOMPARE(newFrame.count(), 1);
+        QCOMPARE(newFrame.at(0).at(1).toInt(), 1);
+    }
+
+    void isColorCopiesUnconverted()
+    {
+        buildStream();
+        stream->setIsColor(true);
+        stream->commitFrame(bgrFrame(), 1);
+        QCOMPARE(frameBuf[0].channels(), 3);
+        QCOMPARE(frameBuf[0].at<cv::Vec3b>(0, 0), cv::Vec3b(100, 100, 100));
+    }
+
+    void bufferFullDropsWithoutWriting()
+    {
+        buildStream();
+        QVERIFY(freeFrames->tryAcquire(kBufSize));   // consumer owns every slot
+        frameBuf[0] = cv::Mat(4, 4, CV_8UC1, cv::Scalar(77));
+        tsBuf[0] = 999;
+        QSignalSpy messages(stream, &VideoStreamBase::sendMessage);
+        QSignalSpy newFrame(stream, &VideoStreamBase::newFrameAvailable);
+
+        stream->commitFrame(bgrFrame(), 12345);
+
+        QCOMPARE(acqNum->loadRelaxed(), 0);
+        QCOMPARE(newFrame.count(), 0);
+        QCOMPARE(tsBuf[0], qint64(999));                        // slot untouched
+        QCOMPARE(frameBuf[0].at<uchar>(0, 0), uchar(77));       // slot untouched
+        QVERIFY(messages.count() > 0);
+        QVERIFY(messages.at(0).at(0).toString().contains("buffer is full"));
+    }
+
+    void ringBufferWrapsAround()
+    {
+        buildStream();
+        for (int i = 0; i < kBufSize + 2; i++) {
+            stream->commitFrame(bgrFrame(), 1000 + i);
+            consumeOne();
+        }
+        // Frame kBufSize wrapped into slot 0, frame kBufSize+1 into slot 1.
+        QCOMPARE(tsBuf[0], qint64(1000 + kBufSize));
+        QCOMPARE(tsBuf[1], qint64(1000 + kBufSize + 1));
+        QCOMPARE(acqNum->loadRelaxed(), kBufSize + 2);
+    }
+
+    // First successful read seeds the offset so the counter tracks the
+    // acquisition count from frame 2 on; the first slot keeps the raw counter
+    // value (long-standing behavior all three backends shared).
+    void daqCounterOffsetSeeding()
+    {
+        buildStream();
+        stream->script[SEL_CONTRAST] = {{true, 100}, {true, 101}, {true, 102}};
+        for (int i = 0; i < 3; i++)
+            stream->commitFrame(bgrFrame(), i);
+        QCOMPARE(daqBuf[0], qint64(100));
+        QCOMPARE(daqBuf[1], qint64(2));
+        QCOMPARE(daqBuf[2], qint64(3));
+    }
+
+    // A failed counter read must write the -1 sentinel, not fabricate a 0 -
+    // and critically must NOT seed the offset (a garbage offset on frame 0
+    // used to corrupt the whole recording's counter column).
+    void daqCounterFailedReadWritesSentinel()
+    {
+        buildStream();
+        stream->script[SEL_CONTRAST] = {{false, 0}, {true, 200}, {true, 201}};
+        for (int i = 0; i < 3; i++)
+            stream->commitFrame(bgrFrame(), i);
+        QCOMPARE(daqBuf[0], qint64(-1));       // failed read: sentinel
+        QCOMPARE(daqBuf[1], qint64(200));      // first SUCCESS seeds (raw value kept)
+        QCOMPARE(daqBuf[2], qint64(2));        // tracking from there
+    }
+
+    void noDaqCounterMeansSentinel()
+    {
+        buildStream(0, 0, /*withDaqCounter=*/false);
+        stream->commitFrame(bgrFrame(), 1);
+        QCOMPARE(daqBuf[0], qint64(-1));
+        QCOMPARE(stream->controlReads, 0);   // no counter -> no register traffic
+    }
+
+    void extTriggerEmitsOnEdges()
+    {
+        buildStream();
+        stream->setExtTriggerTrackingState(true);
+        stream->script[SEL_GAMMA] = {{true, 0}, {true, 0}, {true, 1}, {true, 1}, {true, 0}};
+        QSignalSpy triggers(stream, &VideoStreamBase::extTriggered);
+        for (int i = 0; i < 5; i++) {
+            stream->commitFrame(bgrFrame(), i);
+            consumeOne();
+        }
+        QCOMPARE(triggers.count(), 2);
+        QCOMPARE(triggers.at(0).at(0).toBool(), true);    // 0 -> 1 rising
+        QCOMPARE(triggers.at(1).at(0).toBool(), false);   // 1 -> 0 falling
+    }
+
+    // A failed trigger read is skipped entirely: treating it as 0 would fake
+    // a falling edge (and the rebound a rising one).
+    void extTriggerFailedReadFakesNoEdge()
+    {
+        buildStream();
+        stream->setExtTriggerTrackingState(true);
+        stream->script[SEL_GAMMA] = {{true, 1}, {false, 0}, {true, 1}};
+        QSignalSpy triggers(stream, &VideoStreamBase::extTriggered);
+        for (int i = 0; i < 3; i++) {
+            stream->commitFrame(bgrFrame(), i);
+            consumeOne();
+        }
+        QCOMPARE(triggers.count(), 0);
+    }
+
+    void bnoUnpacksIntoSlot()
+    {
+        buildStream();
+        stream->setHeadOrientationConfig(true, false);
+        // Unit quaternion w=1: raw w = 2^14, x=y=z=0.
+        stream->script[SEL_SATURATION] = {{true, 16384}};
+        stream->commitFrame(bgrFrame(), 1);
+        QCOMPARE(bnoBuf[0], 1.0f);                       // w
+        QCOMPARE(bnoBuf[1], 0.0f);                       // x
+        QCOMPARE(bnoBuf[2], 0.0f);                       // y
+        QCOMPARE(bnoBuf[3], 0.0f);                       // z
+        QVERIFY(qAbs(bnoBuf[4]) < 1e-5f);                // normError ~ 0
+    }
+
+    // Failed BNO reads keep the last good quaternion instead of fabricating
+    // an all-zero one; before any good read, the default is flagged corrupt
+    // via normError = 1 so consumers reject it.
+    void bnoFailedReadKeepsLastGood()
+    {
+        buildStream();
+        stream->setHeadOrientationConfig(true, false);
+        stream->script[SEL_SATURATION] = {{false, 0}, {true, 16384}, {false, 0}};
+        for (int i = 0; i < 3; i++) {
+            stream->commitFrame(bgrFrame(), i);
+            consumeOne();
+        }
+        QCOMPARE(bnoBuf[0 * 5 + 0], 0.0f);   // before first success: zero quat...
+        QCOMPARE(bnoBuf[0 * 5 + 4], 1.0f);   // ...flagged corrupt
+        QCOMPARE(bnoBuf[1 * 5 + 0], 1.0f);   // good read
+        QCOMPARE(bnoBuf[2 * 5 + 0], 1.0f);   // failed read keeps last good
+        QVERIFY(qAbs(bnoBuf[2 * 5 + 4]) < 1e-5f);
+    }
+
+    void frameSizeLocksToFirstFrame()
+    {
+        buildStream();
+        QSignalSpy messages(stream, &VideoStreamBase::sendMessage);
+        QSignalSpy newFrame(stream, &VideoStreamBase::newFrameAvailable);
+
+        stream->commitFrame(bgrFrame(4, 4), 1);
+        stream->commitFrame(bgrFrame(8, 8), 2);   // mid-stream size change: dropped
+        stream->commitFrame(bgrFrame(4, 4), 3);   // matching frames keep flowing
+
+        QCOMPARE(newFrame.count(), 2);
+        QCOMPARE(acqNum->loadRelaxed(), 2);
+        QCOMPARE(messages.count(), 1);
+        QVERIFY(messages.at(0).at(0).toString().contains("mid-stream"));
+    }
+
+    void mismatchWarningOncePerEpisode()
+    {
+        buildStream();
+        QSignalSpy messages(stream, &VideoStreamBase::sendMessage);
+        stream->commitFrame(bgrFrame(4, 4), 1);
+        stream->commitFrame(bgrFrame(8, 8), 2);
+        stream->commitFrame(bgrFrame(8, 8), 3);   // same episode: quiet drop
+        QCOMPARE(messages.count(), 1);
+        stream->commitFrame(bgrFrame(4, 4), 4);   // recovery resets the warning
+        stream->commitFrame(bgrFrame(8, 8), 5);   // new episode warns again
+        QCOMPARE(messages.count(), 2);
+    }
+
+    void configSizeMismatchWarnsButCommits()
+    {
+        buildStream(10, 10);
+        QSignalSpy messages(stream, &VideoStreamBase::sendMessage);
+        stream->commitFrame(bgrFrame(4, 4), 1);
+        QCOMPARE(acqNum->loadRelaxed(), 1);   // still committed
+        QCOMPARE(messages.count(), 1);
+        QVERIFY(messages.at(0).at(0).toString().contains("config expects"));
+    }
+
+    void backoffProgression()
+    {
+        ReconnectBackoff backoff;
+        QVERIFY(backoff.firstFailure());
+        QCOMPARE(backoff.nextDelayMs(), 1000);
+        QVERIFY(!backoff.firstFailure());
+        QCOMPARE(backoff.nextDelayMs(), 2000);
+        QCOMPARE(backoff.nextDelayMs(), 3000);
+        QCOMPARE(backoff.nextDelayMs(), 4000);
+        QCOMPARE(backoff.nextDelayMs(), 5000);
+        QCOMPARE(backoff.nextDelayMs(), 5000);   // capped
+        QCOMPARE(backoff.attempts(), 6);
+        backoff.reset();
+        QVERIFY(backoff.firstFailure());
+        QCOMPARE(backoff.nextDelayMs(), 1000);
+    }
+};
+
+QTEST_GUILESS_MAIN(TestVideoStreamBase)
+#include "tst_videostreambase.moc"

--- a/tests/tst_videostreambase.cpp
+++ b/tests/tst_videostreambase.cpp
@@ -200,6 +200,20 @@ private slots:
         QCOMPARE(daqBuf[2], qint64(2));        // tracking from there
     }
 
+    // The counter register is unsigned 16-bit (UVC CONTRAST): raw values
+    // above 32767 must not flip negative (they did on the pre-R4 libuvc/mac
+    // paths, which read it through a signed cast).
+    void daqCounterIsUnsigned()
+    {
+        buildStream();
+        stream->script[SEL_CONTRAST] = {{true, 40000}, {true, 40001}};
+        stream->commitFrame(bgrFrame(), 0);
+        consumeOne();
+        stream->commitFrame(bgrFrame(), 1);
+        QCOMPARE(daqBuf[0], qint64(40000));
+        QCOMPARE(daqBuf[1], qint64(2));
+    }
+
     void noDaqCounterMeansSentinel()
     {
         buildStream(0, 0, /*withDaqCounter=*/false);


### PR DESCRIPTION
The last substantial refactor before v2.0.0. The OpenCV, libuvc, and macOS hybrid backends each carried a private copy of everything between acquiring a frame and publishing it (~250 duplicated lines that had already drifted once — the acquire-first fix in #90 had to be applied three times). `VideoStreamBase` now owns the shared machinery; each backend keeps only its transport.

## What moved into the base

- **`commitFrame()`** — the per-frame block: ring-slot reservation (acquire-first), timestamping, convert-to-slot (virtual; libuvc overrides for raw YUYV), external-trigger edge detection, BNO quaternion capture, DAQ frame-counter bookkeeping, publish/emit. Backends provide `readControl()` / `writeControlWord()` / `attemptReconnect()` hooks.
- **`runReconnectCycle()` + `ReconnectBackoff`** — one reconnect policy everywhere: message + optional diagnosis on the first failure of an episode, then 1 s → 5 s backoff. The plain-OpenCV and libuvc paths previously spammed a warning every second forever with no backoff.
- **Frame-size lock** — the stream locks to its first delivered frame size and drops mid-stream size changes loudly instead of writing mixed-size frames into the ring buffer the recorder is consuming (the failure mode behind the ΔF/F crash fixed in #89).
- The trivial slots/setters (`stopStream` — typo fixed from `stopSteam` — `setPropertyI2C`, `setIsColor`, …) and `setBufferParameters`, previously identical in all three classes.

## Bugs fixed along the way

- **Failed UVC control reads were indistinguishable from reading 0**: a failed read could fake an external-trigger edge, fabricate an all-zero head-orientation quaternion, and corrupt the DAQ counter offset for the whole recording if it hit frame 0. Failed reads are now skipped (trigger), hold the last good value (BNO), and log `-1` in the DAQ Frame Number CSV column so gaps are visible post-hoc. The offset seeds on the first *successful* read.
- **Linux cameras could never reconnect**: `attemptReconnect()` had no `"V4L"` case, so the retry loop ran forever.
- **Quit-during-reconnect use-after-free window**: the backoff slept up to 5 s in one blind `msleep` while `stopAndJoinStream()` waits only 3 s; the abandoned thread could wake and write into freed buffers. The backoff now sleeps in 100 ms slices, delivering queued events and checking the stop flag.
- **Stale commands flushed ahead of SERDES mode packets on reconnect** (pre-existing on libuvc/mac): the queue is now cleared before the mode packets; `requestInitCommands` restores device state right after.
- **Connect-time errors never reached the message console** (emitted before the message wiring existed, at two hops): `VideoDevice` now holds early messages and the backend relays them after wiring — "webcam resolve failed: …" and friends finally show up in the UI.

## Review + validation

Two independent adversarial review passes (old-vs-new behavior comparison per backend) drove three corrections before this PR: the DAQ counter stays **unsigned** 16-bit (preserving historical Windows/OpenCV CSV values byte-for-byte; the direct backends lose a false sign-flip at raw 32767), the macOS stall diagnosis still runs **before** the AVF session is released (the counter only advances while streaming — releasing first would flip ADVANCING verdicts to FROZEN), and the shutdown race above.

- New `tst_videostreambase` (15 cases): stub backend with scripted control reads pins acquire-first drops, ring wrap, offset seeding, `-1` sentinels, trigger edges (incl. no fake edges on read failure), BNO last-good, size lock/recovery, backoff progression. First unit coverage this logic has ever had. Plus `queueClearDropsEverything` in the protocol suite. All 10 suites green; clean build has zero warnings.
- **Live-validated on macOS**: webcam recording with unplug/replug mid-recording through the consolidated path — 115 CSV rows == 115 avi frames, contiguous frame numbers, monotonic timestamps, the 11.5 s outage visible as one honest gap, constant frame size through reconnect, quiet paced retries instead of 1 Hz spam.
- **Windows hardware pass planned** (real Miniscope on the OCV/DirectShow path) before merge — the one surface macOS can't exercise. Linux/libuvc is compile-verified by CI; its loop structure is preserved line-for-line around the shared calls.