### PR TITLE
Opt-in fine led0 steps for V4 miniscopes (backwards-compatible #69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,14 @@ published together from CI.
 - Removed `deviceConfigs/miniscopes.json` and `behaviorCams.json` — dead
   since the device catalog moved to `videoDevices.json`, but they looked
   authoritative and old wiki instructions pointed users at them.
+- **Opt-in fine `led0` steps** for V4 miniscopes: set
+  `"led0FineSteps": true` on the device in the user config and the
+  illumination slider runs 0–255, addressing the LED driver's 255 hardware
+  steps individually instead of 0–100%, giving 2.55× finer steps — bright
+  preps needing very dim illumination asked for this
+  ([#68](https://github.com/Aharoni-Lab/Miniscope-DAQ-QT-Software/issues/68)/[#69](https://github.com/Aharoni-Lab/Miniscope-DAQ-QT-Software/pull/69)).
+  Both mappings span the same brightness range. Without the flag, nothing
+  changes: existing configs keep their exact LED output.
 
 **Recorded-data quality**
 - Miniscope `timeStamps.csv` files gain a **`DAQ Frame Number`** column: the

--- a/deviceConfigs/userConfigProps.json
+++ b/deviceConfigs/userConfigProps.json
@@ -255,7 +255,11 @@
                 },
                 "led0": {
                     "type": "Integer",
-                    "tips": "This sets the initial excitation LED intensity. Values can be from 0 to 100 but many Miniscope configurations have trouble with values over 70 or 80 due to current limits through certain coax cable lengths."
+                    "tips": "This sets the initial excitation LED intensity. Values can be from 0 to 100 (or 0 to 255 when led0FineSteps is true) but many Miniscope configurations have trouble with values over 70% of the range due to current limits through certain coax cable lengths."
+                },
+                "led0FineSteps": {
+                    "type": "Boolean",
+                    "tips": "When true, the led0 slider runs 0 to 255 and addresses every hardware step of the LED driver individually instead of 0 to 100 percent, giving 2.55x finer steps for very dim illumination. Both mappings span the same brightness range. Leave off (default) to keep the exact LED output of existing configs."
                 },
                 "frameRate": {
                     "type": "String",

--- a/deviceConfigs/userConfigSchema.json
+++ b/deviceConfigs/userConfigSchema.json
@@ -285,7 +285,11 @@
                         "led0": {
                             "type": "number",
                             "minimum": 0,
-                            "description": "Excitation LED power at startup."
+                            "description": "Excitation LED power at startup, in the led0 slider's units (0-100 by default; 0-255 with led0FineSteps)."
+                        },
+                        "led0FineSteps": {
+                            "type": "boolean",
+                            "description": "When true, the led0 slider runs 0-255 and addresses the LED driver's 255 hardware steps individually instead of 0-100%, giving 2.55x finer steps - useful for very dim illumination. Both mappings span the same brightness range. Off by default: existing configs keep their exact LED output."
                         },
                         "ewl": {
                             "type": "number",

--- a/deviceConfigs/videoDevices.json
+++ b/deviceConfigs/videoDevices.json
@@ -314,6 +314,10 @@
                 "stepSize": 1,
                 "displayValueScale": -2.55,
                 "displayValueOffset": -255,
+                "fineSteps": {
+                    "max": 255,
+                    "displayValueScale": -1
+                },
                 "sendCommand": [
                     {
                         "protocol": "I2C",
@@ -527,6 +531,10 @@
                 "stepSize": 1,
                 "displayValueScale": -2.55,
                 "displayValueOffset": -255,
+                "fineSteps": {
+                    "max": 255,
+                    "displayValueScale": -1
+                },
                 "sendCommand": [
                     {
                         "protocol": "I2C",

--- a/source/videodevice.cpp
+++ b/source/videodevice.cpp
@@ -444,26 +444,21 @@ void VideoDevice::configureDeviceControls() {
 //        qDebug() << controlItem;
         values = controlSettings[controlName[i]].toObject();
 
-        // Opt-in alternate control map: a catalog control block may carry a
-        // "fineSteps" override set (e.g. V4 led0 addressing all 255 hardware
-        // steps individually - slider 0-255 - instead of 100 coarse percent
-        // steps; issue #68. Both mappings span the same brightness range,
-        // only the step size differs). The user config enables it per device
-        // with "<control>FineSteps": true; without the flag the historical
-        // mapping is untouched, so existing configs keep their exact LED
-        // output.
+        // Merge the catalog's optional "fineSteps" override block (issue #68:
+        // e.g. V4 led0 at one hardware step per slider tick) when the user
+        // config sets "<control>FineSteps": true. take() runs unconditionally
+        // so the block is never forwarded to the QML item as a property.
         const QJsonObject fineSteps = values.take("fineSteps").toObject();
-        if (m_ucDevice[controlName[i] + "FineSteps"].toBool(false)) {
+        if (m_ucDevice[controlName[i] + "FineSteps"].toBool()) {
             if (fineSteps.isEmpty()) {
-                sendMessage("Warning: " + m_deviceName + ": " + controlName[i] + "FineSteps is set, but "
+                sendMessage("Warning: " + m_deviceName + " has " + controlName[i] + "FineSteps set, but "
                             + m_deviceType + " defines no fine-steps mapping for " + controlName[i]
                             + ". Using the default mapping.");
             }
             else {
                 for (auto it = fineSteps.constBegin(); it != fineSteps.constEnd(); ++it)
                     values[it.key()] = it.value();
-                sendMessage(m_deviceName + " " + controlName[i] + " using fine hardware steps (0-"
-                            + QString::number(values["max"].toDouble()) + ").");
+                sendMessage(m_deviceName + " " + controlName[i] + " is using fine hardware steps.");
             }
         }
 

--- a/source/videodevice.cpp
+++ b/source/videodevice.cpp
@@ -444,6 +444,29 @@ void VideoDevice::configureDeviceControls() {
 //        qDebug() << controlItem;
         values = controlSettings[controlName[i]].toObject();
 
+        // Opt-in alternate control map: a catalog control block may carry a
+        // "fineSteps" override set (e.g. V4 led0 addressing all 255 hardware
+        // steps individually - slider 0-255 - instead of 100 coarse percent
+        // steps; issue #68. Both mappings span the same brightness range,
+        // only the step size differs). The user config enables it per device
+        // with "<control>FineSteps": true; without the flag the historical
+        // mapping is untouched, so existing configs keep their exact LED
+        // output.
+        const QJsonObject fineSteps = values.take("fineSteps").toObject();
+        if (m_ucDevice[controlName[i] + "FineSteps"].toBool(false)) {
+            if (fineSteps.isEmpty()) {
+                sendMessage("Warning: " + m_deviceName + ": " + controlName[i] + "FineSteps is set, but "
+                            + m_deviceType + " defines no fine-steps mapping for " + controlName[i]
+                            + ". Using the default mapping.");
+            }
+            else {
+                for (auto it = fineSteps.constBegin(); it != fineSteps.constEnd(); ++it)
+                    values[it.key()] = it.value();
+                sendMessage(m_deviceName + " " + controlName[i] + " using fine hardware steps (0-"
+                            + QString::number(values["max"].toDouble()) + ").");
+            }
+        }
+
         if (m_ucDevice.contains(controlName[i])) {// sets starting value if it is defined in user config
             if (m_ucDevice[controlName[i]].isDouble())
                 values["startValue"] = m_ucDevice[controlName[i]].toDouble();

--- a/tests/tst_configvalidator.cpp
+++ b/tests/tst_configvalidator.cpp
@@ -26,6 +26,7 @@ private slots:
     void missingRequiredKeyWarns();
     void legacyDeviceArrayFormValidates();
     void missingSchemaFileWarnsInsteadOfBlocking();
+    void catalogFineStepsBlocksAreWellFormed();
 
 private:
     QJsonObject loadJson(const QString &path);
@@ -177,6 +178,56 @@ void TestConfigValidator::missingSchemaFileWarnsInsteadOfBlocking()
         checkUserConfig(config, QStringLiteral("/nonexistent/schema.json"));
     QCOMPARE(messages.size(), 1);
     QVERIFY(messages[0].contains("skipping config validation"));
+}
+
+// The fine-steps feature's fragile surface is the shipped catalog, not the
+// 5-line merge in videodevice.cpp: a videoDevices.json edit could drop a V4
+// "fineSteps" block, typo a key (merged keys flow into QQuickItem::setProperty,
+// which fails SILENTLY for unknown properties), or override semantic fields
+// like sendCommand. Pin the shape here so catalog edits can't rot the flag.
+void TestConfigValidator::catalogFineStepsBlocksAreWellFormed()
+{
+    const QJsonObject catalog =
+        loadJson(QStringLiteral(REPO_SOURCE_DIR "/deviceConfigs/videoDevices.json"));
+    QVERIFY(!catalog.isEmpty());
+
+    int fineStepsBlocks = 0;
+    for (auto dev = catalog.constBegin(); dev != catalog.constEnd(); ++dev) {
+        const QJsonObject controls = dev.value().toObject()["controlSettings"].toObject();
+        for (auto ctl = controls.constBegin(); ctl != controls.constEnd(); ++ctl) {
+            const QJsonObject control = ctl.value().toObject();
+            if (!control.contains("fineSteps"))
+                continue;
+            fineStepsBlocks++;
+            const QJsonObject fineSteps = control["fineSteps"].toObject();
+            QVERIFY2(!fineSteps.isEmpty(),
+                     qPrintable(dev.key() + "/" + ctl.key() + ": fineSteps must be a non-empty object"));
+            for (auto it = fineSteps.constBegin(); it != fineSteps.constEnd(); ++it) {
+                const QString where = dev.key() + "/" + ctl.key() + "/fineSteps/" + it.key();
+                // Only override keys the control itself defines - anything else
+                // would reach setProperty() on the QML item and fail silently.
+                QVERIFY2(control.contains(it.key()),
+                         qPrintable(where + " overrides a key the control does not define"));
+                // Overriding the wire command or the boot value is beyond what
+                // the flag means (a finer slider mapping).
+                QVERIFY2(it.key() != "sendCommand" && it.key() != "startValue",
+                         qPrintable(where + " must not override command/startValue semantics"));
+                QVERIFY2(it.value().type() == control[it.key()].type(),
+                         qPrintable(where + " changes the JSON type of the key it overrides"));
+            }
+        }
+    }
+
+    // The shipped feature: both V4 variants carry the led0 mapping (0-255,
+    // one hardware step per tick on the inverted register).
+    for (const QString &devName : {QStringLiteral("Miniscope_V4"), QStringLiteral("Miniscope_V4_BNO")}) {
+        const QJsonObject fineSteps = catalog[devName].toObject()["controlSettings"]
+                                          .toObject()["led0"].toObject()["fineSteps"].toObject();
+        QVERIFY2(!fineSteps.isEmpty(), qPrintable(devName + " lost its led0 fineSteps block"));
+        QCOMPARE(fineSteps["max"].toDouble(), 255.0);
+        QCOMPARE(fineSteps["displayValueScale"].toDouble(), -1.0);
+    }
+    QCOMPARE(fineStepsBlocks, 2);
 }
 
 QTEST_MAIN(TestConfigValidator)


### PR DESCRIPTION
Ports the intent of #69 (issue #68: bright preps need dimmer minimum illumination than the 0–100% mapping's 101 coarse steps allow) onto qt6-port, reworked to be **fully backwards compatible**: a config using `led0: 10` produces exactly the same LED output as before this PR.

Named `FineSteps`: both mappings span the same brightness range — the flag changes the *step size* (256 addressable steps vs 101). Not "range" (the default already covers the full range) and not "resolution" (reads as imaging resolution).

## How it works

- `deviceConfigs/videoDevices.json`: the V4 / V4_BNO `led0` blocks keep their historical mapping untouched and gain a `"fineSteps"` override set (`max: 255`, `displayValueScale: -1` → `i2c = 255 − v`).
- A user config opts in per device with `"led0FineSteps": true` — the slider then runs 0–255, one hardware step per tick (slider 1 = the dimmest non-off setting the driver has).
- Without the flag, nothing changes anywhere.
- The merge is generic (`<control>FineSteps` picks up a catalog `"fineSteps"` block), so no LED-specific code; setting the flag for a device type without such a mapping warns and uses the default. Documented in the JSON schema (autocomplete + description in editors).

## Why not #69 as filed

Two reasons:
1. It changed the default mapping, silently re-scaling the LED output of every existing user config.
2. Its proposed map had a sign error: `scale: 1, offset: 255` gives `i2c = v − 255`, and the packet builder packs `quint32(round(v)) & 0xFF` — so slider 0 would send register 1, near **maximum** brightness where the user expects *off* (the register is inverted: 255 = off, 0 = max). The corrected map is `255 − v`.

## Validation

- All 10 test suites green, warning-clean build; shipped example configs still validate against the schema (CI-guarded).
- The flag path needs a quick hardware sanity check on the next bench session: set `"led0FineSteps": true`, confirm slider 0 = LED off, slider 255 = max, and small values are visibly dimmer than the default map's step 1.

Closes #68. Supersedes #69 (credit to @sneakers-the-rat for the diagnosis and the original PR).