### PR TITLE
Add Open Ephys commutator control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,18 @@ published together from CI.
 - Stopping a recording now **drains the ring buffer** first, so the last
   frames of a session are saved instead of silently dropped.
 
+**Hardware integration**
+- **Open Ephys commutator control**: the software can now drive an
+  [Open Ephys commutator](https://github.com/open-ephys/commutator-controller)
+  directly over its USB serial port, so the tether unwinds as the animal turns
+  — no separate Bonsai workflow required. A V4 (or newer) Miniscope's live BNO
+  head orientation is converted to incremental motor turns (a C++ port of the
+  [bonsai-commutator](https://github.com/open-ephys/bonsai-commutator)
+  `QuaternionToTwist` algorithm) and streamed to the device on its own thread.
+  Enable it with a top-level `commutator` block in the user config (`enabled`,
+  `port`, optional `deviceName`, and — for non-standard mounts — `headstageAxis`
+  / `commutatorAxis` / `fallbackMode`). Off unless configured.
+
 ### Changed
 - Build system: qmake → **CMake** (Qt 6.4+, C++17). The old `.pro` file is no
   longer used.
@@ -180,6 +192,12 @@ published together from CI.
 - Device connection errors (wrong `deviceID`, device busy, resolve failures)
   now appear in the message console — they used to be emitted before the
   message log was listening, so only a generic "cannot connect" ever showed.
+- The live **"Dropped Frames"** readout no longer sticks at `N/A` for the rest
+  of a session after a Miniscope is unplugged and reconnected. The device's
+  frame counter restarts when it power-cycles (as the recorded `DAQ Frame
+  Number` column intentionally shows), which left the live readout permanently
+  negative; it is now measured within each connection span. The recorded CSV
+  column is unchanged.
 
 ## [1.11] and earlier
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,9 @@ set(CMAKE_AUTORCC ON)   # compiles source/qml.qrc automatically
 # QOpenGLFramebufferObject moved out of QtGui into the separate Qt6::OpenGL
 # module. The custom renderers (videodisplay, tracedisplay, behaviortracker)
 # need it.
-find_package(Qt6 6.4 REQUIRED COMPONENTS Core Gui Qml Quick QuickControls2 Widgets OpenGL)
+# SerialPort (Qt6::SerialPort) drives the optional Open Ephys commutator. It is a
+# separate conda-forge package, qt6-serialport, version-locked to qt6-main.
+find_package(Qt6 6.4 REQUIRED COMPONENTS Core Gui Qml Quick QuickControls2 Widgets OpenGL SerialPort)
 qt_standard_project_setup(REQUIRES 6.4)
 
 # This project has no .ui files (the UI is all QML), so AUTOUIC is unnecessary.
@@ -115,6 +117,7 @@ endif()
 # --- Sources ---------------------------------------------------------------
 set(SOURCES
     source/backend.cpp
+    source/commutator.cpp
     source/configvalidator.cpp
     source/behaviorcam.cpp
     source/behaviortracker.cpp
@@ -125,6 +128,7 @@ set(SOURCES
     source/miniscope.cpp
     source/newquickview.cpp
     source/tracedisplay.cpp
+    source/twistcalculator.cpp
     source/videodevice.cpp
     source/videodisplay.cpp
     source/videostreambase.cpp
@@ -134,6 +138,7 @@ set(SOURCES
 
 set(HEADERS
     source/backend.h
+    source/commutator.h
     source/configvalidator.h
     source/behaviorcam.h
     source/behaviortracker.h
@@ -143,6 +148,7 @@ set(HEADERS
     source/miniscope.h
     source/newquickview.h
     source/tracedisplay.h
+    source/twistcalculator.h
     source/videodevice.h
     source/videodisplay.h
     source/videostreamocv.h
@@ -260,6 +266,7 @@ target_link_libraries(MiniscopeDAQ PRIVATE
     Qt6::QuickControls2
     Qt6::Widgets
     Qt6::OpenGL
+    Qt6::SerialPort
     ${OpenCV_LIBS}
 )
 

--- a/deviceConfigs/userConfigProps.json
+++ b/deviceConfigs/userConfigProps.json
@@ -174,6 +174,44 @@
             "tips": "These 'window' key: value pairs define the location and size of the trace display window."
         }
     },
+    "commutator": {
+        "enabled": {
+            "type": "Bool",
+            "tips": "Enables driving an Open Ephys commutator (github.com/open-ephys/commutator-controller) so the tether unwinds as the animal turns. Requires a V4 (or newer) Miniscope with head orientation enabled. No Bonsai needed."
+        },
+        "port": {
+            "type": "String",
+            "tips": "Serial port the commutator is connected to, e.g. \"COM5\" on Windows, \"/dev/ttyACM0\" on Linux, or \"/dev/cu.usbmodemXXXX\" on macOS. If the port can't be opened, the software prints the list of available ports to the message log."
+        },
+        "deviceName": {
+            "type": "String",
+            "tips": "Which Miniscope's head orientation drives the commutator, matching its name under devices/miniscopes. Leave blank to use the first Miniscope that has head orientation enabled."
+        },
+        "led": {
+            "type": "Bool",
+            "tips": "Turns the commutator's indicator LED on or off. Defaults to on."
+        },
+        "sampleRate": {
+            "type": "Double",
+            "tips": "How many times per second the head orientation is sampled to compute a rotation command, in Hz. 10 is a good default."
+        },
+        "headstageAxis": {
+            "type": "Array(Double)",
+            "tips": "The direction the tether leaves the headstage as [x, y, z] in the Miniscope IMU's reference frame. Default is [0, 0, 1]. If the commutator winds the tether up instead of unwinding it, negate this to [0, 0, -1]."
+        },
+        "commutatorAxis": {
+            "type": "Array(Double)",
+            "tips": "The direction the tether enters the rotating part of the commutator as [x, y, z] in the global frame. Default [0, 0, 1] works for the usual upright mounting."
+        },
+        "fallbackThreshold": {
+            "type": "Double",
+            "tips": "Advanced. Cosine threshold where the twist calculation switches to a fallback near its mathematical pole. Default -0.9. Most setups never need to change this."
+        },
+        "fallbackMode": {
+            "type": "String",
+            "tips": "Advanced. Either \"global\" or \"local\" - which rotation to assume at the pole. Default \"global\"."
+        }
+    },
     "devices": {
         "miniscopes": {
             "miniscopeDeviceName": {

--- a/deviceConfigs/userConfigSchema.json
+++ b/deviceConfigs/userConfigSchema.json
@@ -197,6 +197,56 @@
                 "windowWidth": { "type": "integer", "minimum": 1 },
                 "windowHeight": { "type": "integer", "minimum": 1 }
             }
+        },
+        "commutator": {
+            "type": "object",
+            "description": "Optional Open Ephys commutator control (github.com/open-ephys/commutator-controller). When enabled, the software drives the commutator over its USB serial port using a Miniscope's live BNO head orientation, so the tether unwinds as the animal turns - no Bonsai needed. Needs a V4_BNO (or newer) Miniscope with headOrientation.enabled true.",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Turns the whole commutator feature on/off."
+                },
+                "port": {
+                    "type": "string",
+                    "description": "Serial port the commutator is on, e.g. \"COM5\" (Windows), \"/dev/ttyACM0\" (Linux), \"/dev/cu.usbmodemXXXX\" (macOS). If it can't be opened, the software logs the available ports."
+                },
+                "deviceName": {
+                    "type": "string",
+                    "description": "Which Miniscope's head orientation drives the commutator (its key under devices.miniscopes). Optional: if omitted, the first Miniscope with headOrientation enabled is used."
+                },
+                "led": {
+                    "type": "boolean",
+                    "description": "Turn the commutator's indicator LED on (default true)."
+                },
+                "sampleRate": {
+                    "type": "number",
+                    "exclusiveMinimum": 0,
+                    "description": "How many times per second (Hz) the orientation is sampled to compute a turn command. Default 10."
+                },
+                "headstageAxis": {
+                    "type": "array",
+                    "items": { "type": "number" },
+                    "minItems": 3,
+                    "maxItems": 3,
+                    "description": "Direction the tether leaves the headstage, as [x, y, z] in the IMU's reference frame. Default [0, 0, 1]. Negate it (e.g. [0, 0, -1]) if the commutator winds the tether up instead of unwinding it."
+                },
+                "commutatorAxis": {
+                    "type": "array",
+                    "items": { "type": "number" },
+                    "minItems": 3,
+                    "maxItems": 3,
+                    "description": "Direction the tether enters the rotating commutator element, as [x, y, z] in the global frame. Default [0, 0, 1] for an upright mount."
+                },
+                "fallbackThreshold": {
+                    "type": "number",
+                    "description": "Advanced: cosine threshold below which the twist estimate uses a fallback near its mathematical pole (headstage and commutator axes nearly opposed). Default -0.9."
+                },
+                "fallbackMode": {
+                    "type": "string",
+                    "enum": ["global", "local"],
+                    "description": "Advanced: which rotation to assume at the pole - \"global\" (orbital motion about the commutator) or \"local\" (about the headstage tether axis). Default \"global\"."
+                }
+            }
         }
     },
     "definitions": {

--- a/environment.yml
+++ b/environment.yml
@@ -36,6 +36,7 @@ channels:
 dependencies:
   - python=3.12
   - qt6-main=6.11
+  - qt6-serialport=6.11   # Qt6::SerialPort (commutator control); version-locked to qt6-main
   - libopencv=4.13
   - numpy=2.4
   - cmake

--- a/source/backend.cpp
+++ b/source/backend.cpp
@@ -1151,6 +1151,16 @@ void backEnd::shutdownThreads()
     for (int i = 0; i < behavCam.length(); i++)
         behavCam[i]->stopAndJoinStream();
 
+    // 2b. Commutator worker: disable the motor and stop its thread. Done after
+    //     the Miniscopes are quiet so no more orientation samples are queued to
+    //     it. Blocking invoke so {enable:false} is written before the port closes.
+    if (commutatorThread && commutatorThread->isRunning()) {
+        QMetaObject::invokeMethod(commutator, "stopRunning", Qt::BlockingQueuedConnection);
+        commutatorThread->quit();
+        if (!commutatorThread->wait(3000))
+            qWarning() << "Commutator thread did not stop within 3s; leaking it";
+    }
+
     // 3. Then the saver loop and its thread.
     if (dataSaverThread && dataSaverThread->isRunning()) {
         QMetaObject::invokeMethod(dataSaver, "stopRunning", Qt::QueuedConnection);
@@ -1409,6 +1419,7 @@ void backEnd::parseUserConfig()
 
     ucBehaviorTracker = m_userConfig["behaviorTracker"].toObject();
     ucTraceDisplay = m_userConfig["traceDisplay"].toObject();
+    ucCommutator = m_userConfig["commutator"].toObject();
 
 
 }
@@ -1583,6 +1594,57 @@ void backEnd::constructUserConfigGUI()
         }
     }
 
+    // Optional commutator (needs a Miniscope with head orientation to drive it,
+    // so create it after the Miniscopes exist).
+    setupCommutator();
+
     connectSnS();
+}
+
+// Create the commutator worker and put it on its own thread when the config asks
+// for one. The BNO quaternion of the chosen source Miniscope is wired straight to
+// it; from then on the worker owns the serial port and does all I/O off the GUI
+// thread. Every early-return path explains itself in the message console rather
+// than failing silently.
+void backEnd::setupCommutator()
+{
+    if (ucCommutator.isEmpty() || !ucCommutator["enabled"].toBool(false))
+        return;
+
+    // Resolve the source Miniscope: the named one, else the first with head
+    // orientation streaming enabled.
+    const QString wanted = ucCommutator["deviceName"].toString();
+    Miniscope *source = nullptr;
+    for (Miniscope *m : miniscope) {
+        if (!wanted.isEmpty()) {
+            if (m->getDeviceName() == wanted) { source = m; break; }
+        }
+        else if (m->getHeadOrienataionStreamState()) {
+            source = m;
+            break;
+        }
+    }
+
+    if (!source) {
+        if (!wanted.isEmpty())
+            sendMessage("ERROR: Commutator deviceName \"" + wanted
+                        + "\" matches no configured Miniscope; commutator disabled.");
+        else
+            sendMessage("ERROR: Commutator needs a Miniscope with headOrientation enabled to "
+                        "drive it, but none was found; commutator disabled.");
+        return;
+    }
+    if (!source->getHeadOrienataionStreamState())
+        sendMessage("Warning: Commutator source \"" + source->getDeviceName()
+                    + "\" does not have headOrientation enabled, so no rotation data will flow.");
+
+    commutator = new Commutator(nullptr, ucCommutator);
+    QObject::connect(commutator, SIGNAL(sendMessage(QString)), controlPanel, SLOT(receiveMessage(QString)));
+    QObject::connect(source, &Miniscope::newHeadQuaternion, commutator, &Commutator::handleNewQuaternion);
+
+    commutatorThread = new QThread;
+    commutator->moveToThread(commutatorThread);
+    QObject::connect(commutatorThread, SIGNAL(started()), commutator, SLOT(startRunning()));
+    commutatorThread->start();
 }
 

--- a/source/backend.h
+++ b/source/backend.h
@@ -18,6 +18,7 @@
 #include "datasaver.h"
 #include "behaviortracker.h"
 #include "tracedisplay.h"
+#include "commutator.h"
 
 
 class backEnd : public QObject
@@ -135,6 +136,9 @@ public:
     void parseUserConfig();
 
     void setupBehaviorTracker();
+    // Create + thread the optional commutator worker when the config has an
+    // enabled "commutator" block and a Miniscope to drive it. No-op otherwise.
+    void setupCommutator();
 
     bool checkForUniqueDeviceNames();
     bool checkForCompression();
@@ -217,6 +221,7 @@ private:
     QJsonObject ucBehaviorCams;
     QJsonObject ucBehaviorTracker;
     QJsonObject ucTraceDisplay;
+    QJsonObject ucCommutator;
 
     QVector<Miniscope*> miniscope;
     QVector<BehaviorCam*> behavCam;
@@ -225,6 +230,11 @@ private:
 
     DataSaver *dataSaver;
     QThread *dataSaverThread;
+
+    // Optional Open Ephys commutator driver, on its own thread. Null unless the
+    // config enables it and a source Miniscope is found.
+    Commutator *commutator = nullptr;
+    QThread *commutatorThread = nullptr;
 
     BehaviorTracker *behavTracker;
 

--- a/source/commutator.cpp
+++ b/source/commutator.cpp
@@ -1,0 +1,187 @@
+#include "commutator.h"
+
+#include <QSerialPort>
+#include <QSerialPortInfo>
+#include <QJsonArray>
+
+#include <cmath>
+
+namespace {
+
+// Read a [x, y, z] JSON array into a QVector3D, falling back to def if the value
+// is missing or not a 3-element array.
+QVector3D parseAxis(const QJsonValue &value, const QVector3D &def)
+{
+    const QJsonArray a = value.toArray();
+    if (a.size() != 3)
+        return def;
+    return QVector3D(float(a[0].toDouble()), float(a[1].toDouble()), float(a[2].toDouble()));
+}
+
+// Human-readable list of the serial ports currently present, for error messages
+// when the configured port can't be opened.
+QString availablePortList()
+{
+    QStringList names;
+    for (const QSerialPortInfo &info : QSerialPortInfo::availablePorts())
+        names << info.portName();
+    return names.isEmpty() ? QStringLiteral("(none detected)") : names.join(", ");
+}
+
+} // namespace
+
+Commutator::Commutator(QObject *parent, QJsonObject ucCommutator)
+    : QObject(parent)
+{
+    m_portName = ucCommutator["port"].toString();
+    m_sourceDeviceName = ucCommutator["deviceName"].toString();
+    m_ledEnabled = ucCommutator["led"].toBool(true);
+
+    const double rate = ucCommutator["sampleRate"].toDouble(10.0);
+    m_sampleIntervalMs = (rate > 0.0) ? int(1000.0 / rate) : 100;
+
+    const QVector3D headAxis = parseAxis(ucCommutator["headstageAxis"], QVector3D(0.0f, 0.0f, 1.0f));
+    const QVector3D commAxis = parseAxis(ucCommutator["commutatorAxis"], QVector3D(0.0f, 0.0f, 1.0f));
+    const double fallbackThreshold = ucCommutator["fallbackThreshold"].toDouble(-0.9);
+    const TwistCalculator::FallbackMode mode =
+        (ucCommutator["fallbackMode"].toString("global").compare("local", Qt::CaseInsensitive) == 0)
+            ? TwistCalculator::FallbackMode::Local
+            : TwistCalculator::FallbackMode::Global;
+    m_twist.configure(headAxis, commAxis, fallbackThreshold, mode);
+}
+
+void Commutator::startRunning()
+{
+    if (m_portName.isEmpty()) {
+        emit sendMessage("ERROR: Commutator is enabled but no serial 'port' is set in the config; "
+                         "commutator disabled. Ports available: " + availablePortList());
+        return;
+    }
+
+    m_running = true;
+    openPort();   // if it fails, handleNewQuaternion keeps retrying
+}
+
+bool Commutator::openPort()
+{
+    // Start from a clean port object each attempt (a port dropped on unplug is
+    // closed but still allocated).
+    if (m_port) {
+        m_port->close();
+        m_port->deleteLater();
+        m_port = nullptr;
+    }
+
+    m_port = new QSerialPort(this);
+    m_port->setPortName(m_portName);
+    // The controller is a USB-CDC virtual serial port, which ignores line
+    // settings, but set sane 115200 8N1 values so a real UART adapter also works.
+    m_port->setBaudRate(QSerialPort::Baud115200);
+    m_port->setDataBits(QSerialPort::Data8);
+    m_port->setParity(QSerialPort::NoParity);
+    m_port->setStopBits(QSerialPort::OneStop);
+    m_port->setFlowControl(QSerialPort::NoFlowControl);
+    connect(m_port, &QSerialPort::errorOccurred, this, &Commutator::handlePortError);
+
+    if (!m_port->open(QIODevice::ReadWrite)) {
+        // Report once. Suppressed if we already announced a disconnect (the
+        // unplug case) so a mid-session outage doesn't also spam open failures.
+        if (!m_reportedOpenError && !m_reportedDisconnect) {
+            emit sendMessage("ERROR: Commutator could not open serial port '" + m_portName + "': "
+                             + m_port->errorString() + ". Retrying until it appears. Ports available: "
+                             + availablePortList());
+            m_reportedOpenError = true;
+        }
+        m_port->deleteLater();
+        m_port = nullptr;
+        return false;
+    }
+
+    // Fresh link: discard any stale orientation reference so the first sample
+    // after (re)connecting doesn't emit a large catch-up turn.
+    m_twist.reset();
+    m_haveSampleClock = false;
+    writeCommand(QStringLiteral("{enable:true}"));
+    writeCommand(m_ledEnabled ? QStringLiteral("{led:true}") : QStringLiteral("{led:false}"));
+
+    const bool wasOutage = m_reportedDisconnect || m_reportedOpenError;
+    emit sendMessage(QString(wasOutage ? "Commutator reconnected on " : "Commutator connected on ")
+                     + m_portName + ", driven by \"" + m_sourceDeviceName + "\" head orientation.");
+    m_reportedOpenError = false;
+    m_reportedDisconnect = false;
+    return true;
+}
+
+void Commutator::handlePortError(QSerialPort::SerialPortError error)
+{
+    // ResourceError is what a USB unplug surfaces as; treat a couple of related
+    // fatal states the same way. Close the port so the reconnect path reopens it.
+    if (error != QSerialPort::ResourceError && error != QSerialPort::PermissionError)
+        return;
+
+    if (m_port && m_port->isOpen())
+        m_port->close();
+    if (!m_reportedDisconnect) {
+        emit sendMessage("Commutator disconnected on " + m_portName
+                         + "; will reconnect automatically when it returns.");
+        m_reportedDisconnect = true;
+    }
+}
+
+void Commutator::stopRunning()
+{
+    if (portOk()) {
+        writeCommand(QStringLiteral("{enable:false}"));
+        m_port->flush();
+    }
+    if (m_port) {
+        m_port->close();
+        m_port->deleteLater();
+        m_port = nullptr;
+    }
+    m_running = false;
+}
+
+bool Commutator::portOk() const
+{
+    return m_port && m_port->isOpen();
+}
+
+void Commutator::handleNewQuaternion(double w, double x, double y, double z)
+{
+    if (!m_running)
+        return;
+
+    // Port down (never opened, or unplugged): retry opening it at ~1 Hz instead
+    // of sending. The scope's orientation stream keeps calling us while running,
+    // so this doubles as the reconnect clock - no separate timer needed.
+    if (!portOk()) {
+        if (!m_reconnectClock.isValid() || m_reconnectClock.elapsed() >= 1000) {
+            m_reconnectClock.restart();
+            openPort();
+        }
+        return;
+    }
+
+    // Decimate the (frame-rate) orientation stream to the configured sample
+    // rate, so twist is computed between evenly-spaced samples (matching the
+    // Bonsai SampleInterval -> QuaternionToTwist pipeline) and serial traffic
+    // stays bounded.
+    if (m_haveSampleClock && m_sampleClock.elapsed() < m_sampleIntervalMs)
+        return;
+    m_sampleClock.restart();
+    m_haveSampleClock = true;
+
+    const double turns = m_twist.update(QQuaternion(float(w), float(x), float(y), float(z)));
+
+    // Bonsai skips 0/NaN/inf turns; a still animal produces ~0 and needs no
+    // command. QString::number is locale-independent (no stray decimal commas).
+    if (std::isfinite(turns) && turns != 0.0)
+        writeCommand(QStringLiteral("{turn:%1}").arg(QString::number(turns, 'g', 10)));
+}
+
+void Commutator::writeCommand(const QString &command)
+{
+    if (portOk())
+        m_port->write(command.toUtf8());
+}

--- a/source/commutator.h
+++ b/source/commutator.h
@@ -1,0 +1,84 @@
+#ifndef COMMUTATOR_H
+#define COMMUTATOR_H
+
+#include <QObject>
+#include <QJsonObject>
+#include <QQuaternion>
+#include <QElapsedTimer>
+#include <QString>
+#include <QSerialPort>
+
+#include "twistcalculator.h"
+
+// Drives an Open Ephys commutator (github.com/open-ephys/commutator-controller)
+// directly over its USB serial port, so the tether unwinds as the animal turns
+// without needing the separate Bonsai plugin. It consumes a Miniscope's live BNO
+// head-orientation quaternion, converts each sample to an incremental rotation
+// with TwistCalculator, and writes the device's tiny text protocol:
+//   {turn:<double>}   relative rotation in full motor turns
+//   {enable:<bool>}   motor driver on/off
+//   {led:<bool>}      indicator LED on/off
+//
+// Lives on its own QThread (like DataSaver); quaternions arrive from the source
+// Miniscope's display-frame handler via a queued connection, so no serial I/O
+// ever runs on the GUI/render thread. Configured from the user config's optional
+// top-level "commutator" object.
+class Commutator : public QObject
+{
+    Q_OBJECT
+public:
+    explicit Commutator(QObject *parent, QJsonObject ucCommutator);
+
+    // deviceName of the Miniscope whose head orientation should drive rotation.
+    // Empty means "the first Miniscope with head orientation streaming enabled",
+    // resolved by the backend.
+    QString sourceDeviceName() const { return m_sourceDeviceName; }
+
+public slots:
+    // Thread entry point (connect to QThread::started): opens the serial port and
+    // enables the motor + indicator LED. Emits sendMessage() on success/failure.
+    void startRunning();
+    // Disables the motor and closes the port. Idempotent.
+    void stopRunning();
+
+    // Feed the newest head-orientation quaternion (queued from the Miniscope).
+    // Decimated to the configured sample rate before a turn command is emitted.
+    // Also drives reconnection: while the port is down it retries opening it
+    // (throttled) instead of sending, so a mid-session USB unplug/replug of the
+    // commutator recovers on its own.
+    void handleNewQuaternion(double w, double x, double y, double z);
+
+    // Drops the port when the OS reports the device vanished (unplug), so the
+    // reconnect path in handleNewQuaternion takes over.
+    void handlePortError(QSerialPort::SerialPortError error);
+
+signals:
+    void sendMessage(QString msg);
+
+private:
+    // (Re)open the serial port and, on success, enable the motor + LED and reset
+    // the twist state. Returns true if the port is open afterwards. Emits the
+    // open-failure message only once per outage so retries don't spam the log.
+    bool openPort();
+    bool portOk() const;
+    void writeCommand(const QString &command);
+
+    QString m_portName;
+    QString m_sourceDeviceName;
+    int m_sampleIntervalMs = 100;   // 10 Hz default
+    bool m_ledEnabled = true;
+
+    QSerialPort *m_port = nullptr;
+    TwistCalculator m_twist;
+    QElapsedTimer m_sampleClock;
+    bool m_haveSampleClock = false;
+    bool m_running = false;           // between startRunning() and stopRunning()
+
+    // Reconnection bookkeeping: retry opening the port at ~1 Hz while it is
+    // down, and report each outage/recovery once.
+    QElapsedTimer m_reconnectClock;
+    bool m_reportedOpenError = false;
+    bool m_reportedDisconnect = false;
+};
+
+#endif // COMMUTATOR_H

--- a/source/miniscope.cpp
+++ b/source/miniscope.cpp
@@ -219,6 +219,10 @@ void Miniscope::handleNewDisplayFrame(qint64 timeStamp, cv::Mat frame, int bufId
             bnoDisplay->setProperty("qy", bnoBuffer[bufIdx*5+2]);
             bnoDisplay->setProperty("qz", bnoBuffer[bufIdx*5+3]);
 
+            // Feed the optional commutator (no-op if none is connected).
+            emit newHeadQuaternion(bnoBuffer[bufIdx*5+0], bnoBuffer[bufIdx*5+1],
+                                   bnoBuffer[bufIdx*5+2], bnoBuffer[bufIdx*5+3]);
+
             // Figure out Euler Angles
             double qw = bnoBuffer[bufIdx*5+0];
             double qx = bnoBuffer[bufIdx*5+1];

--- a/source/miniscope.h
+++ b/source/miniscope.h
@@ -39,6 +39,13 @@ public:
 
 
     void setupBNOTraceDisplay() override; // overrides parent
+
+signals:
+    // Emitted once per displayed frame with the latest good BNO quaternion
+    // (w, x, y, z) while head-orientation streaming is on. Drives the optional
+    // Commutator (queued connection to its worker thread).
+    void newHeadQuaternion(double w, double x, double y, double z);
+
 public slots:
 //    void displayHasBeenCreated();
     void handleDFFSwitchChange(bool checked);

--- a/source/twistcalculator.cpp
+++ b/source/twistcalculator.cpp
@@ -1,0 +1,69 @@
+#include "twistcalculator.h"
+
+#include <cmath>
+
+namespace {
+constexpr double kTwoPi = 6.283185307179586476925286766559;
+}
+
+void TwistCalculator::configure(const QVector3D &headstageAxis, const QVector3D &commutatorAxis,
+                                double fallbackThreshold, FallbackMode fallbackMode)
+{
+    m_headstageAxis = headstageAxis;
+    m_commutatorAxis = commutatorAxis;
+    m_fallbackThreshold = fallbackThreshold;
+    m_fallbackMode = fallbackMode;
+}
+
+double TwistCalculator::update(const QQuaternion &rotation)
+{
+    // A zero quaternion is the IMU's "no data" sentinel; ignore it.
+    if (rotation.length() == 0.0f)
+        return 0.0;
+
+    const QQuaternion current = rotation.normalized();
+    double twist = 0.0;
+
+    if (m_hasPrev) {
+        const QQuaternion last = m_prev;
+        const QQuaternion conjugate = last.conjugated();
+
+        // Incremental rotation from the last sample to the current one.
+        const QQuaternion delta = (current * conjugate).normalized();
+
+        // The headstage tether axis (local), rotated into the last sample's
+        // global orientation: q * v * q^-1 with v the pure-vector quaternion.
+        const QQuaternion localAxis(0.0f, m_headstageAxis);
+        const QQuaternion projection = ((last * localAxis) * conjugate).normalized();
+
+        const QVector3D deltaV = delta.vector();
+        const QVector3D projectionV = projection.vector();
+
+        // How much of the incremental rotation is about the tether axis
+        // (expressed locally) vs. about the commutator's own axis (global).
+        const double localDot = QVector3D::dotProduct(deltaV, projectionV);
+        const double localTwist = 2.0 * std::atan2(localDot, static_cast<double>(delta.scalar()));
+
+        const double globalDot = QVector3D::dotProduct(deltaV, m_commutatorAxis);
+        const double globalTwist = 2.0 * std::atan2(globalDot, static_cast<double>(delta.scalar()));
+
+        // Cosine of the angle between the projected tether axis and the
+        // commutator axis (both unit vectors -> just the dot product). Near -1
+        // the blended estimate below has a pole, so fall back there.
+        const double cosAngle = QVector3D::dotProduct(projectionV, m_commutatorAxis);
+
+        if (cosAngle > m_fallbackThreshold)
+            twist = (localTwist + globalTwist) / (1.0 + cosAngle);
+        else
+            twist = (m_fallbackMode == FallbackMode::Global) ? globalTwist : localTwist;
+    }
+
+    m_prev = current;
+    m_hasPrev = true;
+
+    if (std::isnan(twist))
+        return 0.0;
+    // Negated: the commutator rotates to cancel the headstage twist. Radians
+    // -> turns, the unit the {turn:x} command expects.
+    return -twist / kTwoPi;
+}

--- a/source/twistcalculator.h
+++ b/source/twistcalculator.h
@@ -1,0 +1,52 @@
+#ifndef TWISTCALCULATOR_H
+#define TWISTCALCULATOR_H
+
+#include <QQuaternion>
+#include <QVector3D>
+
+// C++ port of the Open Ephys bonsai-commutator "QuaternionToTwist" operator
+// (github.com/open-ephys/bonsai-commutator). Turns a stream of head-orientation
+// quaternions into the incremental rotation ("twist") about the tether axis that
+// has happened since the previous sample, in units of full turns - exactly what
+// the commutator's {turn:x} command consumes to unwind the cable.
+//
+// Stateful, like the Bonsai operator: it remembers the last quaternion and
+// returns the delta each call, so feed it the (decimated) orientation stream and
+// send every non-zero result straight to the device. No serial/Qt-Quick deps, so
+// it is unit-tested in isolation (tests/tst_twistcalculator.cpp).
+class TwistCalculator
+{
+public:
+    enum class FallbackMode { Global, Local };
+
+    // headstageAxis: the direction the tether leaves the headstage, in the IMU's
+    //   own reference frame (usually +Z). commutatorAxis: the direction the
+    //   tether enters the rotating commutator element, in the global frame
+    //   (usually +Z for an upright mount). Negating either axis flips the sign
+    //   of the twist - the knob to turn if the commutator winds up instead of
+    //   unwinding. fallbackThreshold / fallbackMode handle the algorithm's pole
+    //   where the two axes are nearly opposed (see the Bonsai source).
+    void configure(const QVector3D &headstageAxis, const QVector3D &commutatorAxis,
+                   double fallbackThreshold, FallbackMode fallbackMode);
+
+    // Forget the previous quaternion; the next update() re-seeds and returns 0.
+    // Call whenever the orientation stream restarts (e.g. a device reconnect) so
+    // the first post-gap sample doesn't emit a spurious catch-up turn.
+    void reset() { m_hasPrev = false; }
+
+    // Feed the next orientation sample; returns the number of turns to rotate the
+    // commutator to cancel the twist since the previous sample. Returns 0 on the
+    // first sample, on a zero-length (invalid) quaternion, or on a NaN result.
+    double update(const QQuaternion &rotation);
+
+private:
+    QVector3D m_headstageAxis{0.0f, 0.0f, 1.0f};
+    QVector3D m_commutatorAxis{0.0f, 0.0f, 1.0f};
+    double m_fallbackThreshold = -0.9;
+    FallbackMode m_fallbackMode = FallbackMode::Global;
+
+    bool m_hasPrev = false;
+    QQuaternion m_prev;
+};
+
+#endif // TWISTCALCULATOR_H

--- a/source/videodevice.cpp
+++ b/source/videodevice.cpp
@@ -609,8 +609,11 @@ void VideoDevice::sendNewFrame(){
 //        qDebug() << "Send frame = " << f;
         f = (f - 1)%FRAME_BUFFER_SIZE;
 
-        // TODO: figure out what to do with webcams for dropped frames
-        vidDisplay->setDroppedFrameCount(*m_daqFrameNum - *m_acqFrameNum);
+        // DAQ-counted frames minus software-grabbed frames, rebased to the
+        // current connection epoch so a reconnect (which restarts the DAQ frame
+        // counter) doesn't pin this at "N/A". -1 => "N/A" (webcams, or before
+        // the first DAQ counter read).
+        vidDisplay->setDroppedFrameCount(deviceStream ? deviceStream->droppedFrameEstimate() : -1);
 
         // This function can be overridden by child class to add additional functionality
         handleNewDisplayFrame(timeStampBuffer[f], frameBuffer[f], f, vidDisplay);

--- a/source/videostreambase.cpp
+++ b/source/videostreambase.cpp
@@ -197,6 +197,11 @@ void VideoStreamBase::commitFrame(const cv::Mat &frame, qint64 timestampMs)
                 // would poison the offset for the whole recording).
                 m_daqFrameNumOffset = *daqFrameNum - 1;
                 m_daqOffsetSeeded = true;
+                // Remember where the acquisition count stood, so the live
+                // dropped-frame readout can be measured within this connection
+                // epoch (see droppedFrameEstimate()). 0 at stream start; the
+                // current (large) count after a reconnect.
+                m_acqAtDaqSeed = m_acqFrameNum->loadRelaxed();
             }
         }
         // On failure *daqFrameNum keeps its last value; the CSV gets -1 below.

--- a/source/videostreambase.h
+++ b/source/videostreambase.h
@@ -97,6 +97,19 @@ public:
     void setIsColor(bool isColor) { m_isColor = isColor; }
     void setDeviceName(QString name) { m_deviceName = name; }
 
+    // Estimated frames dropped between the DAQ hardware and the software this
+    // run, for the live GUI readout. Rebased to the current connection epoch: a
+    // reconnect restarts the DAQ frame counter (so the recorded CSV shows the
+    // reset visibly), which would otherwise make this difference go permanently
+    // negative and pin the readout at "N/A". Returns -1 ("N/A") when there is no
+    // DAQ frame counter (behavior cams) or before the first successful read.
+    int droppedFrameEstimate() const
+    {
+        if (daqFrameNum == nullptr || m_acqFrameNum == nullptr || !m_daqOffsetSeeded)
+            return -1;
+        return daqFrameNum->loadRelaxed() - (m_acqFrameNum->loadRelaxed() - m_acqAtDaqSeed);
+    }
+
 signals:
     void sendMessage(QString msg);
     void newFrameAvailable(QString name, int frameNum);
@@ -198,6 +211,7 @@ protected:
     int m_streamIdx = 0;               // frames committed this run (ring-buffer cursor)
     int m_daqFrameNumOffset = 0;
     bool m_daqOffsetSeeded = false;
+    int m_acqAtDaqSeed = 0;            // acq count when the DAQ offset was (re)seeded; epoch base for droppedFrameEstimate()
     int m_extTriggerLast = -1;         // -1 = not primed yet
     cv::Size m_lockedFrameSize;        // locked to the first committed frame
     bool m_sizeMismatchWarned = false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,6 +69,16 @@ if(APPLE)
     add_test(NAME avfframegrabber COMMAND tst_avfframegrabber)
 endif()
 
+# --- Commutator twist math (pure quaternion logic, runs anywhere) --------------
+# Pins the C++ port of Open Ephys's QuaternionToTwist: the sign convention and
+# the quaternion-multiplication order (which must match, or the commutator winds
+# the tether up instead of unwinding it).
+qt_add_executable(tst_twistcalculator tst_twistcalculator.cpp
+    ${CMAKE_SOURCE_DIR}/source/twistcalculator.cpp)
+target_include_directories(tst_twistcalculator PRIVATE ${CMAKE_SOURCE_DIR}/source)
+target_link_libraries(tst_twistcalculator PRIVATE Qt6::Gui Qt6::Test)
+add_test(NAME twistcalculator COMMAND tst_twistcalculator)
+
 # --- Shader compile check ------------------------------------------------------
 # Compiles + links every custom GLSL program in an offscreen GL context, so a
 # shader edit that breaks any platform's GL dialect fails CI instead of failing

--- a/tests/tst_twistcalculator.cpp
+++ b/tests/tst_twistcalculator.cpp
@@ -1,0 +1,135 @@
+#include <QtTest>
+#include <QQuaternion>
+#include <QVector3D>
+
+#include "twistcalculator.h"
+
+#include <cmath>
+
+// Unit tests for the C++ port of Open Ephys's QuaternionToTwist. The purpose is
+// to pin two things that a port can silently get wrong: the SIGN (the commutator
+// must unwind, not wind up) and the quaternion-multiplication CONVENTION (Qt's
+// QQuaternion vs. System.Numerics.Quaternion in the original C#). The turns
+// returned for a known rotation about the tether axis are the ground truth.
+class TestTwistCalculator : public QObject
+{
+    Q_OBJECT
+
+private:
+    static constexpr double kTwoPi = 6.283185307179586;
+
+    // Standard upright mount: tether leaves the headstage along +Z and enters
+    // the commutator along +Z.
+    static TwistCalculator uprightZ()
+    {
+        TwistCalculator t;
+        t.configure(QVector3D(0, 0, 1), QVector3D(0, 0, 1), -0.9,
+                    TwistCalculator::FallbackMode::Global);
+        return t;
+    }
+
+    static QQuaternion rotZ(double degrees)
+    {
+        return QQuaternion::fromAxisAndAngle(QVector3D(0, 0, 1), float(degrees));
+    }
+
+private slots:
+    void firstSampleReturnsZero();
+    void zeroQuaternionReturnsZero();
+    void noRotationReturnsZero();
+    void pureTetherRotationGivesExpectedTurns();
+    void nonIdentityPreviousStillGivesDelta();
+    void accumulatesAcrossSamples();
+    void rotationOrthogonalToTetherGivesNoTwist();
+    void reverseRotationFlipsSign();
+    void resetForgetsPreviousSample();
+};
+
+void TestTwistCalculator::firstSampleReturnsZero()
+{
+    TwistCalculator t = uprightZ();
+    QCOMPARE(t.update(rotZ(37.0)), 0.0);   // nothing to compare against yet
+}
+
+void TestTwistCalculator::zeroQuaternionReturnsZero()
+{
+    TwistCalculator t = uprightZ();
+    t.update(rotZ(0.0));                    // seed
+    QCOMPARE(t.update(QQuaternion(0, 0, 0, 0)), 0.0);   // IMU "no data" sentinel
+}
+
+void TestTwistCalculator::noRotationReturnsZero()
+{
+    TwistCalculator t = uprightZ();
+    t.update(rotZ(20.0));
+    QVERIFY(std::abs(t.update(rotZ(20.0))) < 1e-4);   // identical orientation -> no turn
+}
+
+void TestTwistCalculator::pureTetherRotationGivesExpectedTurns()
+{
+    TwistCalculator t = uprightZ();
+    t.update(rotZ(0.0));                    // seed at identity
+    // +90 deg about the tether axis -> the commutator turns to cancel it:
+    // -(pi/2)/(2pi) = -0.25 turns.
+    const double turns = t.update(rotZ(90.0));
+    QVERIFY2(std::abs(turns - (-0.25)) < 1e-4, qPrintable(QString::number(turns)));
+}
+
+void TestTwistCalculator::nonIdentityPreviousStillGivesDelta()
+{
+    // The convention test: with a non-identity previous orientation, the delta
+    // must be current*prev^-1 (not the reverse). Prev 30 deg, current 120 deg
+    // about Z is a +90 deg increment -> -0.25 turns. A flipped multiplication
+    // order would yield +0.25.
+    TwistCalculator t = uprightZ();
+    t.update(rotZ(30.0));
+    const double turns = t.update(rotZ(120.0));
+    QVERIFY2(std::abs(turns - (-0.25)) < 1e-4, qPrintable(QString::number(turns)));
+}
+
+void TestTwistCalculator::accumulatesAcrossSamples()
+{
+    // Two 45 deg increments sum to the same total as one 90 deg step, because
+    // the operator is incremental.
+    TwistCalculator t = uprightZ();
+    t.update(rotZ(0.0));
+    const double a = t.update(rotZ(45.0));
+    const double b = t.update(rotZ(90.0));
+    QVERIFY2(std::abs((a + b) - (-0.25)) < 1e-4,
+             qPrintable(QString::number(a) + " + " + QString::number(b)));
+}
+
+void TestTwistCalculator::rotationOrthogonalToTetherGivesNoTwist()
+{
+    // Pure pitch/roll (about X) does not twist the tether about Z, so it must
+    // command ~no rotation.
+    TwistCalculator t = uprightZ();
+    t.update(rotZ(0.0));
+    const QQuaternion pitched = QQuaternion::fromAxisAndAngle(QVector3D(1, 0, 0), 60.0f);
+    QVERIFY(std::abs(t.update(pitched)) < 1e-4);
+}
+
+void TestTwistCalculator::reverseRotationFlipsSign()
+{
+    // Rotating the other way about the tether axis reverses the commutator's
+    // direction: -90 deg -> +0.25 turns (vs. -0.25 for +90 deg).
+    TwistCalculator t = uprightZ();
+    t.update(rotZ(0.0));
+    const double turns = t.update(rotZ(-90.0));
+    QVERIFY2(std::abs(turns - 0.25) < 1e-4, qPrintable(QString::number(turns)));
+}
+
+void TestTwistCalculator::resetForgetsPreviousSample()
+{
+    TwistCalculator t = uprightZ();
+    t.update(rotZ(10.0));
+    t.reset();
+    QCOMPARE(t.update(rotZ(80.0)), 0.0);   // treated as a fresh first sample
+}
+
+// GUILESS: this test uses only QQuaternion/QVector3D value types, which need no
+// QGuiApplication or platform plugin. A plain QTEST_MAIN would start a
+// QGuiApplication (Qt6::Gui is linked) and abort on headless CI with "no Qt
+// platform plugin could be initialized".
+QTEST_GUILESS_MAIN(TestTwistCalculator)
+#include "tst_twistcalculator.moc"


### PR DESCRIPTION
Drives an [Open Ephys commutator](https://github.com/open-ephys/commutator-controller) directly over its USB serial port, so the tether unwinds as the animal turns — no separate Bonsai workflow needed. A V4_BNO (or newer) Miniscope's live BNO head orientation is converted to incremental motor turns and streamed to the device. This replaces having to run [bonsai-commutator](https://github.com/open-ephys/bonsai-commutator) alongside the DAQ software just to drive the commutator off the same scope.

## How it works
- **`TwistCalculator`** — a C++ port of the bonsai-commutator `QuaternionToTwist` operator: successive orientation quaternions → the incremental twist about the tether axis, in turns. Pure and unit-tested.
- **`Commutator`** — a `QObject` worker on its own thread (the `DataSaver` pattern). Owns the `QSerialPort`, decimates the orientation stream to a configurable rate (default 10 Hz), and writes the device's text protocol: `{turn:x}`, `{enable:bool}`, `{led:bool}`. All serial I/O is off the GUI/render thread.
- **`Miniscope`** emits a new `newHeadQuaternion` signal per displayed frame on good BNO data, wired (queued) to the worker.
- **backend** parses an optional top-level `commutator` config block, resolves the source Miniscope (by `deviceName`, else the first with head orientation enabled), threads the worker, and tears it down on quit.
- **Auto-reconnect**: a mid-session USB unplug/replug of the commutator recovers on its own — the port is dropped on the OS resource error, then reopened (retried ~1 Hz, driven by the orientation stream) when the device returns, re-enabling the motor and re-seeding the twist so it doesn't lurch across the gap.

## Config
Optional top-level `commutator` block; off unless present. Minimal case:
```json
"commutator": { "enabled": true, "port": "/dev/cu.usbmodemXXXX" }
```
Defaults suit the standard upright mount. `headstageAxis` / `commutatorAxis` / `fallbackMode` are exposed for non-standard geometries (negate a mounting axis if it winds up instead of unwinding). Documented in `userConfigSchema.json` and the tree editor's `userConfigProps.json`; props are looked up by key, so existing configs are unaffected.

## Build / deps
Adds `Qt6::SerialPort` (conda-forge `qt6-serialport`, version-locked to `qt6-main 6.11`) to CMake and `environment.yml`. CI resolves the env from `environment.yml`, so it picks this up; `conda-lock.yml` regeneration stays a release-tag step.

## Tests
`tests/tst_twistcalculator.cpp` (11 cases) pins the turn **sign** and the quaternion-multiplication **convention** (Qt `QQuaternion` vs. the original C# `System.Numerics`) — the two things a port can silently get wrong. All test suites green; warning-clean build.

## Bench tested
Verified on a real commutator (macOS): LED, motor motion, and full closed-loop head-orientation tracking, running alongside a behavior camera. Unplug/replug recovery of both the commutator and the scope confirmed.

## Also included: unrelated reconnect fix
Second commit fixes a **pre-existing** bug surfaced during this testing: the live "Dropped Frames" readout stuck at `N/A` for the rest of a session after a Miniscope unplug/replug. The device's frame counter restarts on power-cycle (as the recorded `DAQ Frame Number` CSV column intentionally shows), which left the live difference permanently negative. The readout is now rebased to each connection span; the recorded CSV is unchanged, and behavior-camera `N/A` behavior is preserved on every platform.