### PR TITLE
Harden release CI + fix Windows config data-loss

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,37 +2,51 @@
 # publish ALL THREE as a single GitHub Release.
 #
 # Triggers:
-#   * push a tag like v1.10  -> build all three, then create/update ONE Release
-#                               with the Windows installer + portable zip, the
-#                               Linux AppImage, and the macOS DMG.
+#   * push a tag like v2.0.0 -> check the tag matches CMakeLists.txt, build all
+#                               three, then cut ONE DRAFT Release carrying the
+#                               Windows installer + portable zip, the Linux
+#                               AppImage, and the macOS DMG. The maintainer runs
+#                               the artifact sanity-check (RELEASING.md) and then
+#                               clicks Publish. A pre-release suffix (v2.0.0-rc1)
+#                               publishes as a prerelease, not "Latest".
+#   * push to master         -> build + test only (no packaging, no Release), so
+#                               a merge that breaks the build is caught before a
+#                               tag is cut rather than mid-release.
 #   * manual "Run workflow"  -> build all and upload them as run artifacts only
 #                               (no Release created).
-#   * pull request into qt6-port -> build-only validation on all platforms (the
-#                               release job is tag-gated, so PRs never publish).
-#                               Note workflow_dispatch can't be used for branch
-#                               validation here: the workflow isn't on the repo's
-#                               default branch, so GitHub doesn't register it for
-#                               manual dispatch; pull_request runs use the PR
-#                               branch's workflow file directly.
+#   * pull request into qt6-port / master -> build + test only on all platforms
+#                               (the packaging + release steps are gated to tags
+#                               and manual runs, so PRs never publish).
 #
 # Shape: three independent build jobs (build-windows, build-linux, build-macos)
-# each upload their artifacts; a final `release` job gathers them and cuts the
-# Release. So a tag yields ONE release carrying every platform's binaries,
-# rather than a separate release per OS.
+# each upload their artifacts; a `check-version` job guards the tag, and a final
+# `release` job gathers the artifacts and cuts the Release. So a tag yields ONE
+# release carrying every platform's binaries, rather than a separate release per
+# OS. Least-privilege: build jobs run read-only; only `release` writes.
 name: Build & Release
 
 on:
   push:
     tags:
       - "v*"
+    branches:
+      - master      # build+test validation on direct pushes / PR merges to master
   workflow_dispatch:
   pull_request:
     branches:
       - qt6-port
       - master      # keeps PR validation alive after the qt6 work merges home
 
+# Least privilege by default: build/test jobs run read-only (they pull network
+# deps and run dependency code), and only the release job is granted write to
+# publish the Release. Keeps future signing secrets out of PR-triggered jobs.
 permissions:
-  contents: write          # needed to create the Release on tag pushes
+  contents: read
+
+concurrency:
+  # Coalesce superseded runs on the same ref, but never cancel a release build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_type != 'tag' }}
 
 jobs:
   # --- Windows ---------------------------------------------------------------
@@ -64,13 +78,15 @@ jobs:
         with:
           arch: x64
 
+      # USE_PYTHON=OFF to match what all three platforms actually ship: the
+      # DeepLabCut-Live tracker is not bundled (the DMG/AppImage scripts already
+      # build OFF), so CI builds, tests, and packages the SAME configuration.
       - name: Configure (CMake + Ninja + MSVC)
         run: >
           cmake -B build -S . -G Ninja
           -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_PREFIX_PATH="$env:CONDA_PREFIX/Library"
-          -DPython3_EXECUTABLE="$env:CONDA_PREFIX/python.exe"
-          -DUSE_PYTHON=ON
+          -DUSE_PYTHON=OFF
 
       - name: Build (Release)
         run: cmake --build build --config Release
@@ -83,10 +99,11 @@ jobs:
       - name: Deploy standalone bundle (into build/Release/)
         run: cmake --build build --config Release --target deploy
 
-      # PRs stop after build+test+deploy: the zip/installer/artifacts below
-      # exist to be released or downloaded, and nothing consumes them on a PR.
+      # PRs and plain branch pushes stop after build+test+deploy: the
+      # zip/installer/artifacts below exist to be released (tag) or downloaded
+      # (manual run), and nothing consumes them otherwise.
       - name: Package the release folder into a zip
-        if: github.event_name != 'pull_request'
+        if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
         run: |
           $name = if ($env:GITHUB_REF_TYPE -eq 'tag') { "MiniscopeDAQ-$env:GITHUB_REF_NAME-Windows-x64.zip" } else { "MiniscopeDAQ-Windows-x64.zip" }
           Compress-Archive -Path build/Release/* -DestinationPath $name -Force
@@ -94,15 +111,18 @@ jobs:
           "Built $name"
 
       - name: Build installer (Inno Setup)
-        if: github.event_name != 'pull_request'
+        if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
         run: |
-          # The in-installer version label comes from the app itself
-          # (source/main.cpp: #define VERSION_NUMBER "x.y"), so it always matches
-          # what the running app reports regardless of tag vs manual trigger.
-          $m = Select-String -Path source/main.cpp -Pattern '#define\s+VERSION_NUMBER\s+"([^"]+)"'
-          if (-not $m) { throw "VERSION_NUMBER not found in source/main.cpp" }
+          # The in-installer version label comes from CMakeLists.txt's
+          # project(MiniscopeDAQ VERSION x.y.z) - the single source of truth that
+          # also drives the app's displayed version (via MINISCOPE_VERSION) and
+          # the DMG/AppImage file names, so every artifact and the running app
+          # always report the same number. (build-dmg.sh / build-appimage.sh
+          # extract it the same way.)
+          $m = Select-String -Path CMakeLists.txt -Pattern 'project\(MiniscopeDAQ\s+VERSION\s+([0-9.]+)'
+          if (-not $m) { throw "project(MiniscopeDAQ VERSION ...) not found in CMakeLists.txt" }
           $ver = $m.Matches[0].Groups[1].Value
-          "App version (from main.cpp): $ver"
+          "App version (from CMakeLists.txt): $ver"
 
           # The artifact FILE name tracks the git tag (or a generic name for
           # manual runs) so each tagged release stays identifiable.
@@ -131,13 +151,14 @@ jobs:
           "Built $base.exe"
 
       - name: Upload Windows artifacts
-        if: github.event_name != 'pull_request'
+        if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v7
         with:
           name: MiniscopeDAQ-Windows-x64
           path: |
             ${{ env.ZIP_NAME }}
             ${{ env.INSTALLER_NAME }}
+          if-no-files-found: error
           retention-days: 14
 
   # --- Linux (AppImage) ------------------------------------------------------
@@ -180,23 +201,36 @@ jobs:
       - name: Run unit tests
         run: ctest --test-dir build-appimage --output-on-failure
 
+      # Record the exact resolved dependency set - especially libuvc, which is
+      # installed outside environment.yml and so is absent from conda-lock.yml -
+      # so a Linux release can be reconstructed after the CI logs expire. Ships
+      # alongside the AppImage on the release.
+      - name: Record dependency versions
+        if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
+        run: conda list -n miniscope-qt6 > dist/versions-linux-x86_64.txt
+
       - name: Name the artifact
-        if: github.event_name != 'pull_request'
+        if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
         run: |
+          set -o pipefail
           f=$(ls dist/Miniscope_DAQ*-x86_64.AppImage | head -1)
+          [ -n "$f" ] || { echo "::error::No AppImage found in dist/"; exit 1; }
           echo "APPIMAGE_PATH=$f" >> "$GITHUB_ENV"
           echo "Built $f"
 
       - name: Upload Linux artifact
-        if: github.event_name != 'pull_request'
+        if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v7
         with:
           name: MiniscopeDAQ-Linux-x86_64
-          path: ${{ env.APPIMAGE_PATH }}
+          path: |
+            ${{ env.APPIMAGE_PATH }}
+            dist/versions-linux-x86_64.txt
+          if-no-files-found: error
           retention-days: 14
 
   # --- macOS (Apple Silicon) ---------------------------------------------------
-  # Build + test with USE_PYTHON=ON (validates the full source tree), then
+  # Build + test with USE_PYTHON=OFF (the configuration that ships), then
   # package the distributable .app + DMG with packaging/macos/build-dmg.sh
   # (its own USE_PYTHON=OFF build, matching the lean Linux AppImage). Runs on
   # the arm64 runner with the same conda-forge stack as the other jobs
@@ -221,13 +255,14 @@ jobs:
           activate-environment: miniscope-qt6
           auto-activate: false
 
+      # USE_PYTHON=OFF so the tested tree matches the shipped DMG (build-dmg.sh
+      # also builds OFF); DeepLabCut-Live is not bundled on any platform.
       - name: Configure (CMake + Ninja)
         run: >
           cmake -B build -S . -G Ninja
           -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_PREFIX_PATH="$CONDA_PREFIX"
-          -DPython3_EXECUTABLE="$CONDA_PREFIX/bin/python3"
-          -DUSE_PYTHON=ON
+          -DUSE_PYTHON=OFF
 
       - name: Build (Release)
         run: cmake --build build
@@ -237,41 +272,94 @@ jobs:
       - name: Run unit tests
         run: ctest --test-dir build --output-on-failure
 
-      # PRs stop after build+test, like the other platforms.
+      # PRs and plain branch pushes stop after build+test; only tags and manual
+      # runs package.
       - name: Build .app + DMG
-        if: github.event_name != 'pull_request'
+        if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
         run: packaging/macos/build-dmg.sh
 
       - name: Name the artifact
-        if: github.event_name != 'pull_request'
+        if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
         run: |
+          set -o pipefail
           f=$(ls dist/Miniscope-DAQ*-macOS-*.dmg | head -1)
+          [ -n "$f" ] || { echo "::error::No DMG found in dist/"; exit 1; }
           echo "DMG_PATH=$f" >> "$GITHUB_ENV"
           echo "Built $f"
 
       - name: Upload macOS artifact
-        if: github.event_name != 'pull_request'
+        if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v7
         with:
           name: MiniscopeDAQ-macOS-arm64
           path: ${{ env.DMG_PATH }}
+          if-no-files-found: error
           retention-days: 14
 
-  # --- Single release --------------------------------------------------------
-  # Gather all three platforms' artifacts and publish them as ONE Release. Only
-  # runs on tag pushes; manual runs stop after the build jobs (artifacts only).
-  release:
-    needs: [build-windows, build-linux, build-macos]
+  # --- Version guard ---------------------------------------------------------
+  # A tag MUST match project(MiniscopeDAQ VERSION x.y.z) in CMakeLists.txt (the
+  # single source that drives every artifact's file name and the in-app version).
+  # This blocks the release below, so a mistyped tag can never publish a release
+  # whose artifacts and running app disagree on the version. Skipped on non-tag
+  # runs, so it never interferes with PR / branch validation.
+  check-version:
     if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Assert tag matches CMakeLists.txt version
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          cmake_ver=$(sed -nE 's/^project\(MiniscopeDAQ[[:space:]]+VERSION[[:space:]]+([0-9.]+).*/\1/p' CMakeLists.txt | head -1)
+          tag_ver="${TAG#v}"
+          echo "tag=$tag_ver  CMakeLists.txt=$cmake_ver"
+          if [ "$cmake_ver" != "$tag_ver" ]; then
+            echo "::error::Tag $TAG (version $tag_ver) != CMakeLists.txt project() version $cmake_ver. Bump CMakeLists.txt to match the tag (or retag), then push again."
+            exit 1
+          fi
+
+  # --- Single release --------------------------------------------------------
+  # Gather all three platforms' artifacts and publish them as ONE Release. Only
+  # runs on tag pushes (manual runs stop after the build jobs, artifacts only).
+  # Published as a DRAFT so the maintainer runs RELEASING.md's artifact
+  # sanity-check before clicking Publish; a tag with a pre-release suffix
+  # (e.g. v2.0.0-rc1) goes out as a prerelease instead of "Latest".
+  release:
+    needs: [check-version, build-windows, build-linux, build-macos]
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write        # only this job writes the Release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
       - name: Download all build artifacts
         uses: actions/download-artifact@v8
         with:
           path: artifacts       # each artifact lands in artifacts/<name>/
 
-      - name: Publish Release
+      # Release notes = the curated CHANGELOG section for this version (what
+      # users should read), not the raw merged-PR list. Grabs the block under
+      # the first "## [" header, which RELEASING.md step 2 renames from
+      # "[Unreleased]" to the version + date at release time.
+      - name: Extract changelog section for release notes
+        run: |
+          set -euo pipefail
+          awk '/^## \[/{n++} n==1{print} n==2{exit}' CHANGELOG.md > RELEASE_NOTES.md
+          if [ ! -s RELEASE_NOTES.md ]; then
+            echo "::error::Could not extract a changelog section from CHANGELOG.md"; exit 1
+          fi
+          echo "----- release notes -----"; cat RELEASE_NOTES.md
+
+      - name: Publish Release (draft)
         uses: softprops/action-gh-release@v3
         with:
           files: artifacts/**/*
-          generate_release_notes: true
+          fail_on_unmatched_files: true
+          body_path: RELEASE_NOTES.md
+          draft: true
+          prerelease: ${{ contains(github.ref_name, '-') }}

--- a/BUILD_LINUX.md
+++ b/BUILD_LINUX.md
@@ -19,8 +19,10 @@ unchanged. The two Linux-specific additions made for this port are:
 
 ## Toolchain: conda (validated) vs. apt
 
-**Use the conda environment (`environment.yml`).** It pins the *exact* same
-Qt/OpenCV/Python as the Windows CI build (Qt 6.11, OpenCV 4.13, Python 3.12), and
+**Use the conda environment (`environment.yml`).** It pins the same
+Qt/OpenCV/Python as the Windows CI build to major.minor (Qt 6.11, OpenCV 4.13,
+Python 3.12), floating only the patch level (use `conda-lock.yml` for a
+released version's exact package set — see RELEASING.md), and
 it has been validated end-to-end on Ubuntu 24.04 — including launching natively on
 **Wayland** with no `xcb`/`libGL` friction (the historical conda-Qt-on-Linux
 worry did **not** materialize here).

--- a/BUILD_MACOS.md
+++ b/BUILD_MACOS.md
@@ -16,9 +16,11 @@ so macOS compiles the portable paths as-is.
 
 ## 1. Toolchain: Miniforge (conda-forge)
 
-Use the repo's `environment.yml` — it pins the *exact* same Qt/OpenCV/Python
-stack as the Windows and Linux CI builds (Qt 6.11, OpenCV 4.13, Python 3.12),
-and every pin resolves on `osx-arm64` unchanged.
+Use the repo's `environment.yml` — it pins the same Qt/OpenCV/Python stack as
+the Windows and Linux CI builds to major.minor (Qt 6.11, OpenCV 4.13,
+Python 3.12), floating only the patch level, and every pin resolves on
+`osx-arm64` unchanged. For the exact package set of a released version, use
+`conda-lock.yml` (see RELEASING.md).
 
 Prerequisites: Xcode Command Line Tools (`xcode-select --install`; AppleClang
 is the compiler — no full Xcode needed).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,11 +31,19 @@ published together from CI.
   head-orientation reads work despite kernel-side UVC control caching. See
   `BUILD_LINUX.md`.
 - **Windows installer** (`Setup.exe`, Inno Setup) alongside the portable zip,
-  both produced by CI.
+  both produced by CI. On Windows, your user configs and recordings now live in
+  `Documents\Miniscope` (matching macOS and Linux) instead of inside the install
+  folder, so they survive upgrades and uninstalls; the installed folder holds
+  only read-only example configs.
 - One tagged release now publishes Windows zip + installer, Linux AppImage,
-  and macOS DMG together from a single CI workflow.
+  and macOS DMG together from a single CI workflow, as a reviewable draft with
+  the changelog as its release notes.
+- All platforms now build, test, and ship the same configuration — the optional
+  DeepLabCut-Live tracker (embedded Python) is no longer bundled on Windows,
+  matching macOS and Linux. Build it locally with `-DUSE_PYTHON=ON` if needed.
 - Reproducible toolchain: `environment.yml` (conda-forge) pins the same
-  Qt 6.11 / OpenCV 4.13 / Python 3.12 stack on all three platforms.
+  Qt 6.11 / OpenCV 4.13 / Python 3.12 stack (to major.minor) on all three
+  platforms; `conda-lock.yml` records the exact package set per release.
 
 **Reliability & diagnostics**
 - Unit-test infrastructure (QtTest/CTest) run by CI on every PR: protocol

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,10 +158,15 @@ set(HEADERS
 
 if(APPLE)
     # The hybrid Miniscope backend (AVFoundation frames + IOKit pipe-0 controls),
-    # plus the .app bundle's runtime path setup (bundlepaths.cpp is portable Qt
-    # so the tests can run it everywhere, but only macOS main() calls it).
+    # plus the packaged-runtime path setup (bundlepaths.cpp is portable Qt so the
+    # tests can run it everywhere; macOS main() calls prepareBundleRuntime()).
     list(APPEND SOURCES source/videostreammac.cpp source/bundlepaths.cpp)
     list(APPEND HEADERS source/videostreammac.h source/bundlepaths.h)
+elseif(WIN32)
+    # Windows main() calls BundlePaths::seedUserDataDirs() to keep user configs
+    # and recordings in ~/Documents/Miniscope, outside the install dir.
+    list(APPEND SOURCES source/bundlepaths.cpp)
+    list(APPEND HEADERS source/bundlepaths.h)
 endif()
 
 qt_add_executable(MiniscopeDAQ

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,13 +2,25 @@
 
 How a Miniscope DAQ release is cut. One tag produces the Windows portable zip,
 the Windows installer (`Setup.exe`), the Linux AppImage, and the macOS DMG
-together from CI (`.github/workflows/release.yml`).
+together from CI (`.github/workflows/release.yml`). All platforms build, test,
+and ship the same `USE_PYTHON=OFF` configuration (no embedded DeepLabCut-Live).
 
 ## Steps
 
-1. **Freeze the dependency set.** Regenerate the lock file so the release's
-   exact library versions are recorded and the binaries can be rebuilt
-   identically later, even after conda-forge moves on:
+1. **Bump the version.** Set `project(MiniscopeDAQ VERSION x.y.z)` in
+   `CMakeLists.txt` - the single source of truth. The in-app version (via
+   `MINISCOPE_VERSION`), the DMG/AppImage file names, and the Windows installer
+   all derive from it, and CI's `check-version` job **fails the release unless
+   the git tag equals this value**, so the tag and every artifact can never
+   disagree. Releases are 3-part SemVer (`vX.Y.Z`) from v2.0.0 on.
+
+2. **Finalize the changelog.** Rename the `[Unreleased]` header in
+   `CHANGELOG.md` to `[x.y.z] — YYYY-MM-DD`. The CI `release` job extracts this
+   section verbatim and uses it as the GitHub Release notes, so this is exactly
+   what users read - write it for them, not as an internal PR log.
+
+3. **Freeze the dependency set.** Regenerate the lock file so the release's
+   exact library versions are recorded:
 
    ```sh
    pip install conda-lock
@@ -16,21 +28,15 @@ together from CI (`.github/workflows/release.yml`).
        --lockfile conda-lock.yml
    ```
 
-   Commit the updated `conda-lock.yml`. (Day-to-day builds use
+   Commit the updated `conda-lock.yml`. (Day-to-day builds and CI use
    `environment.yml`, which floats on patch releases within its major.minor
    pins; the lock file is the snapshot of record.)
 
    Known gap: `libuvc` (Linux Miniscope backend) is installed by the Linux CI
-   job separately from `environment.yml`, so it is not in the lock file. When
-   rebuilding a Linux release exactly, check the release job's log for the
-   libuvc version it installed.
-
-2. **Finalize the changelog.** Rename the `[Unreleased]` section in
-   `CHANGELOG.md` to the version number and date.
-
-3. **Check the version.** `project(MiniscopeDAQ VERSION x.y.z)` in
-   `CMakeLists.txt` is the single source of truth - the UI, the DMG/AppImage
-   file names, and the installer all derive from it.
+   job separately from `environment.yml`, so it is not in the lock file. The
+   Linux job now attaches a `versions-linux-x86_64.txt` (a full `conda list`,
+   including the resolved `libuvc`) to the release, so the exact version
+   survives even after the CI logs expire.
 
 4. **Merge to master and tag.** Merge the release branch with a REGULAR merge
    (not squash - the PR history is the history), then tag:
@@ -39,12 +45,19 @@ together from CI (`.github/workflows/release.yml`).
    git tag vX.Y.Z && git push origin vX.Y.Z
    ```
 
-   CI builds and attaches all four artifacts to the GitHub release.
+   CI runs `check-version`, builds/tests all platforms, and cuts a **DRAFT**
+   GitHub Release with all four artifacts + the Linux versions file. A tag with
+   a pre-release suffix (e.g. `v2.0.0-rc1`) is marked as a prerelease rather
+   than "Latest". If `check-version` fails, the tag disagrees with
+   `CMakeLists.txt`: fix step 1, delete and re-push the tag.
 
-5. **Sanity-check the artifacts.** Download each artifact and confirm it
-   launches and can load an example config. On macOS also confirm the DMG
-   opens on a machine that didn't build it (ad-hoc signature, Gatekeeper
-   right-click-Open path).
+5. **Sanity-check the artifacts, then publish.** The release is a draft, so
+   nothing is public yet. Download each artifact and confirm it launches and can
+   load an example config. On macOS also confirm the DMG opens on a machine that
+   didn't build it (ad-hoc signature; on current macOS this needs
+   System Settings → Privacy & Security → "Open Anyway", or
+   `xattr -cr /Applications/MiniscopeDAQ.app` - see BUILD_MACOS.md). When
+   satisfied, click **Publish release** on GitHub.
 
 ## Rebuilding an old release exactly
 
@@ -53,4 +66,11 @@ git checkout vX.Y.Z
 conda-lock install -n miniscope-rebuild conda-lock.yml
 conda activate miniscope-rebuild
 # then build per BUILD_MACOS.md / BUILD_LINUX.md / environment.yml header
+# for Linux, also install the libuvc version from that release's
+# versions-linux-x86_64.txt asset (it is not in conda-lock.yml).
 ```
+
+Note: this reproduces the dependency set, not a byte-identical binary - the
+build embeds its compile date, and the CI runner toolchain/system libs
+(MSVC/Xcode/AppleClang, apt GL libs, Inno Setup, linuxdeploy) float with the
+runner images. Treat it as "same versions," not "same bytes."

--- a/environment.yml
+++ b/environment.yml
@@ -4,9 +4,12 @@
 #     conda env create -f environment.yml
 #     conda activate miniscope-qt6
 #     cmake -B build -S . -G "Visual Studio 17 2022" -A x64 ^
-#         -DCMAKE_PREFIX_PATH="%CONDA_PREFIX%/Library" ^
-#         -DPython3_EXECUTABLE="%CONDA_PREFIX%/python.exe" -DUSE_PYTHON=ON
+#         -DCMAKE_PREFIX_PATH="%CONDA_PREFIX%/Library" -DUSE_PYTHON=OFF
 #     cmake --build build --config Release
+#
+# Packaged releases ship USE_PYTHON=OFF on every platform (the DeepLabCut-Live
+# tracker is not bundled). Build with -DUSE_PYTHON=ON only if you specifically
+# want the embedded-Python tracker for local use.
 #     cmake --build build --config Release --target deploy   # -> build/Release/
 #
 # To update an existing env after editing this file:

--- a/packaging/windows/MiniscopeDAQ.iss
+++ b/packaging/windows/MiniscopeDAQ.iss
@@ -7,10 +7,14 @@
 ; shortcut, optional desktop shortcut, and an entry in "Add or Remove Programs"
 ; with a working uninstaller.
 ;
-; Per-user is deliberate: the launcher writes ./userConfigs relative to the
-; install dir, so the app must land somewhere the user can write to. {autopf}
-; with PrivilegesRequired=lowest resolves to %LocalAppData%\Programs, which is
-; user-writable and needs no elevation.
+; Per-user is deliberate: the launcher sets the working dir to the install root
+; and the app refreshes ./deviceConfigs + ./Scripts there, so the app must land
+; somewhere the user can write to. {autopf} with PrivilegesRequired=lowest
+; resolves to %LocalAppData%\Programs, which is user-writable and needs no
+; elevation. The user's OWN configs and recordings do NOT live here - the app
+; seeds them into %USERPROFILE%\Documents\Miniscope on first run (see
+; BundlePaths::seedUserDataDirs), so they survive upgrades and uninstall. The
+; userConfigs shipped into {app} below are read-only seed examples.
 ;
 ; Build locally (after `cmake --build build --config Release --target deploy`):
 ;   iscc packaging\windows\MiniscopeDAQ.iss
@@ -49,8 +53,9 @@ AppName={#MyAppName}
 AppVersion={#MyAppVersion}
 ; Controls the wizard caption AND the "Add or Remove Programs" display name.
 ; Without this, Inno shows "<AppName> version <AppVersion>"; set it explicitly
-; for a clean "Miniscope DAQ 1.2" that matches the version shown in the app's
-; Help (sourced from source/main.cpp VERSION_NUMBER - see the CI step).
+; for a clean "Miniscope DAQ 2.0.0" that matches the version shown in the app's
+; Help. MyAppVersion is passed in by CI from CMakeLists.txt's project() version
+; (the single source of truth) - see the "Build installer" step.
 AppVerName={#MyAppName} {#MyAppVersion}
 AppPublisher={#MyAppPublisher}
 AppPublisherURL={#MyAppURL}

--- a/source/bundlepaths.cpp
+++ b/source/bundlepaths.cpp
@@ -85,6 +85,17 @@ static QString defaultEnvDir(const char *name, const QString &dirPath)
     return dir;
 }
 
+void seedUserDataDirs(const QString &seedRoot)
+{
+    const QString docs =
+        QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation)
+        + QStringLiteral("/Miniscope");
+    const QString userConfigDir =
+        defaultEnvDir("MINISCOPE_USERCONFIG_DIR", docs + QStringLiteral("/userConfigs"));
+    seedDirectory(seedRoot + QStringLiteral("/userConfigs"), userConfigDir);
+    defaultEnvDir("MINISCOPE_DATA_DIR", docs + QStringLiteral("/data"));
+}
+
 bool prepareBundleRuntime()
 {
     const QString resources =
@@ -103,16 +114,11 @@ bool prepareBundleRuntime()
         return false;
     }
 
-    const QString docs =
-        QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation)
-        + QStringLiteral("/Miniscope");
-    const QString userConfigDir =
-        defaultEnvDir("MINISCOPE_USERCONFIG_DIR", docs + QStringLiteral("/userConfigs"));
-    seedDirectory(resources + QStringLiteral("/userConfigs"), userConfigDir);
-    defaultEnvDir("MINISCOPE_DATA_DIR", docs + QStringLiteral("/data"));
+    seedUserDataDirs(resources);
 
     qInfo().nospace() << "Bundle runtime: working dir " << work
-                      << ", user configs " << userConfigDir;
+                      << ", user configs "
+                      << qEnvironmentVariable("MINISCOPE_USERCONFIG_DIR");
     return true;
 }
 

--- a/source/bundlepaths.h
+++ b/source/bundlepaths.h
@@ -4,15 +4,17 @@
 #include <QString>
 #include <QStringList>
 
-// Runtime path setup for the packaged macOS .app bundle.
+// Runtime path setup for packaged builds.
 //
 // The app reads its runtime data (./deviceConfigs, ./Scripts) and the example
 // user configs relative to the WORKING DIRECTORY - fine for a dev build run
 // from the repo root, wrong for a double-clicked .app whose working directory
-// is "/". The Windows launcher and the Linux AppImage wrapper solve this
-// outside the app; on macOS a wrapper script inside the bundle would break
-// code signing and TCC camera-permission attribution, so the same setup runs
-// natively in main() instead (prepareBundleRuntime below, macOS-only call).
+// is "/". The Linux AppImage wrapper solves this entirely outside the app; on
+// macOS a wrapper script inside the bundle would break code signing and TCC
+// camera-permission attribution, so the full setup runs natively in main()
+// instead (prepareBundleRuntime below, macOS-only call). On Windows the
+// launcher already puts the working directory at the install root, so main()
+// only needs the user-config/data half of the contract (seedUserDataDirs).
 //
 // The helpers are plain path->path functions so the unit tests can exercise
 // them against temp directories on every platform.
@@ -34,6 +36,16 @@ bool refreshWorkingData(const QString &srcRoot, const QString &workRoot,
 // (user edits survive upgrades). Creates dstDir. Returns the number seeded,
 // or -1 if dstDir cannot be created.
 int seedDirectory(const QString &srcDir, const QString &dstDir);
+
+// Point the user's config/data folders at ~/Documents/Miniscope and seed the
+// example user configs there (from seedRoot/userConfigs, never clobbering
+// existing files). Defaults MINISCOPE_USERCONFIG_DIR / MINISCOPE_DATA_DIR
+// (respecting any preexisting values) so the config open/save dialogs and the
+// new-config data directory land in ~/Documents/Miniscope/{userConfigs,data} -
+// OUTSIDE the install dir, so the user's own configs and recordings survive an
+// upgrade (which refreshes the install dir) and an uninstall (which deletes
+// it). Shared by the macOS bundle path and the Windows launcher path.
+void seedUserDataDirs(const QString &seedRoot);
 
 // Full bundle bootstrap, called from main() on macOS before the backend is
 // constructed (it reads ./deviceConfigs in its constructor). No-op (returns

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -14,8 +14,10 @@
 #include <QStyleHints>
 
 #include "backend.h"
-#ifdef Q_OS_MACOS
+#if defined(Q_OS_MACOS) || defined(Q_OS_WIN)
 #include "bundlepaths.h"
+#include <QDir>
+#include <QFileInfo>
 #endif
 
 #include <opencv2/core/version.hpp>   // CV_VERSION (e.g. "4.13.0"); macro-only header
@@ -48,12 +50,23 @@ int main(int argc, char *argv[])
 
     QGuiApplication app(argc, argv);
 
-#ifdef Q_OS_MACOS
+#if defined(Q_OS_MACOS)
     // Packaged .app: switch to a writable working directory holding the
     // app-internal configs and default the user-config/data folders, BEFORE
     // the backend is constructed (it reads ./deviceConfigs in its
     // constructor). No-op for dev builds run from the repo root.
     BundlePaths::prepareBundleRuntime();
+#elif defined(Q_OS_WIN)
+    // Packaged Windows build: the launcher has already set the working
+    // directory to the install root (holding deviceConfigs/Scripts/userConfigs),
+    // so unlike macOS we only need the user-config/data half of the contract:
+    // seed the example configs into ~/Documents/Miniscope and point the dialogs
+    // there, so the user's own configs and recordings live outside the install
+    // dir (which upgrades refresh and uninstall deletes). Detected by the real
+    // exe living under .../bin (the deployed layout); a dev build run straight
+    // from the build tree keeps the run-from-CWD behavior.
+    if (QFileInfo(QCoreApplication::applicationDirPath()).fileName() == QLatin1String("bin"))
+        BundlePaths::seedUserDataDirs(QDir::currentPath());
 #endif
 
     // Qt6: the default Controls style on Windows is the native style, which does


### PR DESCRIPTION
Pre-merge hardening of the release/build/publish pipeline so v2.0.0 can ship robustly. Two commits, split by concern.

## Release CI (`dcfa78c`)
- **Release-blocker fixed:** the Windows installer version came from a stale `main.cpp` regex that can no longer match the refactored bareword `#define VERSION_NUMBER` — it would have thrown on **every** tagged build and produced no artifacts. Now sourced from `CMakeLists.txt project(VERSION)`, the same single source the DMG/AppImage already use.
- **`check-version` job** fails the release unless the git tag equals the `CMakeLists.txt` version — artifacts and the in-app version can't disagree.
- **Draft releases:** a tag cuts a draft (sanity-check artifacts, then Publish); `-rc`/`-beta` tags publish as prereleases, not "Latest".
- **No silent partial release:** `pipefail` + empty-check in the naming steps, `if-no-files-found: error` on all uploads.
- **Real release notes:** body comes from the curated `CHANGELOG.md` section, not the raw merged-PR list.
- **`USE_PYTHON=OFF` everywhere** so CI builds/tests exactly what ships (Windows previously shipped embedded Python; macOS tested ON but shipped OFF).
- Least-privilege `permissions` (only the release job writes), `concurrency` group, build+test validation on `master` pushes, and a per-release `conda list` (incl. the un-locked `libuvc`) attached for reproducibility.
- Docs updated: `RELEASING.md`, `CHANGELOG.md`, `environment.yml`, `BUILD_MACOS/LINUX.md`.

## Windows config data-loss (`62f71fe`)
On Windows the app read/wrote `userConfigs` inside the install dir, so an upgrade (`ignoreversion`) overwrote edited configs and an uninstall deleted them. macOS/Linux already keep user data in `~/Documents/Miniscope`. `bundlepaths` is now cross-platform: `seedUserDataDirs()` seeds examples into `~/Documents/Miniscope` without clobbering and defaults `MINISCOPE_USERCONFIG_DIR`/`MINISCOPE_DATA_DIR`; `main()` calls it on Windows. Guarded on the deployed `.../bin` layout, so dev builds are unaffected and it can never block launch.

## Verification
- Workflow YAML validated; C++ compiled against the conda env (both `USE_PYTHON` configs); `bundlepaths` unit test passes; changelog extractor produces the correct section.
- **Not yet run on Windows** — the config-in-Documents path is compile-validated only; confirm during the first draft-release artifact check.

## Deliberately deferred
Conda/ccache caching and SHA-pinning the actions — real wins, but need a live CI run to validate cache keys / SHAs. Follow-up.

## Out of scope (per discussion)
Code signing / notarization (macOS Gatekeeper "damaged", Windows SmartScreen) and Intel-Mac support.