### PR TITLE
Fix standalone MiniCAM TTL trigger not starting recordings (#67)

### DIFF
--- a/source/backend.cpp
+++ b/source/backend.cpp
@@ -1247,6 +1247,17 @@ void backEnd::connectSnS()
         QObject::connect(dataSaver, &DataSaver::recordingFailed, behavCam[i],
                          [cam = behavCam[i]] { cam->setWindowRecordingIndicator(false); });
 
+        // External-trigger support for MiniCAMs. A MiniCAM uses the same DAQ
+        // PCB/firmware as a Miniscope, so it reports the trigger state over the
+        // same UVC side-channel; these are the two connections the miniscope
+        // loop above makes. Gated on isMiniCAM so real webcams (which have no
+        // such side-channel) are left untouched. Fixes the standalone-MiniCAM
+        // TTL trigger not starting recordings (issue #67).
+        if (behavCam[i]->getIsMiniCAM()) {
+            QObject::connect(controlPanel, &ControlPanel::setExtTriggerTrackingState, behavCam[i], &VideoDevice::setExtTriggerTrackingState);
+            QObject::connect(behavCam[i], &VideoDevice::extTriggered, controlPanel, &ControlPanel::extTriggerTriggered);
+        }
+
 //        if (behavTracker) {
 //            QObject::connect(behavCam[i], SIGNAL(newFrameAvailable(QString, int)), behavTracker, SLOT( handleNewFrameAvailable(QString, int)));
 //        }

--- a/source/behaviorcam.h
+++ b/source/behaviorcam.h
@@ -39,6 +39,12 @@ public slots:
     // LEAVE THIS!!!!
     void handleCamPropsClicked() { emit openCamPropsDialog();}
 
+public:
+    // A MiniCAM rides the same DAQ PCB/firmware as a Miniscope, so it reports
+    // the external-trigger state over the same UVC side-channel. Webcams do not,
+    // which is why the ext-trigger wiring in backEnd is gated on this.
+    bool getIsMiniCAM() const { return isMiniCAM; }
+
 private:
     QJsonObject m_ucDevice;
     QJsonObject m_cDevice;


### PR DESCRIPTION
## Problem

External TTL triggering starts a recording for miniscopes but **not** for a standalone MiniCAM. Reported in #67 and corroborated by several users.

## Root cause

A MiniCAM is a `BehaviorCam`, and the `behavCam` wiring loop in `backEnd::connectSignalsAndSlots()` omitted the two external-trigger connections that the `miniscope` loop makes:

- `ControlPanel::setExtTriggerTrackingState → VideoDevice::setExtTriggerTrackingState` (arms the per-frame `SEL_GAMMA` trigger read in `commitFrame`)
- `VideoDevice::extTriggered → ControlPanel::extTriggerTriggered` (delivers the detected edge, which calls `startRecording()`)

Without these, the trigger state was never read and the edge never reached the control panel, so a MiniCAM never started/stopped on TTL. All the base-class plumbing already existed — only the two backend connections were missing.

## Fix

Wire the two connections for MiniCAMs, gated on a new `BehaviorCam::getIsMiniCAM()` accessor.

- A MiniCAM rides the **same DAQ PCB/firmware as a Miniscope**, so it reports the trigger state over the same UVC side-channel — wiring it identically is correct.
- Gating on `isMiniCAM` leaves real webcams (which have no such side-channel) completely untouched — they never get pointless per-frame trigger reads and cannot regress.
- The `Minicam-Mono-XGA` config carries an `led0` control, so the LED-arming logic in `handleSetExtTriggerTrackingState` finds its control and does not null-deref.

## Scope / notes

- Minimal change: the recording itself is still driven by the existing global `recordStart`/`recordStop → DataSaver` path, exactly as for a manual recording. This PR only makes the TTL edge reach that path for MiniCAMs.
- Covers Windows/Linux (the OpenCV backend, where control reads over the DAQ work). Full macOS coverage would additionally require giving the MiniCAM the direct-control backend and is left as a follow-up.

## Testing

- Incremental build clean (Qt6/CMake/Ninja).
- All 13 existing tests pass.
- Hardware validation of the TTL path on a physical standalone MiniCAM still recommended before release.

Closes #67
