### PR TITLE
Surface device disconnects with a persistent window indicator (#74)

### DIFF
--- a/source/VideoWindowShell.qml
+++ b/source/VideoWindowShell.qml
@@ -33,6 +33,9 @@ Item {
 
     property bool miniscope: false
     property bool recording: false
+    // Driven from C++ (VideoDevice) on device connection loss/recovery. Defaults
+    // true so the disconnect chip only appears once a drop actually happens.
+    property bool connected: true
 
     signal takeScreenShotSignal()
     signal vidPropChangedSignal(string name, double displayValue, double i2cValue, double i2cValue2)
@@ -217,6 +220,11 @@ Item {
         anchors.margins: Theme.spacing
         spacing: 6
 
+        StatusChip {
+            visible: !root.connected
+            text: qsTr("⚠ DISCONNECTED")
+            textColor: Theme.warning
+        }
         StatusChip {
             visible: root.recording
             text: qsTr("● REC")

--- a/source/videodevice.cpp
+++ b/source/videodevice.cpp
@@ -153,6 +153,15 @@ VideoDevice::VideoDevice(QObject *parent, QJsonObject ucDevice, qint64 softwareS
         // Handle request for reinitialization of commands
         QObject::connect(deviceStream, &VideoStreamBase::requestInitCommands, this, &VideoDevice::handleInitCommandsRequest);
 
+        // Drive a persistent "disconnected" indicator on the device window.
+        // Queued to the GUI thread (deviceStream lives on its own thread),
+        // mirroring the existing recording-indicator property push.
+        QObject::connect(deviceStream, &VideoStreamBase::connectionLost, this,
+                         [this](bool lost) {
+                             if (rootObject)
+                                 rootObject->setProperty("connected", !lost);
+                         });
+
         // --- USED ONLY FOR MINISCOPE INITIALLY -------------------------------
         // Handle external triggering passthrough
         QObject::connect(this, &VideoDevice::setExtTriggerTrackingState, deviceStream, &VideoStreamBase::setExtTriggerTrackingState);

--- a/source/videostreambase.cpp
+++ b/source/videostreambase.cpp
@@ -224,6 +224,7 @@ bool VideoStreamBase::runReconnectCycle(ReconnectBackoff &backoff, const QString
 {
     if (backoff.firstFailure()) {
         sendMessage("Warning: " + m_deviceName + " " + what + " failed. Attempting to reconnect.");
+        emit connectionLost(true);
         diagnoseStreamFailure();
     }
     // Interruptible backoff: sleep in short slices, delivering queued events
@@ -241,6 +242,7 @@ bool VideoStreamBase::runReconnectCycle(ReconnectBackoff &backoff, const QString
     if (attemptReconnect()) {
         sendMessage("Warning: " + m_deviceName + " reconnected (after " +
                     QString::number(backoff.attempts()) + " attempts).");
+        emit connectionLost(false);
         qDebug() << "Reconnect to camera" << m_cameraID;
         backoff.reset();
         // The device may have power-cycled, resetting its hardware frame

--- a/source/videostreambase.h
+++ b/source/videostreambase.h
@@ -115,6 +115,11 @@ signals:
     void newFrameAvailable(QString name, int frameNum);
     void extTriggered(bool triggerState);
     void requestInitCommands();
+    // Connection state for a persistent UI indicator: true on the first failure
+    // of a reconnect episode, false once the device is back. The scrolling
+    // message log already records the same events, but is easy to miss during an
+    // unattended multi-device session (issue #74).
+    void connectionLost(bool lost);
 
 public slots:
     virtual void startStream() = 0;


### PR DESCRIPTION
## Problem

Issue #74: with multiple miniscopes recording in parallel, a device intermittently loses its data link (root physical cause turned out to be ESD/mechanical — out of scope here). The software complaint is that **the disconnect never surfaces**: the only notice is a single line in the scrolling 500-entry message log, no status indicator changes, the DAQ lights stay green, and users only notice the dropout after the fact. A maintainer noted in-thread that the software should alert the user when a device drops.

## Fix

Add a persistent, prominent per-window indicator (purely additive; the streaming/reconnect logic is unchanged):

- **`VideoStreamBase::connectionLost(bool)`** — new signal, emitted `true` on the first failure of a reconnect episode and `false` once the device reconnects, right alongside the existing log messages in `runReconnectCycle`.
- **`VideoDevice`** forwards it to the window's `connected` QML property, queued to the GUI thread exactly like the existing recording-indicator push (`setWindowRecordingIndicator`), so it's cross-thread-safe.
- **`VideoWindowShell.qml`** shows a red **⚠ DISCONNECTED** status chip while a device is disconnected; it clears automatically on reconnect. `connected` defaults `true`.

## Scope

This surfaces the disconnect. It intentionally does **not** address the *separate* gap that a reconnect reverts the device's control settings (focus / frame rate / gain / LED) to power-on defaults — that fix is being handled in its own PR and needs hardware validation on a real multi-scope reconnect. **#74 stays open until that lands**, so this PR uses `Refs #74`, not `Closes`.

## Testing

- Incremental build clean (Qt6/CMake/Ninja); QML resource recompiled.
- All 13 existing tests pass.
- The disconnect path itself requires a physical device drop to exercise; visual confirmation of the chip on a rig is worth a quick check before release, but the change is additive and low-risk.

Refs #74
