### PR TITLE
Fix deployed-Windows crash: missing qt.conf broke per-device QML windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,15 @@ published together from CI.
   an error message instead of writing mixed-size frames into the recording.
 
 ### Fixed
+- Windows standalone build: opening any device window crashed the app
+  (access violation in Qt6Core) because the deployed layout was missing a
+  `qt.conf` — Qt's relocatable path lookup pointed at nonexistent
+  directories, so the per-device QML engines could not find modules like
+  `QtQuick.Window`. `deploy.py` now writes the `qt.conf`, matching what
+  macdeployqt (macOS) and linuxdeploy-plugin-qt (Linux) already do for the
+  other platforms' bundles. A device window whose QML fails to load for any
+  other reason now logs the loader errors and disables that device instead
+  of crashing.
 - Quitting the app now stops and joins every worker thread (capture loops,
   data saver, behavior tracker) in order — previously no thread was ever
   joined, so exit raced still-running threads against object teardown.

--- a/source/behaviortracker.cpp
+++ b/source/behaviortracker.cpp
@@ -261,6 +261,19 @@ void BehaviorTracker::createView(QSize resolution)
 #endif
 
 
+    // A failed QML load has no root object; report it and bail out instead
+    // of dereferencing it. sendNewFrame is only connected below, so a bailed
+    // tracker never touches the null trackerDisplay again.
+    const QStringList loadErrors =
+        NewQuickView::loadFailureMessages(view, QStringLiteral("Behavior tracker window"));
+    if (!loadErrors.isEmpty()) {
+        for (const QString &msg : loadErrors)
+            sendMessage(msg);
+        view->deleteLater();
+        view = nullptr;
+        return;
+    }
+
     rootObject = view->rootObject();
     trackerDisplay = rootObject->findChild<TrackerDisplay*>("trackerDisplay");
     QObject::connect(trackerDisplay->window(), &QQuickWindow::beforeRendering, this, &BehaviorTracker::sendNewFrame);

--- a/source/newquickview.cpp
+++ b/source/newquickview.cpp
@@ -1,5 +1,20 @@
 #include "newquickview.h"
 
+#include <QQmlError>
+
+QStringList NewQuickView::loadFailureMessages(const QQuickView *view, const QString &windowLabel)
+{
+    if (view->rootObject())
+        return {};
+    QStringList messages;
+    messages << "ERROR: " + windowLabel + " failed to load ("
+                + view->source().toString() + "). It has been disabled.";
+    const auto errors = view->errors();
+    for (const QQmlError &e : errors)
+        messages << "ERROR: " + e.toString();
+    return messages;
+}
+
 #ifdef Q_OS_WINDOWS
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX

--- a/source/newquickview.h
+++ b/source/newquickview.h
@@ -3,6 +3,7 @@
 
 #include <QObject>
 #include <QQuickView>
+#include <QStringList>
 
 // QQuickView with an optional aspect-ratio lock on interactive resizing.
 // (Close handling moved to the pane host: closing a floating pane re-docks
@@ -12,6 +13,13 @@ class NewQuickView: public QQuickView {
 public:
     NewQuickView(QUrl url):
         QQuickView(url) {}
+
+    // Failure report for a view whose QML produced no root object (bad
+    // qmlFile path, missing QML module in a broken deployment, ...): one
+    // summary line naming windowLabel plus one line per QML loader error.
+    // Empty when the view loaded fine. Every creation site checks this and
+    // bails out cleanly instead of dereferencing the null root object.
+    static QStringList loadFailureMessages(const QQuickView *view, const QString &windowLabel);
 
     // Lock interactive (border-drag) resizing to a fixed width:height ratio of the
     // client area. Pass 0 (the default) to leave the window freely resizable.

--- a/source/tracedisplay.cpp
+++ b/source/tracedisplay.cpp
@@ -3,6 +3,7 @@
 #include "newquickview.h"
 
 #include <QObject>
+#include <QDebug>
 #include <QGuiApplication>
 #include <QScreen>
 #include <QDateTime>
@@ -64,6 +65,20 @@ void TraceDisplayBackend::createView()
     // Not shown here: the Acquire pane host embeds or floats it per the saved
     // layout, and closing a floating trace pane re-docks it instead of tearing
     // it down (teardown happens only in close(), at session end).
+
+    // A failed QML load has no root object; bail out instead of dereferencing
+    // it. Console-only report: createView runs in the constructor, before the
+    // backend can wire up a message channel. close()/addNewTrace()/the pane
+    // host all already skip a null view / m_traceDisplay.
+    const QStringList loadErrors =
+        NewQuickView::loadFailureMessages(view, QStringLiteral("Trace display window"));
+    if (!loadErrors.isEmpty()) {
+        for (const QString &msg : loadErrors)
+            qWarning().noquote() << msg;
+        view->deleteLater();
+        view = nullptr;
+        return;
+    }
 
     m_traceDisplay = view->rootObject()->findChild<TraceDisplay*>("traceDisplay");
     m_traceDisplay->setSoftwareStartTime(m_softwareStartTime);

--- a/source/videodevice.cpp
+++ b/source/videodevice.cpp
@@ -8,6 +8,7 @@
 
 #include <QQuickView>
 #include <QQuickItem>
+#include <QQmlError>
 #include <QSemaphore>
 #include <QObject>
 #include <QTimer>
@@ -252,6 +253,22 @@ void VideoDevice::createView()
         // --------------------
 
         rootObject = view->rootObject();
+        if (!rootObject) {
+            // The window QML failed to load (bad qmlFile path, missing QML
+            // module in a deployed build, ...). Every lookup below would
+            // dereference null and crash, so report the loader's errors to
+            // the message log and take this device down instead.
+            sendMessage("ERROR: " + m_deviceName + " display window failed to load ("
+                        + url.toString() + "). The device has been disabled.");
+            const auto qmlErrors = view->errors();
+            for (const QQmlError &e : qmlErrors)
+                sendMessage("ERROR: " + e.toString());
+            stopAndJoinStream();
+            m_camConnected = 0;
+            view->deleteLater();
+            view = nullptr;
+            return;
+        }
 
         QObject::connect(rootObject, SIGNAL( takeScreenShotSignal() ),
                              this, SLOT( handleTakeScreenShotSignal() ));

--- a/source/videodevice.cpp
+++ b/source/videodevice.cpp
@@ -8,7 +8,6 @@
 
 #include <QQuickView>
 #include <QQuickItem>
-#include <QQmlError>
 #include <QSemaphore>
 #include <QObject>
 #include <QTimer>
@@ -252,23 +251,22 @@ void VideoDevice::createView()
         // pane (WindowContainer) or floats it, per the saved layout.
         // --------------------
 
-        rootObject = view->rootObject();
-        if (!rootObject) {
-            // The window QML failed to load (bad qmlFile path, missing QML
-            // module in a deployed build, ...). Every lookup below would
-            // dereference null and crash, so report the loader's errors to
-            // the message log and take this device down instead.
-            sendMessage("ERROR: " + m_deviceName + " display window failed to load ("
-                        + url.toString() + "). The device has been disabled.");
-            const auto qmlErrors = view->errors();
-            for (const QQmlError &e : qmlErrors)
-                sendMessage("ERROR: " + e.toString());
+        // Every lookup below would dereference a missing root object and
+        // crash, so report a failed QML load to the message log and take
+        // this device down instead.
+        const QStringList loadErrors =
+            NewQuickView::loadFailureMessages(view, m_deviceName + " display window");
+        if (!loadErrors.isEmpty()) {
+            for (const QString &msg : loadErrors)
+                sendMessage(msg);
             stopAndJoinStream();
             m_camConnected = 0;
             view->deleteLater();
             view = nullptr;
             return;
         }
+
+        rootObject = view->rootObject();
 
         QObject::connect(rootObject, SIGNAL( takeScreenShotSignal() ),
                              this, SLOT( handleTakeScreenShotSignal() ));

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -107,6 +107,16 @@ for cat in PLUGIN_CATS:
 print("[3/6] copying QML modules ...")
 shutil.copytree(os.path.join(qt6, "qml"), os.path.join(bindir, "qml"))
 
+# qt.conf: conda's Qt is relocatable, so QLibraryInfo derives every path from
+# Qt6Core.dll's location. In the deployed layout that resolves to nonexistent
+# dirs (e.g. <top>/lib/qt6/qml), so any QQmlEngine beyond the main one (which
+# main.cpp patches by hand) fails imports like QtQuick.Window - the per-device
+# video windows came up empty and the app crashed. This points the built-in
+# paths at the bundled plugins/ and qml/ for EVERY engine in the process.
+# ("Imports"/"Qml2Imports" are the qt.conf keys for QML import paths.)
+with open(os.path.join(bindir, "qt.conf"), "w", encoding="utf-8") as f:
+    f.write("[Paths]\nPrefix = .\nPlugins = .\nImports = qml\nQml2Imports = qml\n")
+
 # --- dependency walk (everything into bin/) ------------------------------
 print("[4/6] copying conda dependencies ...")
 roots = [os.path.join(bindir, os.path.basename(EXE))]

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -112,10 +112,10 @@ shutil.copytree(os.path.join(qt6, "qml"), os.path.join(bindir, "qml"))
 # dirs (e.g. <top>/lib/qt6/qml), so any QQmlEngine beyond the main one (which
 # main.cpp patches by hand) fails imports like QtQuick.Window - the per-device
 # video windows came up empty and the app crashed. This points the built-in
-# paths at the bundled plugins/ and qml/ for EVERY engine in the process.
-# ("Imports"/"Qml2Imports" are the qt.conf keys for QML import paths.)
+# paths at the bundled plugins/ and qml/ for EVERY engine in the process,
+# relative to the exe's dir (the qt.conf default prefix).
 with open(os.path.join(bindir, "qt.conf"), "w", encoding="utf-8") as f:
-    f.write("[Paths]\nPrefix = .\nPlugins = .\nImports = qml\nQml2Imports = qml\n")
+    f.write("[Paths]\nPlugins = .\nQmlImports = qml\n")
 
 # --- dependency walk (everything into bin/) ------------------------------
 print("[4/6] copying conda dependencies ...")


### PR DESCRIPTION
## Problem

The standalone Windows bundle (the `deploy` target output, i.e. what the release zip/installer ship) crashed with an access violation in Qt6Core.dll the moment a session started and a device window tried to open. Dev builds run from the conda env were unaffected, which is why this survived until someone ran the deployed folder.

## Root cause

conda-forge's Qt is built relocatable: `QLibraryInfo` derives every built-in path from `Qt6Core.dll`'s location. In the deployed layout the DLLs live in `bin/`, so Qt looked for QML modules in `<top>/lib/qt6/qml` - which does not exist. The main window survives only because `main.cpp` adds `bin/qml` to *its* engine by hand; every per-device window (`NewQuickView`) creates its own `QQmlEngine` with the broken defaults, so `qrc:/behaviorCam.qml` failed with `module "QtQuick.Window" is not installed`, `rootObject()` came back null, and `VideoDevice::createView()` dereferenced it.

## Fix (two parts)

1. **`tools/deploy.py` writes a `qt.conf`** next to the real exe pointing the built-in plugin/QML paths at the bundled folders. `qt.conf` is Qt's canonical mechanism for custom deployment layouts and fixes path resolution for **every** engine in the process, present and future.
2. **`VideoDevice::createView()` guards a failed QML load**: loader errors go to the session message log and the device is shut down cleanly (stream stopped and joined) instead of crashing the app. This covers any future load failure, e.g. a bad `qmlFile` in a device config, on all platforms.

## Cross-platform check

This gap was Windows-specific: the macOS bundle is built with `macdeployqt` and the Linux AppImage with `linuxdeploy-plugin-qt`, and **both of those tools already write the equivalent `qt.conf`** into their bundles (plus bundle the scanned QML modules). Our Windows deploy is hand-rolled because conda-forge's windeployqt is broken (see deploy.py header) and was missing this one piece of what windeployqt would normally do. The `videodevice.cpp` guard is platform-neutral.

## Verification

- Reproduced the crash on a deployed bundle on Windows 11 (webcam-only user config; `module "QtQuick.Window" is not installed` followed by the null-deref).
- With the fix: same config streams end-to-end in the deployed bundle - device window opens, live video at ~30 FPS (verified via the `MINISCOPE_AUTORUN_CONFIG` + screenshot hooks).
- Full unit test suite passes on Windows (10/10, including the GL shader-compile test that CI skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
