### PR TITLE
Fix Windows resize lag on hybrid GPUs and disconnect-on-resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,17 @@ published together from CI.
   an error message instead of writing mixed-size frames into the recording.
 
 ### Fixed
+- Windows on hybrid-GPU laptops (iGPU + discrete): resizing a session window
+  stalled for seconds per step (lagging the whole desktop) because the app's
+  OpenGL rendering defaulted to the power-saving iGPU, where the session's
+  multiple GL windows serialize their swapchain resizes pathologically. The
+  app now requests the discrete GPU via the standard NVIDIA/AMD driver
+  opt-ins (bench: a 50-step scripted resize storm dropped from 22.6 s to
+  3.0 s, with webcam capture holding ~30 FPS instead of starving to ~6 FPS).
+- A transient camera grab/retrieve failure (e.g. GPU/driver contention while
+  a window is resized) no longer releases the camera and triggers a full
+  disconnect/reconnect cycle - the capture loop retries in place for up to
+  ~1 s first. A genuinely unplugged camera still reconnects as before.
 - Windows standalone build: opening any device window crashed the app
   (access violation in Qt6Core) because the deployed layout was missing a
   `qt.conf` — Qt's relocatable path lookup pointed at nonexistent

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -37,6 +37,21 @@
 
 // For Window's deployment
 //C:\Qt\5.12.6>C:\Qt\5.12.6\msvc2017_64\bin\windeployqt.exe --qmldir C:\Users\DBAharoni\Documents\Projects\Miniscope-DAQ-QT-Software\Miniscope-DAQ-QT-Software\ C:\Users\DBAharoni\Documents\Projects\Miniscope-DAQ-QT-Software\build-Miniscope-DAQ-QT-Software-Desktop_Qt_5_12_6_MSVC2017_64bit-Release\release\Miniscope-DAQ-QT-Software.exe
+
+#ifdef Q_OS_WIN
+// Ask hybrid-GPU (laptop iGPU + discrete) drivers to run this app on the
+// discrete GPU. By default the OpenGL scene graph + raw-GL video underlays
+// land on the power-saving iGPU, where resizing a session window stalls for
+// SECONDS per step inside SwapBuffers: the session holds two nested GL
+// swapchains (shell + embedded video pane), and the iGPU/DWM path serializes
+// their resizes pathologically (bench: 50-step resize storm 22.6s on Intel
+// Arc vs 3.4s on the discrete GPU, with capture starved to ~6 FPS vs a steady
+// ~30 FPS). These exported symbols are the documented NVIDIA/AMD opt-ins.
+extern "C" {
+__declspec(dllexport) unsigned long NvOptimusEnablement = 0x00000001;
+__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+}
+#endif
 int main(int argc, char *argv[])
 {
     // Qt6: high-DPI scaling is always on, so AA_EnableHighDpiScaling is gone

--- a/source/videostreamocv.cpp
+++ b/source/videostreamocv.cpp
@@ -120,6 +120,7 @@ int VideoStreamOCV::connect2Video(QString folderPath, QString filePrefix, float 
 void VideoStreamOCV::startStream()
 {
     resetStreamState();
+    m_transientFailures = 0;
     ReconnectBackoff backoff;
     cv::Mat frame;
     qint64 timestamp = 0;
@@ -153,25 +154,38 @@ void VideoStreamOCV::startStream()
         else
 #endif
         if (m_connectionType != "videoFile") {
+            // A grab/retrieve can fail transiently while the device is fine -
+            // bench-observed on Windows/DSHOW whenever a window is interactively
+            // resized (GPU/DWM contention during the GL swapchain rebuild).
+            // Releasing the camera on the first failure turns that blip into a
+            // full disconnect: seconds of reconnect backoff, frozen video, and
+            // the persistent "disconnected" indicator. So retry briefly in
+            // place, and only run the reconnect cycle when the failure persists
+            // for ~1 s (a genuinely unplugged device still reconnects, just one
+            // second later).
+            const char *failedStep = nullptr;
             if (!cam->grab()) {
+                failedStep = "grab frame";
+            } else {
+                timestamp = monotonicTimeMs();
+                if (!cam->retrieve(frame))
+                    failedStep = "retrieve frame";
+            }
+            if (failedStep) {
+                if (++m_transientFailures < kTransientFailureLimit) {
+                    QThread::msleep(kTransientRetryDelayMs);
+                    continue;
+                }
+                m_transientFailures = 0;
                 if (cam->isOpened()) {
-                    qDebug() << "Grab failed: Releasing cam" << m_cameraID;
+                    qDebug() << failedStep << "failed: Releasing cam" << m_cameraID;
                     cam->release();
                     qDebug() << "Released cam" << m_cameraID;
                 }
-                runReconnectCycle(backoff, "grab frame");
+                runReconnectCycle(backoff, QString::fromLatin1(failedStep));
                 continue;
             }
-            timestamp = monotonicTimeMs();
-            if (!cam->retrieve(frame)) {
-                if (cam->isOpened()) {
-                    qDebug() << "Retrieve failed: Releasing cam" << m_cameraID;
-                    cam->release();
-                    qDebug() << "Released cam" << m_cameraID;
-                }
-                runReconnectCycle(backoff, "retrieve frame");
-                continue;
-            }
+            m_transientFailures = 0;
             backoff.reset();
         }
         else {

--- a/source/videostreamocv.h
+++ b/source/videostreamocv.h
@@ -55,6 +55,13 @@ private:
     QString m_playbackFilePrefix;
     int m_playbackFileIndex;
 
+    // Transient grab/retrieve failure tolerance (see startStream): retry in
+    // place for up to limit * delay (~1 s) before treating the device as
+    // disconnected. Consecutive-failure count; any success resets it.
+    static constexpr int kTransientFailureLimit = 40;
+    static constexpr int kTransientRetryDelayMs = 25;
+    int m_transientFailures = 0;
+
 };
 
 #endif // VIDEOSTREAMOCV_H


### PR DESCRIPTION
## Problem

On Windows (hybrid-GPU laptop), drag-resizing a session window was severely laggy — enough to stutter the entire desktop — and the webcam pane flipped to the "disconnected" indicator with seconds of frozen video. macOS was unaffected. Reported while testing the deployed qt6-port build with a single laptop webcam.

## Diagnosis (measured, not guessed)

A scripted "resize storm" (200 `SetWindowPos` steps, 40 ms apart) against the deployed build:

| scenario | storm wall time (nominal 8 s) | capture rate during storm |
|---|---|---|
| Session running (webcam pane) | **131 s** | ~6 FPS |
| Setup mode (no video pane) | 10.8 s | n/a |
| Session + app pinned to discrete GPU | **~3 s eq.** | ~30 FPS |

`QSG_RENDER_TIMING=1` located the stall: individual frames blocked **2.2–2.7 s inside SwapBuffers**, on both scene-graph windows. On hybrid-GPU machines the app's OpenGL contexts default to the power-saving iGPU (Intel Arc on the bench machine), where the session's multiple GL swapchains (shell + video window, embedded or floating) serialize their resizes pathologically. Setup mode has one GL window — smooth. This also explains why it regressed with the ui-v3 shell: sessions now always have at least two live GL windows.

The "disconnect" was collateral: the same contention makes a single `cam->grab()`/`retrieve()` fail, and the capture loop treated the **first** failure as a dead camera — releasing it and entering reconnect backoff (repeated DirectShow re-opens, which themselves stutter the system).

## Fix (two parts)

1. **`main.cpp` (Windows)**: export `NvOptimusEnablement` / `AmdPowerXpressRequestHighPerformance` — the documented NVIDIA/AMD driver opt-ins that run the app on the discrete GPU. No user/registry setup needed; no effect on iGPU-only machines.
2. **`videostreamocv.cpp`**: transient grab/retrieve tolerance — retry in place for up to ~1 s (40 × 25 ms) before releasing the camera and running the reconnect cycle. A genuinely unplugged camera still reconnects, one second later; a resize hiccup no longer becomes a multi-second disconnect cascade.

## Verification

- Resize storm on the fixed build: **3.0 s for 50 steps** (was 22.6 s), webcam capture steady at ~30 FPS through the drag (was starved to ~6 FPS), **zero** disconnect events (was 4 reconnect cycles).
- Interactive feel-test on the bench laptop (i9 + Intel Arc + RTX 4090): smooth drag-resize with the pane docked and popped out; system-wide lag gone.
- All 10 unit tests pass; macOS/Linux paths untouched by the GPU exports (`#ifdef Q_OS_WIN`) and unaffected in behavior by the capture-loop tolerance (macOS uses the AVF grabber path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
