### PR TITLE
Left-edge dock for Miniscope hardware controls

### DIFF
--- a/source/VideoSliderControl.qml
+++ b/source/VideoSliderControl.qml
@@ -1,10 +1,14 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 
-// Compact video-overlay hardware control: the current value stays visible as
-// a small chip (icon + value) that costs almost no screen space; hovering the
-// chip slides out a slider to its left for adjustment (pressing keeps it
-// open while dragging).
+// One hardware-control row for the left dock (LED, EWL, ...). The current value
+// is always visible (icon + number); the dock reveals the slider in-row when it
+// expands, so every control's slider comes out together - no per-control hover
+// flyout floating over the video.
+//
+// The dock drives `expanded`; when collapsed the slider is hidden and the row
+// is just icon + value, so the whole dock stays narrow.
 //
 // C++ contract (videodevice.cpp control loop, keep stable): objectName set by
 // the window shell; catalog-driven properties min/max/stepSize/startValue/
@@ -14,9 +18,9 @@ import QtQuick.Controls
 // values reach the device through this path.
 Item {
     id: root
-    implicitWidth: chip.width
-    implicitHeight: chip.height
+    implicitHeight: 30
 
+    property bool expanded: false
     property color textColor: "#d8d8e0"
     property var iconPath: ""
     property double min: 0.0
@@ -45,64 +49,27 @@ Item {
             root.valueChangedSignal(slider.value, i2cValue(slider.value), 0)
     }
 
-    readonly property bool expanded: chipHover.hovered || flyoutHover.hovered
-                                     || slider.pressed
+    RowLayout {
+        anchors.fill: parent
+        spacing: 6
 
-    Rectangle {
-        id: chip
-        anchors.right: parent.right
-        width: chipRow.implicitWidth + 12
-        height: 22
-        radius: 4
-        color: "#aa14141a"
-        border.width: root.expanded ? 1 : 0
-        border.color: "#5a5a68"
-
-        HoverHandler { id: chipHover }
-
-        Row {
-            id: chipRow
-            anchors.centerIn: parent
-            spacing: 5
-            RecoloredIcon {
-                height: 16
-                width: 16
-                anchors.verticalCenter: parent.verticalCenter
-                source: root.iconPath
-            }
-            Text {
-                anchors.verticalCenter: parent.verticalCenter
-                text: slider.value.toFixed(root.decimalPrecision)
-                color: root.textColor
-                font.pixelSize: 13
-                font.bold: true
-            }
+        RecoloredIcon {
+            Layout.preferredWidth: 16
+            Layout.preferredHeight: 16
+            source: root.iconPath
         }
-    }
-
-    Rectangle {
-        id: flyout
-        visible: root.expanded
-        anchors.right: chip.left
-        anchors.rightMargin: 4
-        anchors.verticalCenter: chip.verticalCenter
-        width: 170
-        height: 22
-        radius: 4
-        color: "#dd14141a"
-        border.width: 1
-        border.color: "#5a5a68"
-
-        HoverHandler { id: flyoutHover }
 
         Slider {
             id: slider
-            anchors.fill: parent
-            anchors.leftMargin: 8
-            anchors.rightMargin: 8
+            visible: root.expanded
+            opacity: root.expanded ? 1 : 0
+            Layout.fillWidth: true
+            Layout.preferredHeight: root.implicitHeight
             from: root.min
             to: root.max
             stepSize: root.stepSize
+
+            Behavior on opacity { NumberAnimation { duration: 120 } }
 
             onValueChanged: root.valueChangedSignal(value, root.i2cValue(value), 0)
 
@@ -129,6 +96,15 @@ Item {
                 border.width: 1
                 border.color: "#5a5a68"
             }
+        }
+
+        Text {
+            Layout.preferredWidth: 34
+            text: slider.value.toFixed(root.decimalPrecision)
+            color: root.textColor
+            font.pixelSize: 13
+            font.bold: true
+            horizontalAlignment: Text.AlignRight
         }
     }
 }

--- a/source/VideoSpinBoxControl.qml
+++ b/source/VideoSpinBoxControl.qml
@@ -1,9 +1,10 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 
-// Compact video-overlay stepped control (gain, frame rate): the current
-// value stays visible as a small chip; hovering slides out a -/+ stepper to
-// its left.
+// One stepped hardware-control row for the left dock (gain, frame rate). The
+// current value is always visible (icon + number); the dock reveals a -/+
+// stepper in-row when it expands, matching VideoSliderControl's behaviour.
 //
 // C++ contract (videodevice.cpp control loop, keep stable): objectName set by
 // the window shell; catalog-driven properties displaySpinBoxValues/
@@ -13,9 +14,9 @@ import QtQuick.Controls
 // values reach the device through this path.
 Item {
     id: root
-    implicitWidth: chip.width
-    implicitHeight: chip.height
+    implicitHeight: 30
 
+    property bool expanded: false
     property color textColor: "#d8d8e0"
     property var iconPath: ""
     property var displaySpinBoxValues: []
@@ -48,64 +49,43 @@ Item {
             spinBox.value = idx
     }
 
-    readonly property bool expanded: chipHover.hovered || flyoutHover.hovered
+    RowLayout {
+        anchors.fill: parent
+        spacing: 6
 
-    Rectangle {
-        id: chip
-        anchors.right: parent.right
-        width: chipRow.implicitWidth + 12
-        height: 22
-        radius: 4
-        color: "#aa14141a"
-        border.width: root.expanded ? 1 : 0
-        border.color: "#5a5a68"
-
-        HoverHandler { id: chipHover }
-
-        Row {
-            id: chipRow
-            anchors.centerIn: parent
-            spacing: 5
-            RecoloredIcon {
-                height: 16
-                width: 16
-                anchors.verticalCenter: parent.verticalCenter
-                source: root.iconPath
-            }
-            Text {
-                anchors.verticalCenter: parent.verticalCenter
-                text: root.displayTextValues[spinBox.value] !== undefined
-                      ? "" + root.displayTextValues[spinBox.value] : ""
-                color: root.textColor
-                font.pixelSize: 13
-                font.bold: true
-            }
+        RecoloredIcon {
+            Layout.preferredWidth: 16
+            Layout.preferredHeight: 16
+            source: root.iconPath
         }
-    }
 
-    Rectangle {
-        id: flyout
-        visible: root.expanded
-        anchors.right: chip.left
-        anchors.rightMargin: 4
-        anchors.verticalCenter: chip.verticalCenter
-        width: 110
-        height: 22
-        radius: 4
-        color: "#dd14141a"
-        border.width: 1
-        border.color: "#5a5a68"
-
-        HoverHandler { id: flyoutHover }
+        // Collapsed: a plain value label. Expanded: the -/+ stepper (which
+        // shows the same value). Only one is present at a time so the row
+        // stays narrow when collapsed.
+        Text {
+            visible: !root.expanded
+            Layout.fillWidth: true
+            text: root.displayTextValues[spinBox.value] !== undefined
+                  ? "" + root.displayTextValues[spinBox.value] : ""
+            color: root.textColor
+            font.pixelSize: 13
+            font.bold: true
+            horizontalAlignment: Text.AlignRight
+        }
 
         SpinBox {
             id: spinBox
-            anchors.fill: parent
+            visible: root.expanded
+            opacity: root.expanded ? 1 : 0
+            Layout.fillWidth: true
+            Layout.preferredHeight: root.implicitHeight
             from: 0
             to: Math.max(0, root.displaySpinBoxValues.length - 1)
             value: 0
             font.pixelSize: 13
             font.bold: true
+
+            Behavior on opacity { NumberAnimation { duration: 120 } }
 
             textFromValue: function(value) {
                 return root.displaySpinBoxValues[value] !== undefined

--- a/source/VideoWindowShell.qml
+++ b/source/VideoWindowShell.qml
@@ -11,11 +11,12 @@ import Miniscope.Theme 1.0
 //
 // Design: telemetry lives in always-visible status chips over the video (REC
 // state above all - the old windows showed nothing during a recording);
-// hardware controls are always-visible value chips at the top right whose
-// slider/stepper slides out on hover (values glanceable at all times,
-// adjustment UI only when needed); display-only controls (contrast /
-// brightness / saturation / LUT / dFF) and actions sit in an auto-hiding
-// right rail.
+// hardware controls (gain / frame rate / LEDs / EWL - the recorded device
+// settings) live in a left-edge dock whose value + icon are always visible,
+// and which expands on hover (or when pinned) to reveal every control's
+// slider/stepper at once (values glanceable at all times, adjustment UI only
+// when needed); display-only controls (contrast / brightness / saturation /
+// LUT / dFF) and actions sit in an auto-hiding right rail.
 //
 // C++ contract (videodevice/miniscope/behaviorcam.cpp attach by objectName
 // and root signal - keep these stable):
@@ -258,56 +259,131 @@ Item {
         opacity: 0.9
     }
 
-    // --- Sensor value chips (always visible, top right) ------------------------
-    // Each shows its current value at a glance; hovering a chip slides out
-    // its slider/stepper. The catalog (videoDevices.json) defines which
-    // controls exist per device type; C++ shows and configures them.
-    Column {
-        anchors.top: parent.top
-        anchors.right: parent.right
-        anchors.topMargin: Theme.spacing
-        anchors.rightMargin: 34 // clear of the rail's edge-hover zone
-        spacing: 6
+    // --- Hardware control dock (left edge) -------------------------------------
+    // The recorded device settings (gain / frame rate / LEDs / EWL). Value +
+    // icon are always visible so they stay glanceable during a recording;
+    // hovering the dock (or pinning it) expands it and reveals every control's
+    // slider/stepper at once - no per-control flyout floating over the video.
+    // The catalog (videoDevices.json) defines which controls exist per device
+    // type; C++ shows (visible) and configures each by objectName.
+    //
+    // Sizing is window-relative: video panes in the Acquire grid can get small,
+    // so the expanded width clamps to the pane and the rows scroll if a very
+    // short pane can't fit them all.
+    Rectangle {
+        id: hwDock
+        anchors.left: parent.left
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.leftMargin: Theme.spacing
 
-        VideoSpinBoxControl {
-            objectName: "gain"
-            visible: false
-            anchors.right: parent.right
-            iconPath: "img/icon/gain.png"
-            onValueChangedSignal: (displayValue, i2cValue, i2cValue2) =>
-                root.vidPropChangedSignal("gain", displayValue, i2cValue, i2cValue2)
-        }
-        VideoSpinBoxControl {
-            objectName: "frameRate"
-            visible: false
-            anchors.right: parent.right
-            iconPath: "img/icon/fps.png"
-            onValueChangedSignal: (displayValue, i2cValue, i2cValue2) =>
-                root.vidPropChangedSignal("frameRate", displayValue, i2cValue, i2cValue2)
-        }
-        VideoSliderControl {
-            objectName: "led0"
-            visible: false
-            anchors.right: parent.right
-            iconPath: "img/icon/led.png"
-            onValueChangedSignal: (displayValue, i2cValue, i2cValue2) =>
-                root.vidPropChangedSignal("led0", displayValue, i2cValue, i2cValue2)
-        }
-        VideoSliderControl {
-            objectName: "led1"
-            visible: false
-            anchors.right: parent.right
-            iconPath: "img/icon/led.png"
-            onValueChangedSignal: (displayValue, i2cValue, i2cValue2) =>
-                root.vidPropChangedSignal("led1", displayValue, i2cValue, i2cValue2)
-        }
-        VideoSliderControl {
-            objectName: "ewl"
-            visible: false
-            anchors.right: parent.right
-            iconPath: "img/icon/ewl.png"
-            onValueChangedSignal: (displayValue, i2cValue, i2cValue2) =>
-                root.vidPropChangedSignal("ewl", displayValue, i2cValue, i2cValue2)
+        readonly property bool hwExpanded: hwHover.hovered || hwPinned
+        property bool hwPinned: false
+        readonly property int collapsedWidth: 78
+        readonly property int expandedWidth: Math.min(240, root.width - 2 * Theme.spacing)
+
+        // Whether the catalog gave this device any hardware controls. C++ calls
+        // setVisible(true) on each control AFTER the window loads. We must NOT
+        // gate this Rectangle's own `visible` on the children's visibility:
+        // QML `item.visible` is EFFECTIVE visibility, so a hidden dock keeps its
+        // children effectively hidden, their visibleChanged never fires, and the
+        // dock stays hidden forever (chicken-and-egg). Keeping the dock itself
+        // visible lets the children's effective visibility track C++, so this
+        // binding resolves correctly; we hide the empty dock by collapsing its
+        // width and making it transparent instead.
+        readonly property bool hasControls:
+            gainCtl.visible || frameRateCtl.visible || led0Ctl.visible
+            || led1Ctl.visible || ewlCtl.visible
+
+        width: hasControls ? (hwExpanded ? expandedWidth : collapsedWidth) : 0
+        // Never taller than the pane (minus a margin); the ScrollView handles
+        // the overflow if it still doesn't fit.
+        height: Math.min(hwContent.implicitHeight + 2 * Theme.spacing,
+                         root.height - 2 * Theme.spacing)
+        radius: Theme.radiusSmall
+        color: !hasControls ? "transparent"
+                            : (hwExpanded ? "#dd14141a" : "#aa14141a")
+
+        Behavior on width { NumberAnimation { duration: Theme.animMs } }
+
+        HoverHandler { id: hwHover }
+
+        ScrollView {
+            anchors.fill: parent
+            anchors.margins: Theme.spacing
+            contentWidth: availableWidth
+            clip: true
+
+            ColumnLayout {
+                id: hwContent
+                width: hwDock.width - 2 * Theme.spacing
+                spacing: 4
+
+                // Pin (glove-friendly), shown only once expanded.
+                Text {
+                    Layout.alignment: Qt.AlignRight
+                    visible: hwDock.hwExpanded
+                    text: hwDock.hwPinned ? "📌" : "📍"
+                    font: Theme.fontSmall
+                    color: "#8a8a96"
+                    MouseArea {
+                        anchors.fill: parent
+                        anchors.margins: -6
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: hwDock.hwPinned = !hwDock.hwPinned
+                    }
+                }
+
+                VideoSpinBoxControl {
+                    id: gainCtl
+                    objectName: "gain"
+                    visible: false
+                    Layout.fillWidth: true
+                    expanded: hwDock.hwExpanded
+                    iconPath: "img/icon/gain.png"
+                    onValueChangedSignal: (displayValue, i2cValue, i2cValue2) =>
+                        root.vidPropChangedSignal("gain", displayValue, i2cValue, i2cValue2)
+                }
+                VideoSpinBoxControl {
+                    id: frameRateCtl
+                    objectName: "frameRate"
+                    visible: false
+                    Layout.fillWidth: true
+                    expanded: hwDock.hwExpanded
+                    iconPath: "img/icon/fps.png"
+                    onValueChangedSignal: (displayValue, i2cValue, i2cValue2) =>
+                        root.vidPropChangedSignal("frameRate", displayValue, i2cValue, i2cValue2)
+                }
+                VideoSliderControl {
+                    id: led0Ctl
+                    objectName: "led0"
+                    visible: false
+                    Layout.fillWidth: true
+                    expanded: hwDock.hwExpanded
+                    iconPath: "img/icon/led.png"
+                    onValueChangedSignal: (displayValue, i2cValue, i2cValue2) =>
+                        root.vidPropChangedSignal("led0", displayValue, i2cValue, i2cValue2)
+                }
+                VideoSliderControl {
+                    id: led1Ctl
+                    objectName: "led1"
+                    visible: false
+                    Layout.fillWidth: true
+                    expanded: hwDock.hwExpanded
+                    iconPath: "img/icon/led.png"
+                    onValueChangedSignal: (displayValue, i2cValue, i2cValue2) =>
+                        root.vidPropChangedSignal("led1", displayValue, i2cValue, i2cValue2)
+                }
+                VideoSliderControl {
+                    id: ewlCtl
+                    objectName: "ewl"
+                    visible: false
+                    Layout.fillWidth: true
+                    expanded: hwDock.hwExpanded
+                    iconPath: "img/icon/ewl.png"
+                    onValueChangedSignal: (displayValue, i2cValue, i2cValue2) =>
+                        root.vidPropChangedSignal("ewl", displayValue, i2cValue, i2cValue2)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Moves the Miniscope hardware controls (gain / frame rate / LEDs / EWL — the *recorded* device settings) from the top-right hover-flyout chips into a **left-edge dock** on every video window.

- **Collapsed (default):** a slim panel showing each control's icon + current value (`G 1`, `⏱ 40`, `💡 20`) — always glanceable, even during a recording.
- **Hover or pin (📌):** the dock expands and **every** control's slider/stepper appears at once — `− 1X +`, `− 40FPS +`, `[──●──] 20`.
- **Behavior cams** (no hardware controls): dock collapses to zero width / transparent — nothing shown.

This keeps the familiar master-branch model (value always visible, adjustment on demand) while fixing the two clunky parts: the reveal is one in-row panel rather than a fragile flyout floating over live video, and **all** sliders come out together instead of one at a time. Hardware controls now live on the left; display-only controls stay in the right rail.

## Implementation

- `VideoSliderControl` / `VideoSpinBoxControl` rewritten as in-row controls with an `expanded` mode instead of a detached flyout.
- All `objectName`s and the `vidPropChangedSignal` contract are unchanged — **no C++ changes** (`videodevice.cpp` untouched).
- Window-relative sizing: expanded width clamps to `min(240, paneWidth − margin)`, height caps to the pane with a scroll fallback, so it works in the Acquire grid's small panes.

### Note on visibility gating
QML `item.visible` is *effective* visibility, so gating the dock's own `visible` on the children's `.visible` deadlocks: while the dock is hidden, C++'s post-load `setVisible(true)` on a control doesn't change the child's *effective* visibility, `visibleChanged` never fires, and the dock stays hidden forever. The dock is therefore always `visible: true` and hides its empty state via zero width + transparent color instead. (Documented inline so it isn't "simplified" back into the bug.)

## Verification

Exercised end-to-end with a simulated `Siminiscope` device (no hardware) and a webcam config, via the autorun + screenshot hooks:

- ✅ Collapsed dock shows values; hover/pin reveals all sliders/steppers at once.
- ✅ Behavior-cam window shows no dock (clean, no artifact).
- ✅ No QML errors/warnings at load.
- ✅ All 10 ctest cases pass.

The simulated device covers gain/frameRate/led0; EWL and led1 use the identical mechanism but are worth an eyeball on a real V4 on the bench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)