### PR TITLE
Fix schema warnings on a brand-new user config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,18 @@ published together from CI.
   an error message instead of writing mixed-size frames into the recording.
 
 ### Fixed
+- **New** config: the generated skeleton no longer violates the config schema.
+  Its defaults came from field *types* alone, which know nothing about the
+  schema's enums, minimums and array lengths, so a brand-new config carried
+  `configVersion` 0, an empty `poseOverlay.type`, a zero `commutator.sampleRate`
+  with empty axis arrays, and a string-valued `led0FineSteps` — filling in the
+  first field then dumped ~25 warning lines into the Config check panel. Those
+  keys are now seeded with their documented defaults (sample rate 10 Hz, axes
+  `[0, 0, 1]`, fallback mode `global`, …), and New / Add device refresh the
+  Config check panel instead of leaving the previous config's notes on screen.
+- Config check notes only list the actual violations: each one used to be
+  followed by a "failed to validate against …" line for every enclosing section
+  up to the config root, roughly quadrupling the panel's contents.
 - Windows on hybrid-GPU laptops (iGPU + discrete): resizing a session window
   stalled for seconds per step (lagging the whole desktop) because the app's
   OpenGL rendering defaulted to the power-saving iGPU, where the session's

--- a/deviceConfigs/userConfigProps.json
+++ b/deviceConfigs/userConfigProps.json
@@ -296,7 +296,7 @@
                     "tips": "This sets the initial excitation LED intensity. Values can be from 0 to 100 (or 0 to 255 when led0FineSteps is true) but many Miniscope configurations have trouble with values over 70% of the range due to current limits through certain coax cable lengths."
                 },
                 "led0FineSteps": {
-                    "type": "Boolean",
+                    "type": "Bool",
                     "tips": "When true, the led0 slider runs 0 to 255 and addresses every hardware step of the LED driver individually instead of 0 to 100 percent, giving 2.55x finer steps for very dim illumination. Both mappings span the same brightness range. Leave off (default) to keep the exact LED output of existing configs."
                 },
                 "frameRate": {

--- a/source/backend.cpp
+++ b/source/backend.cpp
@@ -228,7 +228,10 @@ void backEnd::saveConfigObjectAs(const QString &filePath)
 
 QJsonValue backEnd::defaultForType(const QString &type)
 {
-    if (type == "Bool")
+    // "Boolean" is accepted alongside "Bool": userConfigProps.json is hand-edited,
+    // and a boolean spelled the other way used to fall through to "" - a string
+    // where the schema wants a bool, which then failed validation.
+    if (type == "Bool" || type == "Boolean")
         return false;
     if (type == "Integer" || type == "Number" || type == "Double")
         return 0;
@@ -266,8 +269,14 @@ void backEnd::newUserConfig()
     for (const QString &k : keys) {
         if (k.contains("COMMENT"))
             continue;
+        if (k == QStringLiteral("$schema"))
+            continue;   // editor hint, not a setting; stamped with a real URL below
         cfg[k] = defaultFromProps(m_configProps.value(k));
     }
+
+    // configVersion (enum [1]) and the $schema pointer. Type defaults would make
+    // configVersion 0, which the schema rejects.
+    stampConfigMetadata(cfg);
 
     // Seed sensible, non-empty defaults so a fresh config is immediately usable
     // instead of being full of blanks/zeros the user has to fill in.
@@ -317,10 +326,24 @@ void backEnd::newUserConfig()
         op["numBinsY"] = 100;
         bt["occupancyPlot"] = op;
         QJsonObject po = bt["poseOverlay"].toObject();
+        po["type"]           = "point";   // enum: point / line / ribbon
         po["numOfPastPoses"] = 6;
         po["markerSize"]     = 20;
         bt["poseOverlay"] = po;
         cfg["behaviorTracker"] = bt;
+    }
+
+    // Commutator stays off, but with the documented defaults rather than zeros:
+    // sampleRate must be > 0, the axes are 3-vectors, and fallbackMode is an enum.
+    if (cfg.contains("commutator")) {
+        QJsonObject cm = cfg.value("commutator").toObject();
+        cm["led"]               = true;
+        cm["sampleRate"]        = 10;
+        cm["headstageAxis"]     = QJsonArray{ 0, 0, 1 };
+        cm["commutatorAxis"]    = QJsonArray{ 0, 0, 1 };
+        cm["fallbackThreshold"] = -0.9;
+        cm["fallbackMode"]      = "global";
+        cfg["commutator"] = cm;
     }
 
     m_userConfig = cfg;
@@ -328,10 +351,10 @@ void backEnd::newUserConfig()
     emit userConfigFileNameChanged();
     m_savedConfig = QJsonObject();  // nothing on disk yet -> dirty until saved
 
-    updateHasDevices();
-    checkUserConfigForIssues();     // emits userConfigOKChanged() -> enables Save/Run
-    updateDirtyState();
-    emit userConfigJsonChanged();
+    // Same tail as any form edit: refreshes the advisory schema notes (a stale
+    // set from the previously loaded config would otherwise stay on screen) and
+    // the checks that enable Save/Run.
+    configEdited();
 }
 
 void backEnd::enrichDeviceDefaults(QJsonObject &device, const QString &category,
@@ -442,10 +465,7 @@ void backEnd::addDevice(const QString &category, const QString &deviceType,
     devices[category]       = section;
     m_userConfig["devices"] = devices;
 
-    updateHasDevices();
-    checkUserConfigForIssues();
-    updateDirtyState();
-    emit userConfigJsonChanged();
+    configEdited();   // includes the schema notes, so a new device is checked too
 }
 
 // Public entry (wired to the "Scan Devices" button): dispatch to the OS-specific

--- a/source/configvalidator.cpp
+++ b/source/configvalidator.cpp
@@ -65,6 +65,22 @@ QStringList validateUserConfigAgainstSchema(const QJsonObject &config,
         return warnings;   // conforms
     }
 
+    // valijson reports one error per failing subschema, so a single bad value
+    // also produces a relay message for every ancestor on the way to the root
+    // ("commutator: Failed to validate against schema associated with property
+    // name 'sampleRate'.", "(config root): Failed to validate against ...").
+    // Those add nothing - the leaf message already carries the full path - and
+    // they buried the real notes under ~4x their number of lines. Kept aside and
+    // used only if no leaf message survives, so nothing is ever silently lost.
+    QStringList relays;
+    const auto isRelay = [](const QString &description) {
+        return description.startsWith(QLatin1String("Failed to validate against schema "
+                                                    "associated with property name"))
+               || description.startsWith(QLatin1String("Failed to validate against child schema"))
+               || description.startsWith(QLatin1String("Failed to validate against additional "
+                                                       "properties schema"));
+    };
+
     valijson::ValidationResults::Error error;
     while (results.popError(error)) {
         // Context segments arrive as "<root>", "[devices]", "[cameras]",
@@ -80,10 +96,13 @@ QStringList validateUserConfigAgainstSchema(const QJsonObject &config,
         }
         const QString where = path.isEmpty() ? QStringLiteral("(config root)")
                                              : path.join(QLatin1Char('.'));
-        warnings.append(where + QStringLiteral(": ")
-                        + QString::fromStdString(error.description));
+        const QString description = QString::fromStdString(error.description);
+        const QString message = where + QStringLiteral(": ") + description;
+        QStringList &sink = isRelay(description) ? relays : warnings;
+        if (!sink.contains(message))
+            sink.append(message);
     }
-    return warnings;
+    return warnings.isEmpty() ? relays : warnings;
 }
 
 QStringList checkUserConfig(QJsonObject &config, const QString &schemaPath)

--- a/source/configvalidator.h
+++ b/source/configvalidator.h
@@ -25,6 +25,9 @@ QStringList migrateUserConfig(QJsonObject &config);
 // Validates config against a JSON Schema (the parsed contents of
 // userConfigSchema.json). Returns one warning line per violation, formatted
 // as "<json path>: <problem>"; empty when the config conforms. Never throws.
+// Ancestor "failed to validate against ..." relay messages (one per level up to
+// the root for every leaf violation) are suppressed as long as at least one
+// concrete violation is reported, so the notes stay readable.
 QStringList validateUserConfigAgainstSchema(const QJsonObject &config,
                                             const QJsonObject &schema);
 

--- a/tests/tst_configform.cpp
+++ b/tests/tst_configform.cpp
@@ -21,6 +21,7 @@
 #include <QTemporaryDir>
 
 #include "backend.h"
+#include "configvalidator.h"
 #include "themecontroller.h"
 
 class TestConfigForm : public QObject
@@ -30,6 +31,7 @@ class TestConfigForm : public QObject
 private slots:
     void initTestCase();
     void formApiRoundTrip();
+    void newConfigValidatesClean();
     void dirtyTracking();
     void configFormQml();
     void directoryStructureArrayEdit();
@@ -125,6 +127,44 @@ void TestConfigForm::formApiRoundTrip()
     QVERIFY(backend.applyRawConfigJson("{\"researcherName\": \"raw\"}").isEmpty());
     QCOMPARE(backend.userConfigJson().value("researcherName").toString(),
              QStringLiteral("raw"));
+}
+
+// A config built by New (and then filled in with devices) must satisfy the schema
+// the app ships with. The generator derives its skeleton from the *types* in
+// userConfigProps.json, which know nothing about the schema's enums, minimums and
+// array lengths - so a bare skeleton carried configVersion 0, poseOverlay.type "",
+// commutator.sampleRate 0 with empty axis arrays, and a string led0FineSteps, and
+// the user's first edit dumped ~25 warning lines into the Config check panel.
+void TestConfigForm::newConfigValidatesClean()
+{
+    backEnd backend;
+    backend.newUserConfig();
+    QVERIFY2(backend.configCheckNotes().isEmpty(),
+             qPrintable("a brand-new config warns:\n  "
+                        + backend.configCheckNotes().replace("\n", "\n  ")));
+
+    // Every supported device type, since each one's defaults come from a
+    // different catalog entry merged into the same schema template.
+    for (const QString &category : {QStringLiteral("miniscopes"), QStringLiteral("cameras")}) {
+        const QStringList types = backend.deviceTypesForCategory(category);
+        QVERIFY2(!types.isEmpty(), qPrintable("no device types for " + category));
+        for (const QString &type : types)
+            backend.addDevice(category, type, type + QStringLiteral(" test"), 0);
+    }
+    QVERIFY2(backend.configCheckNotes().isEmpty(),
+             qPrintable("a new config with devices warns:\n  "
+                        + backend.configCheckNotes().replace("\n", "\n  ")));
+
+    // Check the generated object against the schema directly as well, so this
+    // stays a test of the defaults rather than of when the notes get refreshed.
+    QJsonObject generated =
+        QJsonDocument::fromJson(backend.rawConfigJson().toUtf8()).object();
+    const QStringList warnings = checkUserConfig(generated);
+    QVERIFY2(warnings.isEmpty(), qPrintable("generated config violates the schema:\n  "
+                                            + warnings.join("\n  ")));
+
+    // Stamped as written by this editor version (schema enum: [1]).
+    QCOMPARE(generated.value("configVersion").toInt(), 1);
 }
 
 void TestConfigForm::dirtyTracking()


### PR DESCRIPTION
Creating a user config with **New** and then filling in the first field dumped ~25 schema-check warnings into the Config check panel:

```
behaviorTracker.poseOverlay.type: Failed to match against any enum values.
behaviorTracker.poseOverlay: Failed to validate against schema associated with property name 'type'.
...
commutator.commutatorAxis: Array should contain no fewer than 3 elements.
commutator.fallbackMode: Failed to match against any enum values.
commutator.sampleRate: Expected number greater than 0.000000
configVersion: Failed to match against any enum values.
devices.miniscopes.Federico's v4.led0FineSteps: Value type not permitted by 'type' constraint.
devices.miniscopes: Failed to validate against any child schemas allowed by oneOf constraint.
...
```

## Cause

`newUserConfig()` synthesizes its skeleton from the **type** of each field in `deviceConfigs/userConfigProps.json`, and a type alone cannot satisfy the schema's enums, minimums and array lengths:

| Warning | Generated value | Schema wants |
|---|---|---|
| `configVersion` | `0` (type `Integer`) | enum `[1]` |
| `behaviorTracker.poseOverlay.type` | `""` | enum `point` / `line` / `ribbon` |
| `commutator.sampleRate` | `0` | `> 0` |
| `commutator.headstageAxis`, `commutatorAxis` | `[]` | exactly 3 numbers |
| `commutator.fallbackMode` | `""` | enum `global` / `local` |
| `led0FineSteps` (+ the `devices.miniscopes` `oneOf` cascade under it) | `""` | boolean |

The last one is a plain typo with teeth: the props file spelled the type `"Boolean"`, which `defaultForType()` did not recognize, so it fell through to the string default — and one bad device key collapses the entire `devices.miniscopes` `oneOf`, which is where most of the wall of text came from.

## Changes

- **Seed the schema-constrained keys** with their documented defaults: `configVersion` 1, `poseOverlay.type` `point`, commutator sample rate 10 Hz, axes `[0, 0, 1]`, threshold `-0.9`, fallback mode `global`.
- **Stamp `configVersion`/`$schema` at creation.** The skeleton previously generated `"$schema": ""`, which also defeated `stampConfigMetadata()`'s `if (!contains("$schema"))` on save — so saved new configs never got the editor-validation pointer either.
- **Fix the props type** to `"Bool"`, and accept both spellings in `defaultForType()` so a future hand-edit of that file can't reintroduce the same class of bug silently.
- **New / Add device now refresh the Config check panel.** They only ran the blocking checks, so the notes shown were a stale set from the previously loaded config until the next field edit. Both now go through `configEdited()`, the same tail every form edit uses.
- **Drop cascade relay lines from the panel.** valijson reports one error per failing subschema, so each real violation was followed by a `Failed to validate against schema associated with property name '…'` line for every enclosing section up to the config root — roughly 4x the lines, with the useful leaf messages buried. Relays are suppressed whenever at least one concrete violation is reported, and kept as a fallback so nothing is lost if only relays exist.

## Testing

- New test `TestConfigForm::newConfigValidatesClean()` creates a config, adds one device of **every** supported catalog type, and asserts both that `configCheckNotes()` is empty and that the generated object validates against the shipped schema directly — the second assertion pins the defaults themselves rather than when the notes happen to be refreshed.
- Confirmed the test fails on the old behavior (by temporarily restoring the bad `led0FineSteps` prop type), and that the noise filtering turns that failure's output from a wall of relays into 5 readable lines.
- Full suite: 10/10 pass on Windows (`ctest --test-dir build`).
- Ran the deployed Windows build and created a config with New for a manual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
