### PR TITLE
Fix commutator serial framing; stop it failing silently on a wrong port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,26 @@ published together from CI.
   an error message instead of writing mixed-size frames into the recording.
 
 ### Fixed
+- **Commutator now actually turns.** Commands were written to the serial port
+  without the LF terminator the controller's JSON protocol requires, and the
+  `{enable:true}` / `{led:true}` pair went out as one unterminated chunk. Per the
+  Open Ephys protocol a command is parsed only when a LF arrives, and when
+  several JSON objects arrive before one, *only the first* is processed — so on
+  an RP2040 (USB-C) controller nothing executed at all and every `{turn:…}` sat
+  unparsed, while the port itself opened cleanly. Each command is now its own
+  LF-terminated, immediately flushed line. Turn values are also written in fixed
+  notation (a small twist could previously serialize as `1e-05`, which the
+  controller is not documented to parse).
+- The commutator no longer fails silently. It queries the controller with
+  `{print:true}` on connect and logs the reply (firmware version, enable/LED
+  state, motor power), then reports its own liveness a few seconds in: whether
+  head-orientation samples are arriving and whether turn commands are going out,
+  naming the missing link when they are not. In particular, **a wrong serial
+  port is now called out** — opening any COM port succeeds, so "connected" alone
+  never proved the device on the other end was a commutator; if nothing answers
+  the status query, the log says so and lists the available ports. DTR is also
+  asserted explicitly, which some USB-CDC controllers require before they will
+  talk.
 - **New** config: the generated skeleton no longer violates the config schema.
   Its defaults came from field *types* alone, which know nothing about the
   schema's enums, minimums and array lengths, so a brand-new config carried

--- a/source/commutator.cpp
+++ b/source/commutator.cpp
@@ -3,10 +3,24 @@
 #include <QSerialPort>
 #include <QSerialPortInfo>
 #include <QJsonArray>
+#include <QTimer>
 
 #include <cmath>
 
 namespace {
+
+// Turn commands smaller than this serialize to "0.000000" in the wire format
+// below, so they are not worth a write. The device integrates turn commands, so
+// skipping them loses nothing (1e-6 turns is 0.00036 degrees - orders of
+// magnitude below both the BNO's noise floor and one motor step).
+constexpr double kMinTurnCommand = 1e-6;
+
+// How long after connecting the one-shot status report is emitted.
+constexpr int kStatusReportDelayMs = 5000;
+
+// Cap on buffered controller output, in case a controller talks without ever
+// sending a newline.
+constexpr int kMaxReadBufferBytes = 4096;
 
 // Read a [x, y, z] JSON array into a QVector3D, falling back to def if the value
 // is missing or not a 3-element array.
@@ -60,6 +74,7 @@ void Commutator::startRunning()
 
     m_running = true;
     openPort();   // if it fails, handleNewQuaternion keeps retrying
+    QTimer::singleShot(kStatusReportDelayMs, this, &Commutator::reportStatus);
 }
 
 bool Commutator::openPort()
@@ -82,6 +97,7 @@ bool Commutator::openPort()
     m_port->setStopBits(QSerialPort::OneStop);
     m_port->setFlowControl(QSerialPort::NoFlowControl);
     connect(m_port, &QSerialPort::errorOccurred, this, &Commutator::handlePortError);
+    connect(m_port, &QSerialPort::readyRead, this, &Commutator::handleReadyRead);
 
     if (!m_port->open(QIODevice::ReadWrite)) {
         // Report once. Suppressed if we already announced a disconnect (the
@@ -97,12 +113,24 @@ bool Commutator::openPort()
         return false;
     }
 
+    // USB-CDC microcontroller boards commonly gate their serial link on DTR, and
+    // some only start transmitting once the host asserts it. Qt asserts it for
+    // NoFlowControl, but do it explicitly rather than depend on that default.
+    m_port->setDataTerminalReady(true);
+
     // Fresh link: discard any stale orientation reference so the first sample
     // after (re)connecting doesn't emit a large catch-up turn.
     m_twist.reset();
     m_haveSampleClock = false;
+    m_readBuffer.clear();
     writeCommand(QStringLiteral("{enable:true}"));
     writeCommand(m_ledEnabled ? QStringLiteral("{led:true}") : QStringLiteral("{led:false}"));
+    // Ask the controller to report back (firmware version, enable/led state,
+    // motor power). The reply is the only host-visible proof that our commands
+    // are being parsed at all, and it lands in the session log - a silent
+    // controller means the commands are not getting through, an "enable: false"
+    // in the reply means they are but the motor is not armed.
+    writeCommand(QStringLiteral("{print:true}"));
 
     const bool wasOutage = m_reportedDisconnect || m_reportedOpenError;
     emit sendMessage(QString(wasOutage ? "Commutator reconnected on " : "Commutator connected on ")
@@ -110,6 +138,30 @@ bool Commutator::openPort()
     m_reportedOpenError = false;
     m_reportedDisconnect = false;
     return true;
+}
+
+// Surface whatever the controller says (it replies to {print:true}, and firmware
+// may report errors unprompted) as log lines, so the device's own view of its
+// state is visible instead of being guessed at from the host side.
+void Commutator::handleReadyRead()
+{
+    if (!m_port)
+        return;
+    m_readBuffer.append(m_port->readAll());
+    // A controller that talks without ever sending a newline must not grow this
+    // without bound.
+    if (m_readBuffer.size() > kMaxReadBufferBytes)
+        m_readBuffer = m_readBuffer.right(kMaxReadBufferBytes);
+
+    int newline;
+    while ((newline = m_readBuffer.indexOf('\n')) >= 0) {
+        const QByteArray line = m_readBuffer.left(newline).trimmed();
+        m_readBuffer.remove(0, newline + 1);
+        if (!line.isEmpty()) {
+            m_repliesReceived++;
+            emit sendMessage("Commutator reports: " + QString::fromUtf8(line));
+        }
+    }
 }
 
 void Commutator::handlePortError(QSerialPort::SerialPortError error)
@@ -130,10 +182,8 @@ void Commutator::handlePortError(QSerialPort::SerialPortError error)
 
 void Commutator::stopRunning()
 {
-    if (portOk()) {
-        writeCommand(QStringLiteral("{enable:false}"));
-        m_port->flush();
-    }
+    if (portOk())
+        writeCommand(QStringLiteral("{enable:false}"));   // writeCommand flushes
     if (m_port) {
         m_port->close();
         m_port->deleteLater();
@@ -151,6 +201,7 @@ void Commutator::handleNewQuaternion(double w, double x, double y, double z)
 {
     if (!m_running)
         return;
+    m_samplesReceived++;
 
     // Port down (never opened, or unplugged): retry opening it at ~1 Hz instead
     // of sending. The scope's orientation stream keeps calling us while running,
@@ -174,14 +225,75 @@ void Commutator::handleNewQuaternion(double w, double x, double y, double z)
 
     const double turns = m_twist.update(QQuaternion(float(w), float(x), float(y), float(z)));
 
-    // Bonsai skips 0/NaN/inf turns; a still animal produces ~0 and needs no
-    // command. QString::number is locale-independent (no stray decimal commas).
-    if (std::isfinite(turns) && turns != 0.0)
-        writeCommand(QStringLiteral("{turn:%1}").arg(QString::number(turns, 'g', 10)));
+    const QString command = turnCommand(turns);
+    if (command.isEmpty())
+        return;   // still animal / no usable twist: nothing to send
+    writeCommand(command);
+    m_lastTurnCommand = command;
+    m_turnCommandsSent++;
 }
 
+// One LF-terminated line per command.
+//
+// The controller only parses a command when it sees the LF, and if several JSON
+// objects arrive before one, ONLY THE FIRST IS PROCESSED - see the protocol docs
+// (open-ephys.github.io/commutator-docs -> User Guide -> Remote Control). Writing
+// bare "{enable:true}{led:true}{turn:...}" therefore executed at most the first
+// command on an RP2040 (USB-C) controller and never turned the motor, even though
+// the port opened cleanly. Teensy (Micro-USB) controllers don't need the LF but
+// accept it, so the terminator is right for every version.
+QByteArray Commutator::wireFrame(const QString &command)
+{
+    return command.toUtf8() + '\n';
+}
+
+QString Commutator::turnCommand(double turns)
+{
+    // Bonsai skips 0/NaN/inf turns; a still animal produces ~0 and needs no
+    // command. QString::number is locale-independent (no stray decimal commas),
+    // and 'f' rather than 'g' so a tiny value can never go out in exponent form
+    // ("1e-05"), which the controller's JSON parser is not documented to accept.
+    if (!std::isfinite(turns) || std::abs(turns) < kMinTurnCommand)
+        return QString();
+    return QStringLiteral("{turn:%1}").arg(QString::number(turns, 'f', 6));
+}
+
+// Flushed per command: this is a real-time control signal, not bulk data, so it
+// must not sit in the buffer waiting for the next write.
 void Commutator::writeCommand(const QString &command)
 {
-    if (portOk())
-        m_port->write(command.toUtf8());
+    if (!portOk())
+        return;
+    m_port->write(wireFrame(command));
+    m_port->flush();
+}
+
+// Emitted once, a few seconds after connecting. This feature could fail while
+// looking healthy - the port opens, the LED obeys, and nothing ever turns - so
+// it now says out loud whether orientation samples and turn commands are
+// actually flowing, and which link is missing when they are not.
+void Commutator::reportStatus()
+{
+    if (!m_running)
+        return;
+
+    // Opening the WRONG port succeeds - any serial device accepts an open - so
+    // "connected" alone proves nothing. Nothing answering the {print:true} sent
+    // at connect is the one host-side hint that the port belongs to something
+    // else entirely, which is easy to do when several COM ports are present.
+    if (portOk() && m_repliesReceived == 0)
+        emit sendMessage("Warning: nothing on " + m_portName + " answered the commutator's status "
+                         "query. If the tether does not turn, make sure this is the commutator's "
+                         "port and not another device's. Ports available: " + availablePortList());
+
+    if (m_samplesReceived == 0)
+        emit sendMessage("Warning: Commutator has received no head-orientation samples. It needs a "
+                         "Miniscope with headOrientation enabled and streaming to drive it.");
+    else if (m_turnCommandsSent == 0)
+        emit sendMessage("Warning: Commutator received " + QString::number(m_samplesReceived)
+                         + " head-orientation samples but computed no rotation from them. Check "
+                           "\"headstageAxis\" / \"commutatorAxis\" in the config's commutator section.");
+    else
+        emit sendMessage("Commutator is driving the motor: " + QString::number(m_turnCommandsSent)
+                         + " turn commands sent so far (last " + m_lastTurnCommand + ").");
 }

--- a/source/commutator.h
+++ b/source/commutator.h
@@ -19,6 +19,10 @@
 //   {enable:<bool>}   motor driver on/off
 //   {led:<bool>}      indicator LED on/off
 //
+// Each command is one LF-terminated line (see writeCommand): the controller
+// parses a command only on the LF, and several JSON objects arriving before one
+// leave all but the first unprocessed.
+//
 // Lives on its own QThread (like DataSaver); quaternions arrive from the source
 // Miniscope's display-frame handler via a queued connection, so no serial I/O
 // ever runs on the GUI/render thread. Configured from the user config's optional
@@ -33,6 +37,16 @@ public:
     // Empty means "the first Miniscope with head orientation streaming enabled",
     // resolved by the backend.
     QString sourceDeviceName() const { return m_sourceDeviceName; }
+
+    // --- Wire format (static + pure, so it is unit-testable without a port) ---
+
+    // The bytes for one command: exactly one LF-terminated line.
+    static QByteArray wireFrame(const QString &command);
+    // The {turn:x} command for a computed twist, or an empty string when there
+    // is nothing worth sending (0, sub-resolution, NaN/inf). Always fixed
+    // notation - never exponent form, which the controller is not documented to
+    // parse.
+    static QString turnCommand(double turns);
 
 public slots:
     // Thread entry point (connect to QThread::started): opens the serial port and
@@ -51,6 +65,14 @@ public slots:
     // Drops the port when the OS reports the device vanished (unplug), so the
     // reconnect path in handleNewQuaternion takes over.
     void handlePortError(QSerialPort::SerialPortError error);
+
+    // One-shot report (armed by startRunning) naming which link of the chain is
+    // live: orientation samples in, turn commands out.
+    void reportStatus();
+
+    // Logs each complete line the controller sends back (its {print:true} reply,
+    // and any unprompted firmware output).
+    void handleReadyRead();
 
 signals:
     void sendMessage(QString msg);
@@ -79,6 +101,15 @@ private:
     QElapsedTimer m_reconnectClock;
     bool m_reportedOpenError = false;
     bool m_reportedDisconnect = false;
+
+    // Liveness counters behind reportStatus().
+    qint64 m_samplesReceived = 0;
+    qint64 m_turnCommandsSent = 0;
+    qint64 m_repliesReceived = 0;   // lines the controller sent back
+    QString m_lastTurnCommand;
+
+    // Partial line assembly for the controller's replies (see handleReadyRead).
+    QByteArray m_readBuffer;
 };
 
 #endif // COMMUTATOR_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -79,6 +79,18 @@ target_include_directories(tst_twistcalculator PRIVATE ${CMAKE_SOURCE_DIR}/sourc
 target_link_libraries(tst_twistcalculator PRIVATE Qt6::Gui Qt6::Test)
 add_test(NAME twistcalculator COMMAND tst_twistcalculator)
 
+# --- Commutator wire format (LF framing + turn serialization) -------------------
+# The host cannot see whether the controller accepted a command, so the protocol
+# rules (one LF-terminated command per line; fixed, locale-independent notation)
+# are pinned here instead of at the rig.
+qt_add_executable(tst_commutatorprotocol tst_commutatorprotocol.cpp
+    ${CMAKE_SOURCE_DIR}/source/commutator.cpp
+    ${CMAKE_SOURCE_DIR}/source/twistcalculator.cpp)
+target_include_directories(tst_commutatorprotocol PRIVATE ${CMAKE_SOURCE_DIR}/source)
+target_link_libraries(tst_commutatorprotocol PRIVATE
+    Qt6::Gui Qt6::SerialPort Qt6::Test)
+add_test(NAME commutatorprotocol COMMAND tst_commutatorprotocol)
+
 # --- Session lifecycle (Run -> endSession -> Run, one process) -----------------
 # Links the full app core (miniscope_app) and drives the real backend with a
 # file-playback video stream: capture thread, device window, control panel, and

--- a/tests/tst_commutatorprotocol.cpp
+++ b/tests/tst_commutatorprotocol.cpp
@@ -1,0 +1,90 @@
+#include <QtTest>
+
+#include "commutator.h"
+
+#include <cmath>
+#include <limits>
+
+// Wire format of the commutator's JSON command protocol
+// (open-ephys.github.io/commutator-docs -> User Guide -> Remote Control).
+//
+// This is the layer that failed silently in the field: the port opened, the
+// status LED obeyed, and the motor never turned, because the commands went out
+// unterminated. The controller parses a command only when it sees a LF, and if
+// several JSON objects arrive before one, ONLY THE FIRST is processed - so
+// writing "{enable:true}{led:true}{turn:0.1}" as one unterminated stream is a
+// no-op on RP2040 (USB-C) controllers. Nothing about that is visible from the
+// host side, hence these tests.
+class TestCommutatorProtocol : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void everyCommandIsOneTerminatedLine();
+    void commandsConcatenateIntoSeparateLines();
+    void turnCommandUsesFixedNotation();
+    void negligibleAndNonFiniteTurnsAreSkipped();
+    void turnCommandKeepsSignAndMagnitude();
+    void turnCommandIsLocaleIndependent();
+};
+
+void TestCommutatorProtocol::everyCommandIsOneTerminatedLine()
+{
+    const QByteArray frame = Commutator::wireFrame(QStringLiteral("{enable:true}"));
+    QCOMPARE(frame, QByteArray("{enable:true}\n"));
+    QVERIFY2(frame.endsWith('\n'), "commands must be LF-terminated or the controller never parses them");
+    QCOMPARE(frame.count('\n'), 1);   // exactly one command per line
+}
+
+void TestCommutatorProtocol::commandsConcatenateIntoSeparateLines()
+{
+    // The init pair is written back-to-back and may be flushed as one chunk;
+    // with the terminators the controller still sees two complete commands.
+    const QByteArray stream = Commutator::wireFrame(QStringLiteral("{enable:true}"))
+                              + Commutator::wireFrame(QStringLiteral("{led:true}"));
+    const QList<QByteArray> lines = stream.split('\n');
+    QCOMPARE(lines.size(), 3);   // two commands + trailing empty
+    QCOMPARE(lines[0], QByteArray("{enable:true}"));
+    QCOMPARE(lines[1], QByteArray("{led:true}"));
+    QVERIFY(lines[2].isEmpty());
+}
+
+void TestCommutatorProtocol::turnCommandUsesFixedNotation()
+{
+    // 'g' formatting would emit "1e-05" here, which the controller's JSON parser
+    // is not documented to accept.
+    const QString small = Commutator::turnCommand(0.00001);
+    QVERIFY2(!small.contains(QLatin1Char('e'), Qt::CaseInsensitive),
+             qPrintable("exponent notation reached the wire: " + small));
+    QCOMPARE(small, QStringLiteral("{turn:0.000010}"));
+}
+
+void TestCommutatorProtocol::negligibleAndNonFiniteTurnsAreSkipped()
+{
+    // A still animal produces ~0: no command at all, rather than "{turn:0.000000}".
+    QVERIFY(Commutator::turnCommand(0.0).isEmpty());
+    QVERIFY(Commutator::turnCommand(1e-9).isEmpty());
+    QVERIFY(Commutator::turnCommand(-1e-9).isEmpty());
+    QVERIFY(Commutator::turnCommand(std::numeric_limits<double>::quiet_NaN()).isEmpty());
+    QVERIFY(Commutator::turnCommand(std::numeric_limits<double>::infinity()).isEmpty());
+    QVERIFY(Commutator::turnCommand(-std::numeric_limits<double>::infinity()).isEmpty());
+}
+
+void TestCommutatorProtocol::turnCommandKeepsSignAndMagnitude()
+{
+    // The sign is the direction of rotation, so it must survive verbatim.
+    QCOMPARE(Commutator::turnCommand(1.1), QStringLiteral("{turn:1.100000}"));
+    QCOMPARE(Commutator::turnCommand(-0.5), QStringLiteral("{turn:-0.500000}"));
+}
+
+void TestCommutatorProtocol::turnCommandIsLocaleIndependent()
+{
+    // A German/French locale would render 0.25 as "0,25" through QString::arg,
+    // which is not valid JSON - QString::number(double, char, int) must be used.
+    QLocale::setDefault(QLocale(QLocale::German, QLocale::Germany));
+    QCOMPARE(Commutator::turnCommand(0.25), QStringLiteral("{turn:0.250000}"));
+    QLocale::setDefault(QLocale(QLocale::C));
+}
+
+QTEST_MAIN(TestCommutatorProtocol)
+#include "tst_commutatorprotocol.moc"

--- a/tests/tst_commutatorprotocol.cpp
+++ b/tests/tst_commutatorprotocol.cpp
@@ -86,5 +86,9 @@ void TestCommutatorProtocol::turnCommandIsLocaleIndependent()
     QLocale::setDefault(QLocale(QLocale::C));
 }
 
-QTEST_MAIN(TestCommutatorProtocol)
+// Guiless, like tst_twistcalculator: this is pure string/number logic, but the
+// target links Qt6::Gui (commutator.cpp pulls in QQuaternion), so a plain
+// QTEST_MAIN would construct a QGuiApplication and abort on headless CI with
+// "no Qt platform plugin could be initialized".
+QTEST_GUILESS_MAIN(TestCommutatorProtocol)
 #include "tst_commutatorprotocol.moc"


### PR DESCRIPTION
Chasing a commutator that connected but never turned surfaced two separate problems: one real protocol violation, and a diagnostic gap that made the actual cause invisible from the app.

## Protocol: commands were never terminated

From the [remote control docs](https://open-ephys.github.io/commutator-docs/):

> All JSON commands must be appended by a LF character. **If multiple valid JSONs are received before receiving a LF character, only the first one will be processed** when a LF character is finally received.
> *(Teensy controllers — Micro-USB — do not need the LF, but can operate with it.)*

`writeCommand()` sent no LF at all, and `openPort()` pushed `{enable:true}` and `{led:true}` into the same buffer, so the controller saw one unterminated stream:

```
{enable:true}{led:true}{turn:0.1}{turn:0.2}…
```

On an RP2040 (USB-C) controller that parses to nothing; at most the first object would ever run. Now every command is its own LF-terminated line, flushed on write — a turn command is a real-time control signal, not bulk data, so it must not wait in the buffer for the next one.

Turn values also switched from `'g'` to `'f'` formatting: a small twist could serialize as `1e-05`, and the controller is not documented to parse exponent notation. Values below the wire format's resolution (1e-6 turns ≈ 0.00036°, far under one motor step) are skipped rather than sent as `0.000000` — the device integrates turn commands, so nothing is lost.

## Diagnostics: a wrong port looked identical to a working one

**This turned out to be the real cause on the bench rig** — the configured port belonged to another device. Opening the wrong serial port *succeeds* (any serial device accepts an open), so `Commutator connected on COM5` proved nothing about what was on the other end, and the feature then sat there doing nothing with no way to tell why.

The worker now sends `{print:true}` on connect and logs the controller's reply (firmware version, enable/LED state, `power_good`), then five seconds in reports which link of the chain is actually live:

| Condition | Log line |
|---|---|
| Nothing answered the status query | warns the port may belong to another device, **and lists the available ports** |
| No head-orientation samples | names the Miniscope + `headOrientation` requirement |
| Samples but no computed rotation | points at `headstageAxis` / `commutatorAxis` |
| Otherwise | confirms turn commands are flowing, with the last one sent |

DTR is also asserted explicitly on open; some USB-CDC controllers will not transmit until the host does.

## Testing

- New `tst_commutatorprotocol` pins the parts of the wire format the host can never verify at runtime: one LF-terminated command per line, fixed (never exponent) notation, sign and magnitude preserved, and locale independence — a German/French locale would otherwise render `0.25` as `0,25` and emit invalid JSON.
- Full suite: 11/11 pass on Windows (`ctest --test-dir build`).
- Verified against real hardware: a commutator + Miniscope on the bench, driven from live BNO head orientation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
