### PR TITLE
Stop removed devices from returning on the next Run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,13 @@ published together from CI.
   an error message instead of writing mixed-size frames into the recording.
 
 ### Fixed
+- **A device removed from the config no longer comes back on the next Run.**
+  The parsed device sections were filled key-by-key into backend members that
+  were never emptied, so entries from an earlier parse survived: deleting a
+  webcam and running again rebuilt it (it reappeared in the Acquire grid),
+  renaming a device ran both names, and opening a different config inherited the
+  previous config's devices. The same stale entries also fed the pre-Run checks,
+  so Run could be blocked by the codec of a device no longer in the config.
 - **Commutator now actually turns.** Commands were written to the serial port
   without the LF terminator the controller's JSON protocol requires, and the
   `{enable:true}` / `{led:true}` pair went out as one unterminated chunk. Per the

--- a/source/backend.cpp
+++ b/source/backend.cpp
@@ -1406,6 +1406,17 @@ void backEnd::parseUserConfig()
     QStringList s;
     int count = 0;
 
+    // Start both device maps empty. Every other uc* member below is ASSIGNED the
+    // matching config section, but these two are filled key-by-key, so anything
+    // left from a previous parse survived: a device deleted from the config was
+    // rebuilt on the next Run (the removed webcam reappeared in the Acquire
+    // grid), a renamed one existed twice, and opening a different config
+    // inherited the previous config's devices. Session teardown could not help -
+    // it clears the constructed device objects, and these are what they are
+    // constructed FROM.
+    ucMiniscopes = QJsonObject();
+    ucBehaviorCams = QJsonObject();
+
     // Main JSON header
     dataDirectory= m_userConfig.value("dataDirectory").toString();
 

--- a/tests/tst_sessionlifecycle.cpp
+++ b/tests/tst_sessionlifecycle.cpp
@@ -37,6 +37,7 @@ class TestSessionLifecycle : public QObject
 private slots:
     void initTestCase();
     void runEndRunCycle();
+    void configEditsBetweenRunsAreHonored();
 
 private:
     // Let deferred deletions (endSession tears windows down via deleteLater)
@@ -48,9 +49,45 @@ private:
         QCoreApplication::processEvents();
     }
 
+    // Writes a config whose only devices are file-playback cameras with the
+    // given names, all streaming the AVI generated in initTestCase. Returns its
+    // path, or an empty string if it could not be written.
+    QString writeConfig(const QString &fileName, const QStringList &cameraNames);
+
     QTemporaryDir m_tempDir;
     QString m_configPath;
 };
+
+QString TestSessionLifecycle::writeConfig(const QString &fileName,
+                                          const QStringList &cameraNames)
+{
+    const QJsonObject playback{{"folderPath", m_tempDir.path()},
+                               {"filePrefix", "lifecycle_"},
+                               {"frameRate", 20}};
+    QJsonObject cameras;
+    for (const QString &name : cameraNames)
+        cameras[name] = QJsonObject{{"deviceType", "WebCam"},
+                                    {"videoPlayback", playback},
+                                    {"compression", "MJPG"},
+                                    {"framesPerFile", 1000},
+                                    {"windowScale", 0.5},
+                                    {"windowX", 50},
+                                    {"windowY", 50}};
+    const QJsonObject config{
+        {"dataDirectory", m_tempDir.path()},
+        {"researcherName", "lifecycleTest"},
+        {"directoryStructure", QJsonArray{"researcherName", "date", "time"}},
+        {"devices", QJsonObject{{"cameras", cameras}}},
+    };
+
+    const QString path = m_tempDir.filePath(fileName);
+    QFile f(path);
+    if (!f.open(QIODevice::WriteOnly))
+        return QString();
+    f.write(QJsonDocument(config).toJson());
+    f.close();
+    return path;
+}
 
 void TestSessionLifecycle::initTestCase()
 {
@@ -78,28 +115,8 @@ void TestSessionLifecycle::initTestCase()
 
     // A minimal, valid config: one behavior camera streaming the generated
     // file. No live camera, no tracker, no trace display, no commutator.
-    QJsonObject playback{{"folderPath", m_tempDir.path()},
-                         {"filePrefix", "lifecycle_"},
-                         {"frameRate", 20}};
-    QJsonObject camera{{"deviceType", "WebCam"},
-                       {"videoPlayback", playback},
-                       {"compression", "MJPG"},
-                       {"framesPerFile", 1000},
-                       {"windowScale", 0.5},
-                       {"windowX", 50},
-                       {"windowY", 50}};
-    QJsonObject config{
-        {"dataDirectory", m_tempDir.path()},
-        {"researcherName", "lifecycleTest"},
-        {"directoryStructure", QJsonArray{"researcherName", "date", "time"}},
-        {"devices", QJsonObject{{"cameras", QJsonObject{{"PlaybackCam", camera}}}}},
-    };
-
-    m_configPath = m_tempDir.filePath("lifecycle_config.json");
-    QFile f(m_configPath);
-    QVERIFY(f.open(QIODevice::WriteOnly));
-    f.write(QJsonDocument(config).toJson());
-    f.close();
+    m_configPath = writeConfig("lifecycle_config.json", {"PlaybackCam"});
+    QVERIFY(!m_configPath.isEmpty());
 }
 
 void TestSessionLifecycle::runEndRunCycle()
@@ -183,6 +200,60 @@ void TestSessionLifecycle::runEndRunCycle()
 
     // The quit path (endSession + closeAll) must be safe after all the above.
     backend.exitClicked();
+    drainEvents();
+}
+
+// What the config says at Run time is what the session must contain - after an
+// edit between sessions, and after switching config files.
+//
+// The parsed device sections (ucMiniscopes / ucBehaviorCams) are backend members
+// filled key-by-key rather than assigned, so entries from a previous parse used
+// to survive: a device deleted from the config was rebuilt on the next Run (the
+// removed webcam reappeared in the Acquire grid), and a different config
+// inherited the previous one's devices. Session teardown cannot catch this - it
+// clears the constructed device objects, and these maps are what they are built
+// FROM.
+void TestSessionLifecycle::configEditsBetweenRunsAreHonored()
+{
+    backEnd backend;
+    if (!backend.availableCodecs().contains("MJPG"))
+        QSKIP("MJPG codec unavailable on this host");
+
+    const QString twoCams = writeConfig("two_cams.json", {"KeptCam", "RemovedCam"});
+    QVERIFY(!twoCams.isEmpty());
+    backend.setUserConfigFileName(QUrl::fromLocalFile(twoCams).toString());
+    QVERIFY2(backend.userConfigOK(), "two-camera config failed the backend's checks");
+
+    backend.onRunClicked();
+    QCOMPARE(backend.sessionCameraCount(), 2);
+    QCOMPARE(backend.sessionPanes().size(), 2);
+    backend.endSession();
+    drainEvents();
+
+    // Delete one device, exactly as the form editor's remove button does.
+    backend.removeDevice("cameras", "RemovedCam");
+    QVERIFY(backend.userConfigOK());
+
+    backend.onRunClicked();
+    QCOMPARE(backend.sessionCameraCount(), 1);
+    const QVariantList panes = backend.sessionPanes();
+    QCOMPARE(panes.size(), 1);
+    QCOMPARE(panes[0].toMap().value("name").toString(), QStringLiteral("KeptCam"));
+    backend.endSession();
+    drainEvents();
+
+    // Switching to a different config file: only ITS devices may run.
+    const QString otherCam = writeConfig("other_cam.json", {"OtherCam"});
+    QVERIFY(!otherCam.isEmpty());
+    backend.setUserConfigFileName(QUrl::fromLocalFile(otherCam).toString());
+    QVERIFY(backend.userConfigOK());
+
+    backend.onRunClicked();
+    QCOMPARE(backend.sessionCameraCount(), 1);
+    const QVariantList otherPanes = backend.sessionPanes();
+    QCOMPARE(otherPanes.size(), 1);
+    QCOMPARE(otherPanes[0].toMap().value("name").toString(), QStringLiteral("OtherCam"));
+    backend.endSession();
     drainEvents();
 }
 


### PR DESCRIPTION
Run a config → End Session → delete a device → Run again, and the deleted device came back: a removed webcam reappeared in the Acquire grid, streaming and recording as though it were still configured.

## Cause

`parseUserConfig()` **assigns** every parsed config section to its backend member:

```cpp
ucBehaviorTracker = m_userConfig.value("behaviorTracker").toObject();
ucTraceDisplay    = m_userConfig.value("traceDisplay").toObject();
ucCommutator      = m_userConfig.value("commutator").toObject();
```

…except the two device sections, which are filled key-by-key:

```cpp
ucBehaviorCams[s[i]] = tempObj;   // insert only — never cleared
```

Those members live for the whole process, so entries from an earlier parse survived, and `constructUserConfigGUI()` builds devices by iterating their keys. Session teardown couldn't catch it — teardown clears the *constructed* device objects, and these maps are what those objects are constructed **from**.

## Three symptoms, one cause

| Action | Before |
|---|---|
| Delete a device, Run again | Deleted device is rebuilt — window, capture thread, and recording |
| Rename a device | Runs twice, under both the old and the new name |
| Open a *different* config | Inherits the previous config's devices |

The stale entries also fed `checkForUniqueDeviceNames()` and `checkForCompression()`, so Run could be blocked over the codec of a device that was no longer in the config.

## Fix

Empty both maps at the top of the parse, so each parse rebuilds them from the config alone.

## Testing

- `tst_sessionlifecycle::configEditsBetweenRunsAreHonored()` drives the reported sequence with file-playback cameras — Run two cameras, `endSession`, `removeDevice`, Run — and asserts both the device count and the *pane* descriptors (the grid is built from those). It also covers the config-switch variant.
- **Verified the test reproduces the bug**: with the fix shelved and rebuilt, it fails with `Actual (backend.sessionCameraCount()): 2` vs `Expected: 1` — the removed camera back in the session.
- The config writer `initTestCase` used is now a small helper shared by both cases.
- Full suite: 11/11 pass on Windows.
- Confirmed on the bench with a real webcam + Miniscope config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
