### PR TITLE
Stop producing frames before there is a consumer, and fix four UI papercuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,6 +237,44 @@ published together from CI.
   an error message instead of writing mixed-size frames into the recording.
 
 ### Fixed
+- **Run no longer fills the message log with "frame buffer is full" before the
+  session even opens.** A device began streaming the moment its camera opened,
+  but the DataSaver thread that empties its ring buffer cannot be created until
+  *every* device has been — and opening a camera takes seconds. The first device
+  therefore filled all 128 of its buffer slots while the others were still
+  opening, and reported a lost frame for each one that followed. Capture loops
+  now start held and are released together once the DataSaver is running, so
+  every device's first frame is the start of the session. A genuinely full buffer
+  mid-session is also reported once per episode instead of once per dropped
+  frame, matching how the mid-stream frame-size warning already behaved.
+- **A feature card's enable switch sits with its heading.** The switch for the
+  commutator, trace display and behavior tracker was pinned to the card's right
+  edge with the heading at the far left, so it read as unrelated furniture — the
+  classic result being a commutator with its serial port filled in and the
+  feature never switched on. The switch is now immediately after the title, says
+  its state in words (*Enabled* / *Disabled*, itself clickable), and a card that
+  is open but disabled says so in its body with an Enable button. The fields stay
+  editable while it is off, since the port has to be entered before enabling
+  makes sense.
+- **Narrow switch labels elide instead of being cut mid-word.**
+- **The video window's control panels no longer swallow a small pane.** The
+  display rail was a fixed 250 px and the full height of the window, and the
+  hardware dock expanded to 240 — on a pane 450–630 px wide (three devices on a
+  normal monitor) either one covered 40–56% of the live video, and both together
+  covered essentially all of it. Since most of what they hold (EWL focus, LED,
+  gain, contrast) is adjusted *while watching* that video, both are now sized as a
+  fraction of the pane, the rail is only as tall as its controls instead of
+  full-height, and the dock collapses while the rail is out so the two can never
+  overlap the video at the same time. The rail's labels are shorter to match
+  (*Saturation*, *Colormap*, *ΔF/F*, *Recording ROI…*), with the full wording and
+  the meaning of the icon-only contrast/brightness sliders moved into tooltips.
+- **The message card's colored outline expires instead of staying lit.** It was
+  driven by the session's cumulative error/warning counts, so a single benign
+  warning early in a session — a commutator reporting no rotation from its first
+  samples, with the commutator working fine — left the card ringed amber for the
+  rest of the run, reading as an unresolved fault. The ring now marks the newest
+  message and fades out (15 s for a warning, 60 s for an error); the counts in
+  the header still stay for the whole session, so nothing is forgotten.
 - **The head-orientation logo stays in its corner.** The BNO widget's rotation
   matrix was applied to the widget itself, and a matrix transform rotates about
   the target's top-left corner — so the logo orbited that corner instead of

--- a/source/ConfigForm.qml
+++ b/source/ConfigForm.qml
@@ -865,6 +865,7 @@ Item {
 
                     // --- Commutator ---
                     FormCard {
+                        objectName: "commutatorCard"
                         title: qsTr("Commutator")
                         subtitle: qsTr("Drives an Open Ephys commutator from the Miniscope's head orientation so the tether unwinds itself.")
                         expanded: false

--- a/source/FormCard.qml
+++ b/source/FormCard.qml
@@ -20,7 +20,10 @@ Rectangle {
     signal switchToggled(bool checked)
 
     default property alias body: bodyColumn.data
-    readonly property bool hasBody: bodyColumn.children.length > 0
+    // > 1, not > 0: bodyColumn's first child is the disabled-state hint FormCard
+    // declares itself (see below), so a card whose user declared no rows still
+    // has one child and must not grow a caret over an empty body.
+    readonly property bool hasBody: bodyColumn.children.length > 1
 
     Layout.fillWidth: true
     implicitHeight: headerRow.implicitHeight + 2 * Theme.padding
@@ -33,47 +36,73 @@ Rectangle {
 
     Behavior on implicitHeight { NumberAnimation { duration: Theme.animMs } }
 
-    RowLayout {
+    // The enable switch sits immediately after the title, not out at the right
+    // edge: with the heading on the left and the switch a card-width away, it
+    // read as unrelated furniture and got missed - the classic result being a
+    // commutator with its serial port filled in and the feature still off. The
+    // subtitle moves to its own row underneath so nothing pushes the switch away
+    // from the title it belongs to.
+    ColumnLayout {
         id: headerRow
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.margins: Theme.padding
-        spacing: Theme.spacing
+        spacing: 2
 
-        // Expand / collapse caret (hidden when the card has no body)
-        Text {
-            visible: card.hasBody
-            text: "▸"
-            font: Theme.fontBody
-            color: Theme.textSecondary
-            rotation: card.expanded ? 90 : 0
-            Behavior on rotation { NumberAnimation { duration: Theme.animMs } }
-        }
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Theme.spacing
 
-        ColumnLayout {
-            spacing: 2
+            // Expand / collapse caret (hidden when the card has no body)
             Text {
+                visible: card.hasBody
+                text: "▸"
+                font: Theme.fontBody
+                color: Theme.textSecondary
+                rotation: card.expanded ? 90 : 0
+                Behavior on rotation { NumberAnimation { duration: Theme.animMs } }
+            }
+
+            Text {
+                objectName: "cardTitle"
                 text: card.title
                 font: Theme.fontTitle
                 color: Theme.textPrimary
             }
-            Text {
-                visible: card.subtitle.length > 0
-                text: card.subtitle
-                font: Theme.fontSmall
-                color: Theme.textSecondary
-                wrapMode: Text.WordWrap
-                Layout.fillWidth: true
+
+            UiSwitch {
+                objectName: "enableSwitch"
+                visible: card.showSwitch
+                syncChecked: card.switchChecked
+                onToggled: card.switchToggled(checked)
             }
+            // The state in words, and a second (larger) hit target for the
+            // switch - reading a small pill's position is the hard part.
+            Text {
+                objectName: "enableStateText"
+                visible: card.showSwitch
+                text: card.switchChecked === true ? qsTr("Enabled") : qsTr("Disabled")
+                font: Theme.fontSmall
+                color: card.switchChecked === true ? Theme.accent : Theme.textSecondary
+                MouseArea {
+                    anchors.fill: parent
+                    anchors.margins: -4
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: card.switchToggled(card.switchChecked !== true)
+                }
+            }
+
+            Item { Layout.fillWidth: true }
         }
 
-        Item { Layout.fillWidth: true }
-
-        UiSwitch {
-            visible: card.showSwitch
-            syncChecked: card.switchChecked
-            onToggled: card.switchToggled(checked)
+        Text {
+            visible: card.subtitle.length > 0
+            text: card.subtitle
+            font: Theme.fontSmall
+            color: Theme.textSecondary
+            wrapMode: Text.WordWrap
+            Layout.fillWidth: true
         }
     }
 
@@ -99,5 +128,37 @@ Rectangle {
         anchors.right: parent.right
         anchors.margins: Theme.padding
         spacing: Theme.spacing
+
+        // Declared here so it is the FIRST row of the body: the card's own
+        // children are appended after it via the `body` alias. Someone with this
+        // card open is configuring the feature, which is exactly when a
+        // still-disabled switch is worth saying out loud - the fields stay
+        // editable, since the port has to be typed in before enabling makes
+        // sense.
+        Rectangle {
+            objectName: "disabledHint"
+            visible: card.showSwitch && card.switchChecked !== true
+            Layout.fillWidth: true
+            implicitHeight: offHint.implicitHeight + Theme.spacing
+            radius: Theme.radiusSmall
+            color: Theme.surfaceAlt
+            RowLayout {
+                id: offHint
+                anchors.fill: parent
+                anchors.margins: Theme.spacing / 2
+                spacing: Theme.spacing
+                Text {
+                    Layout.fillWidth: true
+                    text: qsTr("Disabled — nothing here takes effect until you turn it on.")
+                    font: Theme.fontSmall
+                    color: Theme.textSecondary
+                    wrapMode: Text.WordWrap
+                }
+                UiButton {
+                    text: qsTr("Enable")
+                    onClicked: card.switchToggled(true)
+                }
+            }
+        }
     }
 }

--- a/source/SessionBar.qml
+++ b/source/SessionBar.qml
@@ -10,6 +10,7 @@ import Miniscope.Theme 1.0
 // controller) plus a 1 Hz poll of backend.sessionTelemetry().
 ColumnLayout {
     id: bar
+    objectName: "sessionBar"
 
     property bool layoutLocked: false
     signal lockToggled(bool locked)
@@ -289,19 +290,67 @@ ColumnLayout {
     readonly property int errorCount: messages.filter(function (m) { return severityOf(m) === 2 }).length
     readonly property int warningCount: messages.filter(function (m) { return severityOf(m) === 1 }).length
 
+    // The colored outline is an ALERT, not a state: it says "something just
+    // happened", and it expires. A border driven straight off the cumulative
+    // counts meant one benign warning at startup - a commutator reporting no
+    // rotation from its first samples, say - left the card ringed for the rest
+    // of the session, which reads as an unresolved fault. The counts in the
+    // header stay for the whole session, so nothing is forgotten; only the
+    // attention-grab is temporary. Errors hold the ring longer than warnings.
+    readonly property int warningAlertMs: 15000
+    readonly property int errorAlertMs: 60000
+    property int alertSeverity: 0
+    property int seenMessageCount: 0
+
+    function raiseAlert(severity) {
+        // A warning arriving mid-error-alert must not quietly downgrade the ring
+        // (or extend it - the error is what still matters).
+        if (severity < alertSeverity && alertTimer.running)
+            return
+        alertSeverity = severity
+        alertTimer.interval = severity === 2 ? errorAlertMs : warningAlertMs
+        alertTimer.restart()
+    }
+    // What alertTimer does when it fires; named so it can be driven directly.
+    function expireAlert() {
+        alertTimer.stop()
+        alertSeverity = 0
+    }
+
+    onMessagesChanged: {
+        // A new session installs a new controller, so the log restarts: drop the
+        // previous session's alert rather than carry its ring over.
+        if (messages.length < seenMessageCount) {
+            seenMessageCount = messages.length
+            expireAlert()
+            return
+        }
+        var worst = 0
+        for (var i = seenMessageCount; i < messages.length; i++)
+            worst = Math.max(worst, severityOf(messages[i]))
+        seenMessageCount = messages.length
+        if (worst > 0)
+            raiseAlert(worst)
+    }
+
+    Timer { id: alertTimer; onTriggered: bar.expireAlert() }
+
     Rectangle {
         id: logCard
+        objectName: "sessionMessages"
         Layout.fillWidth: true
         implicitHeight: logHeader.implicitHeight + Theme.spacing
                         + (logOpen ? 220 : messageTail.implicitHeight)
         radius: Theme.radiusSmall
         color: Theme.surface
         border.width: 1
-        // The card itself carries the worst severity on screen, so an error is
-        // visible from across the room without reading the text.
-        border.color: bar.errorCount > 0 ? Theme.danger
-                    : bar.warningCount > 0 ? Theme.warning
-                                           : Theme.border
+        // The card carries the severity of the newest message for as long as the
+        // alert lasts, so a problem is visible from across the room without
+        // reading the text - then it fades back out (see raiseAlert).
+        border.color: bar.alertSeverity === 2 ? Theme.danger
+                    : bar.alertSeverity === 1 ? Theme.warning
+                                              : Theme.border
+        Behavior on border.color { ColorAnimation { duration: Theme.animMs * 4 } }
         clip: true
 
         property bool logOpen: false

--- a/source/UiSwitch.qml
+++ b/source/UiSwitch.qml
@@ -50,6 +50,10 @@ Switch {
         font: control.font
         color: control.enabled ? control.textColor : Theme.textDisabled
         verticalAlignment: Text.AlignVCenter
+        // The indicator alone is 40 px, so in a narrow container (the video
+        // windows' control rail is as little as 150 px wide) the label had well
+        // under half the width and was cut mid-word. Elide like UiButton does.
+        elide: Text.ElideRight
         leftPadding: control.indicator.width + (control.text.length > 0 ? Theme.spacing : 0)
     }
 }

--- a/source/VideoWindowShell.qml
+++ b/source/VideoWindowShell.qml
@@ -18,6 +18,11 @@ import Miniscope.Theme 1.0
 // when needed); display-only controls (contrast / brightness / saturation /
 // LUT / dFF) and actions sit in an auto-hiding right rail.
 //
+// Both panels overlay the video, so both are sized as a fraction of the pane
+// (root.panelWidth) rather than in fixed pixels, only as tall as they need, and
+// never open at the same time - a pane in the Acquire grid is often ~450 px wide,
+// and these controls are adjusted while watching the live image.
+//
 // C++ contract (videodevice/miniscope/behaviorcam.cpp attach by objectName
 // and root signal - keep these stable):
 //   root signals: takeScreenShotSignal, vidPropChangedSignal, dFFSwitchChanged,
@@ -57,6 +62,15 @@ Item {
 
     focus: true
     Keys.onSpacePressed: root.takeScreenShotSignal()
+
+    // Width of the two overlay panels (hardware dock, display rail). Panes in the
+    // Acquire grid are routinely 450-630 px wide, where a fixed 250 px panel
+    // covered 40-56% of the video - and most of these controls (EWL focus, LED,
+    // gain, contrast) are adjusted *while watching* the live image. So the panels
+    // are a fraction of the pane instead of a constant, floored at the width a
+    // slider row still needs to be usable and capped at the old 250.
+    readonly property int panelWidth:
+        Math.round(Math.min(250, Math.max(150, width * 0.34)))
 
     // --- Video ---------------------------------------------------------------
     VideoDisplay {
@@ -153,12 +167,19 @@ Item {
         id: railSlider
         property alias iconPath: railSliderIcon.source
         property alias value: railSliderSlider.value
+        // These rows are icon-only to keep the rail narrow, and the icons
+        // (alpha / beta) name the shader term rather than what it does.
+        property string tip: ""
         signal moved(double value)
         spacing: 8
         RecoloredIcon {
             id: railSliderIcon
             Layout.preferredWidth: 18
             Layout.preferredHeight: 18
+            ToolTip.text: railSlider.tip
+            ToolTip.visible: railSlider.tip.length > 0 && iconHover.hovered
+            ToolTip.delay: 400
+            HoverHandler { id: iconHover }
         }
         Slider {
             id: railSliderSlider
@@ -275,14 +296,19 @@ Item {
     // short pane can't fit them all.
     Rectangle {
         id: hwDock
+        objectName: "hardwareDock"
         anchors.left: parent.left
         anchors.verticalCenter: parent.verticalCenter
         anchors.leftMargin: Theme.spacing
 
-        readonly property bool hwExpanded: hwHover.hovered || hwPinned
+        // Collapses while the display rail is out: two panels this wide left
+        // nothing of a small pane's video visible at once, and the rail is what
+        // the pointer is on. One-directional on purpose - the rail must not
+        // depend on the dock in turn, or the two bindings form a cycle.
+        readonly property bool hwExpanded: (hwHover.hovered || hwPinned) && !rail.railOpen
         property bool hwPinned: false
         readonly property int collapsedWidth: 78
-        readonly property int expandedWidth: Math.min(240, root.width - 2 * Theme.spacing)
+        readonly property int expandedWidth: root.panelWidth
 
         // Whether the catalog gave this device any hardware controls. C++ calls
         // setVisible(true) on each control AFTER the window loads. We must NOT
@@ -395,12 +421,19 @@ Item {
     // app theme.
     Rectangle {
         id: rail
-        width: 250
-        anchors.top: parent.top
-        anchors.bottom: parent.bottom
+        objectName: "displayRail"
+        width: root.panelWidth
+        // Only as tall as its contents (capped to the pane), not the full pane
+        // height: the rail's controls come to ~400 px, so a full-height panel was
+        // an opaque slab over video for no reason. Centred, like the dock.
+        height: Math.min(railContent.implicitHeight + 2 * Theme.spacing, root.height)
+        anchors.verticalCenter: parent.verticalCenter
         anchors.right: parent.right
-        anchors.rightMargin: railOpen ? 0 : -width
-        color: "#dd14141a"
+        anchors.rightMargin: railOpen ? Theme.spacing : -(width + Theme.spacing)
+        radius: Theme.radiusSmall
+        // Slightly more see-through than the old #dd: what is behind the rail is
+        // the video being adjusted.
+        color: "#cc14141a"
 
         readonly property bool railOpen: railHover.hovered || edgeHover.hovered || railPinned
         property bool railPinned: false
@@ -416,15 +449,23 @@ Item {
             clip: true
 
             ColumnLayout {
+                id: railContent
                 width: rail.width - 2 * Theme.spacing
                 spacing: Theme.spacing
 
                 RowLayout {
                     Layout.fillWidth: true
                     Text {
-                        text: qsTr("Display (not recorded)")
+                        // Everything under this heading changes the on-screen
+                        // image only. The rail is narrow, so the label is short
+                        // and the caveat lives in the tooltip.
+                        text: qsTr("Display only")
                         font: Theme.fontSmall
                         color: "#8a8a96"
+                        ToolTip.text: qsTr("Affects the live view only — never the recorded video.")
+                        ToolTip.visible: headingHover.hovered
+                        ToolTip.delay: 400
+                        HoverHandler { id: headingHover }
                     }
                     Item { Layout.fillWidth: true }
                     // Pin keeps the rail open (glove-friendly)
@@ -446,33 +487,44 @@ Item {
                 RailSlider {
                     Layout.fillWidth: true
                     iconPath: "img/icon/alpha.png"
+                    tip: qsTr("Contrast")
                     value: 1
                     onMoved: v => root.vidPropChangedSignal("alpha", v, v, 0)
                 }
                 RailSlider {
                     Layout.fillWidth: true
                     iconPath: "img/icon/beta.png"
+                    tip: qsTr("Brightness")
                     value: 0
                     onMoved: v => root.vidPropChangedSignal("beta", v, v, 0)
                 }
 
                 UiSwitch {
                     objectName: "saturationSwitch"
-                    text: qsTr("Show saturation")
+                    text: qsTr("Saturation")
                     textColor: "#d8d8e0"
+                    ToolTip.text: qsTr("Highlight saturated pixels in the live view.")
+                    ToolTip.visible: hovered
+                    ToolTip.delay: 400
                     onToggled: root.saturationSwitchChanged(checked)
                 }
                 UiSwitch {
                     objectName: "lutSwitch"
                     visible: root.miniscope
-                    text: qsTr("Apply LUT colormap")
+                    text: qsTr("Colormap")
                     textColor: "#d8d8e0"
+                    ToolTip.text: qsTr("Apply the config's LUT colormap to the live view.")
+                    ToolTip.visible: hovered
+                    ToolTip.delay: 400
                     onToggled: root.lutSwitchChanged(checked)
                 }
                 UiSwitch {
                     visible: root.miniscope
-                    text: qsTr("ΔF/F display")
+                    text: qsTr("ΔF/F")
                     textColor: "#d8d8e0"
+                    ToolTip.text: qsTr("Show each pixel's change from its running mean.")
+                    ToolTip.visible: hovered
+                    ToolTip.delay: 400
                     onToggled: root.dFFSwitchChanged(checked)
                 }
 
@@ -486,11 +538,17 @@ Item {
                 UiButton {
                     Layout.fillWidth: true
                     text: qsTr("Screenshot")
+                    ToolTip.text: qsTr("Save a PNG of the current frame (or press Space).")
+                    ToolTip.visible: hovered
+                    ToolTip.delay: 400
                     onClicked: root.takeScreenShotSignal()
                 }
                 UiButton {
                     Layout.fillWidth: true
-                    text: qsTr("Select recording ROI…")
+                    text: qsTr("Recording ROI…")
+                    ToolTip.text: qsTr("Drag a region on the video; only that region is recorded.")
+                    ToolTip.visible: hovered
+                    ToolTip.delay: 400
                     onClicked: root.setRoiClicked()
                 }
                 UiButton {
@@ -498,14 +556,20 @@ Item {
                     Layout.fillWidth: true
                     visible: root.miniscope
                     enabled: false // enabled by C++ when the trace display runs
-                    text: qsTr("Add trace ROI…")
+                    text: qsTr("+ Trace ROI…")
+                    ToolTip.text: qsTr("Drag a region to plot its mean in the trace display.")
+                    ToolTip.visible: hovered
+                    ToolTip.delay: 400
                     onClicked: root.addTraceRoiClicked()
                 }
                 UiButton {
                     objectName: "camProps"
                     Layout.fillWidth: true
                     visible: false // shown by C++ for cameras with a props dialog
-                    text: qsTr("Camera properties…")
+                    text: qsTr("Properties…")
+                    ToolTip.text: qsTr("Open the camera driver's own settings dialog.")
+                    ToolTip.visible: hovered
+                    ToolTip.delay: 400
                     onClicked: root.camPropsClicked()
                 }
             }

--- a/source/backend.cpp
+++ b/source/backend.cpp
@@ -1465,6 +1465,20 @@ void backEnd::setupDataSaver()
     // TODO: setup start connections
 
     dataSaverThread->start();
+
+    // The consumer exists, so let the producers go. Every device was created
+    // with its capture loop held (VideoDevice's constructor): the DataSaver is
+    // the only thing that empties a device's ring buffer, and it could not be
+    // created until all the devices were, since it needs their buffers. Opening
+    // a camera takes seconds, so a device left streaming from the moment it
+    // connected would fill its buffer while the others were still opening and
+    // spend the rest of Run reporting dropped frames. Releasing here also means
+    // every device's frame 0 is the start of the session, not the moment its own
+    // camera happened to open.
+    for (Miniscope *device : miniscope)
+        device->releaseStreamHold();
+    for (BehaviorCam *device : behavCam)
+        device->releaseStreamHold();
 }
 
 void backEnd::testCodecSupport()

--- a/source/videodevice.cpp
+++ b/source/videodevice.cpp
@@ -185,6 +185,11 @@ VideoDevice::VideoDevice(QObject *parent, QJsonObject ucDevice, qint64 softwareS
         // THIS SHOULD ONLY BE SENT TO MINISCOPE AND MINICAM DEVICES. USE TO US AN if isMiniCAM statement here
         sendInitCommands();
 
+        // Start the capture loop held: it configures the device from the queued
+        // commands below but acquires no frames until the session's DataSaver -
+        // the ring buffer's only drain - is running. See setStreamHold(); the
+        // backend releases every device together (releaseStreamHold()).
+        deviceStream->setStreamHold(true);
         videoStreamThread->start();
 
         // Short sleep to make i2c initialize commands be sent before loading in user config controls

--- a/source/videodevice.h
+++ b/source/videodevice.h
@@ -68,6 +68,15 @@ public:
     // Orderly shutdown: stop the capture loop and join its thread. Safe to
     // call from the GUI thread; no-op if the device never connected.
     void stopAndJoinStream();
+    // Let the capture loop start acquiring. Devices are constructed with their
+    // stream held (see the constructor) because the ring buffer has no drain
+    // until the session's DataSaver thread runs; the backend calls this on
+    // every device once that thread is up. No-op if the device never connected.
+    void releaseStreamHold()
+    {
+        if (deviceStream)
+            deviceStream->setStreamHold(false);
+    }
     void defineDeviceAddrs();
     void parseUserConfigDevice();
     void sendInitCommands();

--- a/source/videostreambase.cpp
+++ b/source/videostreambase.cpp
@@ -97,6 +97,7 @@ void VideoStreamBase::resetStreamState()
     m_extTriggerLast = -1;
     m_lockedFrameSize = cv::Size();
     m_sizeMismatchWarned = false;
+    m_bufferFullWarned = false;
     // Zero quaternion with normError 1: frames committed before the first
     // successful BNO read are flagged corrupted, not passed off as valid.
     m_lastBnoQuat[0] = m_lastBnoQuat[1] = m_lastBnoQuat[2] = m_lastBnoQuat[3] = 0.0f;
@@ -140,13 +141,20 @@ void VideoStreamBase::commitFrame(const cv::Mat &frame, qint64 timestampMs)
     // frame being saved. Acquiring first also skips the per-frame control
     // reads (~6 ms each on some transports) for frames we are about to drop.
     if (!freeFrames->tryAcquire()) {
-        // No free slot: this frame is thrown away.
-        if (freeFrames->available() == 0) {
+        // No free slot: this frame is thrown away. A full buffer stays full
+        // until the consumer catches up, so report the episode once instead of
+        // once per dropped frame - dozens of identical lines bury whatever else
+        // the message log was showing, and the count in the session bar reads as
+        // dozens of separate faults.
+        if (freeFrames->available() == 0 && !m_bufferFullWarned) {
             sendMessage("Error: " + m_deviceName + " frame buffer is full. Frames will be lost!");
-            QThread::msleep(100);
+            m_bufferFullWarned = true;
         }
+        if (freeFrames->available() == 0)
+            QThread::msleep(100);
         return;
     }
+    m_bufferFullWarned = false;   // a slot was free: re-arm for the next episode
 
     const int bufIdx = m_streamIdx % frameBufferSize;
     timeStampBuffer[bufIdx] = timestampMs;
@@ -265,4 +273,19 @@ void VideoStreamBase::serviceCommandQueue()
     QCoreApplication::processEvents();
     if (!m_commandQueue.isEmpty())
         sendCommands();
+}
+
+bool VideoStreamBase::heldForSession()
+{
+    if (!m_streamHeld)
+        return false;
+    // The device's init commands and the user config's control values are
+    // queued to this thread while the hold is on, so keep servicing them: the
+    // scope is configured and its LED is at the right brightness by the time
+    // the first frame is acquired, exactly as before. The sleep is short
+    // because the hold is released from the GUI thread mid-Run and any delay
+    // here is added to Run's total time.
+    serviceCommandQueue();
+    QThread::msleep(2);
+    return true;
 }

--- a/source/videostreambase.h
+++ b/source/videostreambase.h
@@ -97,6 +97,25 @@ public:
     void setIsColor(bool isColor) { m_isColor = isColor; }
     void setDeviceName(QString name) { m_deviceName = name; }
 
+    // Hold the capture loop before it reads its first frame. The ring buffer's
+    // only drain is the DataSaver thread, which cannot exist until every device
+    // has been constructed - and constructing a device opens a camera, which
+    // takes seconds. Without this hold the first device streams into a buffer
+    // nobody empties for as long as the remaining devices take to open, fills
+    // all FRAME_BUFFER_SIZE slots, and spends the rest of Run reporting
+    // "frame buffer is full. Frames will be lost!".
+    //
+    // Held streams do not acquire frames at all (rather than acquire and
+    // discard): file playback would otherwise burn through the start of the
+    // recording, and there is nothing to keep warm on a live camera that the
+    // 500 ms init-command wait doesn't already cover.
+    //
+    // Thread-safe: called from the GUI thread while the capture loop runs.
+    // Default is unheld, so a stream driven directly (tests, any future caller)
+    // behaves exactly as before.
+    void setStreamHold(bool held) { m_streamHeld = held; }
+    bool streamHeld() const { return m_streamHeld; }
+
     // Estimated frames dropped between the DAQ hardware and the software this
     // run, for the live GUI readout. Rebased to the current connection epoch: a
     // reconnect restarts the DAQ frame counter (so the recorded CSV shows the
@@ -187,11 +206,19 @@ protected:
     // command queue. Call once per loop iteration.
     void serviceCommandQueue();
 
+    // True while setStreamHold(true) is in force: the capture loop must not
+    // read a frame yet. Services the command queue and sleeps briefly, so a
+    // held loop still delivers the device's init and user-config writes and
+    // still notices stopStream(). Call as the first statement of each loop
+    // iteration: `if (heldForSession()) continue;`.
+    bool heldForSession();
+
     // ---- shared state -----------------------------------------------------
     QString m_deviceName;
     int m_cameraID = -1;
 
     std::atomic<bool> m_stopStreaming{false};
+    std::atomic<bool> m_streamHeld{false};
     bool m_headOrientationStreamState = false;
     bool m_isColor = false;
     bool m_trackExtTrigger = false;
@@ -220,6 +247,7 @@ protected:
     int m_extTriggerLast = -1;         // -1 = not primed yet
     cv::Size m_lockedFrameSize;        // locked to the first committed frame
     bool m_sizeMismatchWarned = false;
+    bool m_bufferFullWarned = false;   // re-armed when a slot frees up
     float m_lastBnoQuat[5];            // last good {w,x,y,z,normError}
 };
 

--- a/source/videostreamlibuvc.cpp
+++ b/source/videostreamlibuvc.cpp
@@ -209,6 +209,9 @@ void VideoStreamLibUVC::startStream()
     forever {
         if (m_stopStreaming)
             break;
+        // Nothing drains the ring buffer until the session's DataSaver exists.
+        if (heldForSession())
+            continue;
 
         uvc_frame_t *frame = nullptr;
         // Timeout in us; ~2 frame periods, min 100ms.

--- a/source/videostreammac.cpp
+++ b/source/videostreammac.cpp
@@ -185,6 +185,9 @@ void VideoStreamMac::startStream()
     forever {
         if (m_stopStreaming)
             break;
+        // Nothing drains the ring buffer until the session's DataSaver exists.
+        if (heldForSession())
+            continue;
 
         if (!m_grabber.read(frame)) {
             // The grabber is NOT released here: the stall diagnosis inside

--- a/source/videostreamocv.cpp
+++ b/source/videostreamocv.cpp
@@ -139,6 +139,11 @@ void VideoStreamOCV::startStream()
     forever {
         if (m_stopStreaming)
             break;
+        // Nothing drains the ring buffer until the session's DataSaver exists.
+        // Playback devices must not advance either, or the recording would
+        // start partway in.
+        if (heldForSession())
+            continue;
 
         // Get new frame and handle disconnects
 #ifdef Q_OS_MACOS

--- a/tests/tst_configform.cpp
+++ b/tests/tst_configform.cpp
@@ -38,6 +38,7 @@ private slots:
     void led0FineStepsHints();
     void duplicateDeviceNamesAreRefused();
     void runReportsProgressAndClearsIt();
+    void enableSwitchSitsWithItsHeading();
     void directoryStructureArrayEdit();
 
 private:
@@ -486,6 +487,64 @@ void TestConfigForm::runReportsProgressAndClearsIt()
 // into a JSON array on its own — so the value was stored as null, the config
 // failed schema validation ("type not permitted"), and the field blanked on
 // the next edit. This drives the real QML write path to pin the fix.
+// A feature card's enable switch used to sit at the far right edge with the
+// heading at the far left, which reads as unrelated furniture: the reference
+// config is the exact failure case - a commutator with its serial port filled in
+// (COM3) and `enabled` still false. The switch now sits with the title, says its
+// state in words, and an open-but-disabled card says so in its body.
+void TestConfigForm::enableSwitchSitsWithItsHeading()
+{
+    backEnd backend;
+    loadExampleConfig(backend);
+    QCOMPARE(backend.userConfigJson().value("commutator").toMap()
+                 .value("enabled").toBool(), false);
+
+    QQmlEngine engine;
+    engine.rootContext()->setContextProperty("backend", &backend);
+    QQmlComponent component(&engine, QUrl("qrc:/ConfigForm.qml"));
+    QScopedPointer<QObject> form(component.create());
+    QVERIFY2(form, "ConfigForm.qml failed to create");
+    auto *formItem = qobject_cast<QQuickItem *>(form.data());
+    QVERIFY(formItem);
+    formItem->setWidth(900);
+    formItem->setHeight(1200);
+
+    QQuickItem *card = findVisualChild(formItem, "commutatorCard");
+    QVERIFY2(card, "commutatorCard missing from ConfigForm.qml");
+    QQuickItem *sw = findVisualChild(card, "enableSwitch");
+    QQuickItem *state = findVisualChild(card, "enableStateText");
+    QQuickItem *hint = findVisualChild(card, "disabledHint");
+    QQuickItem *title = findVisualChild(card, "cardTitle");
+    QVERIFY(sw);
+    QVERIFY(state);
+    QVERIFY(hint);
+    QVERIFY(title);
+
+    // Directly after the title - both are siblings in the same header row now,
+    // so the gap is one layout spacing. It used to be pushed past the subtitle's
+    // full width to the card's right edge, which is what made it missable. This
+    // is deliberately measured against the title rather than against the card
+    // width: the assertion has to hold at any card width.
+    const qreal gap = sw->x() - (title->x() + title->width());
+    QVERIFY2(gap >= 0 && gap < 40,
+             qPrintable(QStringLiteral("switch is %1 px from the title (switch x=%2, title ends %3)")
+                            .arg(gap).arg(sw->x())
+                            .arg(title->x() + title->width())));
+    // ...and the state word reads with the switch, on its far side.
+    QVERIFY2(state->x() > sw->x(), "the state word is not grouped with the switch");
+    QCOMPARE(state->property("text").toString(), QStringLiteral("Disabled"));
+
+    // The body hint appears once the card is open - the point at which someone
+    // is filling in the port and about to forget the switch.
+    card->setProperty("expanded", true);
+    QVERIFY2(hint->isVisible(), "an open, disabled card does not say it is off");
+
+    // Enabling from either affordance clears it and updates the word.
+    backend.setConfigValue({"commutator", "enabled"}, true);
+    QVERIFY2(!hint->isVisible(), "the hint survived enabling the feature");
+    QCOMPARE(state->property("text").toString(), QStringLiteral("Enabled"));
+}
+
 void TestConfigForm::directoryStructureArrayEdit()
 {
     backEnd backend;

--- a/tests/tst_sessionlifecycle.cpp
+++ b/tests/tst_sessionlifecycle.cpp
@@ -16,8 +16,10 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
+#include <QQmlProperty>
 #include <QQuickStyle>
 #include <QQuickItem>
+#include <QQuickView>
 #include <QQuickWindow>
 #include <QSGRendererInterface>
 #include <QTemporaryDir>
@@ -40,6 +42,9 @@ private slots:
     void initTestCase();
     void runEndRunCycle();
     void configEditsBetweenRunsAreHonored();
+    void producersHeldUntilConsumerReady();
+    void messageAlertExpires();
+    void videoWindowPanelsScaleToPane();
     void paneGridArrangement();
 
 private:
@@ -55,7 +60,8 @@ private:
     // Writes a config whose only devices are file-playback cameras with the
     // given names, all streaming the AVI generated in initTestCase. Returns its
     // path, or an empty string if it could not be written.
-    QString writeConfig(const QString &fileName, const QStringList &cameraNames);
+    QString writeConfig(const QString &fileName, const QStringList &cameraNames,
+                        int frameRate = 20);
 
     // Items a Repeater created (every pane of the grid) are not QObject children
     // of the window, so findChildren() can't see them - walk the visual tree.
@@ -77,11 +83,12 @@ private:
 };
 
 QString TestSessionLifecycle::writeConfig(const QString &fileName,
-                                          const QStringList &cameraNames)
+                                          const QStringList &cameraNames,
+                                          int frameRate)
 {
     const QJsonObject playback{{"folderPath", m_tempDir.path()},
                                {"filePrefix", "lifecycle_"},
-                               {"frameRate", 20}};
+                               {"frameRate", frameRate}};
     QJsonObject cameras;
     for (const QString &name : cameraNames)
         cameras[name] = QJsonObject{{"deviceType", "WebCam"},
@@ -298,6 +305,204 @@ void TestSessionLifecycle::configEditsBetweenRunsAreHonored()
     const QVariantList otherPanes = backend.sessionPanes();
     QCOMPARE(otherPanes.size(), 1);
     QCOMPARE(otherPanes[0].toMap().value("name").toString(), QStringLiteral("OtherCam"));
+    backend.endSession();
+    drainEvents();
+}
+
+// A device's ring buffer has exactly one drain: the DataSaver thread. That
+// thread cannot be created until every device is, because it is wired to their
+// buffers - and constructing a device opens a camera, which takes seconds. So a
+// device that streamed from the moment it connected filled all FRAME_BUFFER_SIZE
+// slots while the remaining devices were still opening, and Run ended with a
+// message log full of "frame buffer is full. Frames will be lost!" before the
+// operator had done anything.
+//
+// Devices are therefore constructed with their capture loop held and released
+// together once the DataSaver is up. Three playback cameras at a high frame rate
+// reproduce the original flood: each device takes ~0.5 s to construct, which is
+// far longer than the first one needs to fill 128 slots.
+void TestSessionLifecycle::producersHeldUntilConsumerReady()
+{
+    backEnd backend;
+    if (!backend.availableCodecs().contains("MJPG"))
+        QSKIP("MJPG codec unavailable on this host");
+
+    const QString path = writeConfig("held_streams.json",
+                                     {"FastCamA", "FastCamB", "FastCamC"},
+                                     /*frameRate=*/500);
+    QVERIFY(!path.isEmpty());
+    backend.setUserConfigFileName(QUrl::fromLocalFile(path).toString());
+    QVERIFY2(backend.userConfigOK(), "three-camera config failed the backend's checks");
+
+    backend.onRunClicked();
+    QVERIFY(backend.sessionActive());
+    QCOMPARE(backend.sessionCameraCount(), 3);
+
+    QObject *ctl = backend.sessionControl();
+    QVERIFY(ctl != nullptr);
+    const QStringList log = ctl->property("messageLog").toStringList();
+    for (const QString &line : log)
+        QVERIFY2(!line.contains("buffer is full"),
+                 qPrintable("a device streamed before the DataSaver existed: " + line));
+
+    // ...and the hold really was released, rather than left on forever: every
+    // device has to be acquiring frames now.
+    drainEvents(400);
+    const QVariantList devices = backend.sessionTelemetry().value("devices").toList();
+    QCOMPARE(devices.size(), 3);
+    for (const QVariant &device : devices) {
+        const QVariantMap map = device.toMap();
+        QVERIFY2(map.value("frames").toInt() > 0,
+                 qPrintable(map.value("name").toString() + " never acquired a frame"));
+    }
+
+    backend.endSession();
+    QVERIFY(!backend.sessionActive());
+    drainEvents();
+}
+
+// The message card's colored outline is an alert that expires, not a state
+// derived from the session's cumulative counts. Driven off the counts, a single
+// benign warning - a commutator reporting no rotation from its first samples,
+// with the commutator working perfectly - ringed the card amber for the rest of
+// the session, which reads as an unresolved fault. The counts in the header are
+// the persistent record; the ring is only the attention-grab.
+void TestSessionLifecycle::messageAlertExpires()
+{
+    backEnd backend;
+    if (!backend.availableCodecs().contains("MJPG"))
+        QSKIP("MJPG codec unavailable on this host");
+
+    backend.setUserConfigFileName(QUrl::fromLocalFile(m_configPath).toString());
+    QVERIFY(backend.userConfigOK());
+
+    QQmlApplicationEngine engine;
+    engine.rootContext()->setContextProperty("backend", &backend);
+    engine.load(QUrl(QStringLiteral("qrc:/AppShell.qml")));
+    QVERIFY2(!engine.rootObjects().isEmpty(), "AppShell.qml failed to load");
+
+    backend.onRunClicked();
+    QVERIFY(backend.sessionActive());
+    drainEvents();
+
+    auto *window = qobject_cast<QQuickWindow *>(engine.rootObjects().first());
+    QVERIFY(window != nullptr);
+    QList<QQuickItem *> bars;
+    collectItems(window->contentItem(), QStringLiteral("sessionBar"), bars);
+    QCOMPARE(bars.size(), 1);
+    QQuickItem *bar = bars.first();
+    QList<QQuickItem *> cards;
+    collectItems(bar, QStringLiteral("sessionMessages"), cards);
+    QCOMPARE(cards.size(), 1);
+    QQuickItem *card = cards.first();
+
+    // Normalize first: Run itself logs a few (severity-0) lines, and this test is
+    // about what happens to the outline afterwards. border.color is a grouped
+    // property, so it has to be read through QQmlProperty, not QObject::property.
+    QVERIFY(QMetaObject::invokeMethod(bar, "expireAlert"));
+    drainEvents(600);
+    const QColor quiet = QQmlProperty::read(card, "border.color").value<QColor>();
+    const int errorsBefore = bar->property("errorCount").toInt();
+    const int warningsBefore = bar->property("warningCount").toInt();
+
+    QObject *ctl = backend.sessionControl();
+    QVERIFY(ctl != nullptr);
+
+    QVERIFY(QMetaObject::invokeMethod(ctl, "receiveMessage",
+                                      Q_ARG(QString, "Warning: commutator computed no rotation")));
+    drainEvents(100);
+    QCOMPARE(bar->property("alertSeverity").toInt(), 1);
+    const QColor alerted = QQmlProperty::read(card, "border.color").value<QColor>();
+    QVERIFY2(alerted != quiet, "a new warning did not raise the outline");
+    QCOMPARE(bar->property("warningCount").toInt(), warningsBefore + 1);
+
+    // An error outranks a warning that is still showing...
+    QVERIFY(QMetaObject::invokeMethod(ctl, "receiveMessage",
+                                      Q_ARG(QString, "ERROR: something real")));
+    drainEvents(100);
+    QCOMPARE(bar->property("alertSeverity").toInt(), 2);
+    // ...and a later warning must not downgrade it while it is up.
+    QVERIFY(QMetaObject::invokeMethod(ctl, "receiveMessage",
+                                      Q_ARG(QString, "Warning: and another")));
+    drainEvents(100);
+    QCOMPARE(bar->property("alertSeverity").toInt(), 2);
+
+    // When the alert expires (alertTimer fires this), the ring goes back to
+    // normal but the session's counts - the thing that must not be forgotten -
+    // are all still there.
+    QVERIFY(QMetaObject::invokeMethod(bar, "expireAlert"));
+    drainEvents(600);   // the Behavior animates the colour back (4 * animMs)
+    QCOMPARE(bar->property("alertSeverity").toInt(), 0);
+    QCOMPARE(QQmlProperty::read(card, "border.color").value<QColor>(), quiet);
+    QCOMPARE(bar->property("errorCount").toInt(), errorsBefore + 1);
+    QCOMPARE(bar->property("warningCount").toInt(), warningsBefore + 2);
+
+    backend.endSession();
+    drainEvents();
+}
+
+// The hardware dock and the display rail overlay the live video, and most of
+// what they hold (EWL focus, LED, gain, contrast) is adjusted *while watching*
+// that video. At a fixed 250 px each they covered 40-56% of a normal Acquire pane
+// individually, and effectively all of it together. So they are a fraction of the
+// pane, and only one is ever out at a time.
+void TestSessionLifecycle::videoWindowPanelsScaleToPane()
+{
+    backEnd backend;
+    if (!backend.availableCodecs().contains("MJPG"))
+        QSKIP("MJPG codec unavailable on this host");
+
+    backend.setUserConfigFileName(QUrl::fromLocalFile(m_configPath).toString());
+    QVERIFY(backend.userConfigOK());
+    backend.onRunClicked();
+    QVERIFY(backend.sessionActive());
+
+    const QVariantList panes = backend.sessionPanes();
+    QCOMPARE(panes.size(), 1);
+    auto *view = qobject_cast<QQuickView *>(
+        panes[0].toMap().value("window").value<QObject *>());
+    QVERIFY2(view != nullptr, "the device pane is not a QQuickView");
+    QQuickItem *shell = view->rootObject();
+    QVERIFY(shell != nullptr);
+    QQuickItem *rail = shell->findChild<QQuickItem *>(QStringLiteral("displayRail"));
+    QQuickItem *dock = shell->findChild<QQuickItem *>(QStringLiteral("hardwareDock"));
+    QVERIFY(rail != nullptr);
+    QVERIFY(dock != nullptr);
+
+    // Width tracks the pane: 34% of it, floored where a slider row stops being
+    // usable and capped at the old fixed width. The shell item is driven directly
+    // rather than through the view - a pane embeds this window in a container that
+    // owns its geometry, so setWidth() on the view does not stick.
+    shell->setWidth(1200);
+    drainEvents(100);
+    QCOMPARE(rail->width(), 250.0);           // capped
+    shell->setWidth(600);
+    drainEvents(100);
+    QCOMPARE(rail->width(), 204.0);           // 0.34 * 600
+    shell->setWidth(300);
+    drainEvents(100);
+    QCOMPARE(rail->width(), 150.0);           // floored
+
+    // Not full height either: the rail's controls come to well under a pane.
+    shell->setWidth(600);
+    shell->setHeight(900);
+    drainEvents(100);
+    QVERIFY2(rail->height() < 0.9 * shell->height(),
+             qPrintable(QStringLiteral("rail is %1 tall in a %2 pane")
+                            .arg(rail->height()).arg(shell->height())));
+
+    // One panel at a time: an open rail collapses the dock even when the dock is
+    // pinned, so the two can never cover the video together.
+    QQmlProperty::write(dock, "hwPinned", true);
+    drainEvents(100);
+    QCOMPARE(QQmlProperty::read(dock, "hwExpanded").toBool(), true);
+    QQmlProperty::write(rail, "railPinned", true);
+    drainEvents(100);
+    QCOMPARE(QQmlProperty::read(dock, "hwExpanded").toBool(), false);
+    QQmlProperty::write(rail, "railPinned", false);
+    drainEvents(100);
+    QCOMPARE(QQmlProperty::read(dock, "hwExpanded").toBool(), true);
+
     backend.endSession();
     drainEvents();
 }

--- a/tests/tst_videostreambase.cpp
+++ b/tests/tst_videostreambase.cpp
@@ -162,6 +162,31 @@ private slots:
         QVERIFY(messages.at(0).at(0).toString().contains("buffer is full"));
     }
 
+    // A full buffer stays full until the consumer catches up, so every frame in
+    // between hits the same branch. Reporting each one buried the rest of the
+    // message log under dozens of identical lines (and the session bar's error
+    // count read them as dozens of separate faults) - it is one episode, like
+    // the size-mismatch warning above.
+    void bufferFullWarningOncePerEpisode()
+    {
+        buildStream();
+        QVERIFY(freeFrames->tryAcquire(kBufSize));   // consumer owns every slot
+        QSignalSpy messages(stream, &VideoStreamBase::sendMessage);
+
+        stream->commitFrame(bgrFrame(), 1);
+        stream->commitFrame(bgrFrame(), 2);
+        stream->commitFrame(bgrFrame(), 3);
+        QCOMPARE(messages.count(), 1);
+
+        freeFrames->release(kBufSize);                // consumer caught up
+        stream->commitFrame(bgrFrame(), 4);           // commits, re-arming the warning
+        QCOMPARE(messages.count(), 1);
+
+        QVERIFY(freeFrames->tryAcquire(kBufSize - 1));// full again: a new episode
+        stream->commitFrame(bgrFrame(), 5);
+        QCOMPARE(messages.count(), 2);
+    }
+
     void ringBufferWrapsAround()
     {
         buildStream();


### PR DESCRIPTION
Five things found on the bench after #116. All tested against a real three-device rig as they landed.

## The frame-buffer error flood at Run

Reported as ~40 of these seconds after clicking Run, on a rig that was working perfectly:

```
16:26:41  Error: My Miniscope frame buffer is full. Frames will be lost!
16:26:41  Error: My Miniscope frame buffer is full. Frames will be lost!
   ... x40, interleaved with My Camera
```

A device's ring buffer has exactly **one** drain: the DataSaver thread. That thread cannot be created until every device has been, because it is wired to their buffers (`setupDataSaver` needs `getFrameBufferPointer()` from each) — and opening a camera takes seconds. But each device started streaming inside its own constructor. So `My Miniscope` streamed for the ~8 s that `My Camera` and `My Camera2` took to open, filled all 128 slots, and then reported a lost frame for every frame after that.

Nothing was wrong with the hardware; the producer was simply running with no consumer.

Capture loops now start **held** and are released together once the DataSaver thread is up:

```cpp
// VideoDevice ctor, after sendInitCommands()
deviceStream->setStreamHold(true);
videoStreamThread->start();

// end of backEnd::setupDataSaver()
for (Miniscope *device : miniscope)   device->releaseStreamHold();
for (BehaviorCam *device : behavCam)  device->releaseStreamHold();
```

Two decisions worth recording:

- **Held loops acquire nothing**, rather than acquire-and-discard. File-playback devices would otherwise burn through the start of the recording, and there is nothing to keep warm on a live camera that the existing 500 ms init-command wait doesn't already cover.
- **`heldForSession()` keeps servicing the command queue** while it waits, so the device's init commands and the user config's control values still reach the hardware on the same schedule (`frameRate changed to 20`, `gain changed to 1` land exactly where they used to). One call site per backend, `if (heldForSession()) continue;`.

A side benefit: every device's frame 0 is now the start of the session rather than the moment its own camera happened to open.

Separately, a genuinely full buffer mid-session is now reported **once per episode** instead of once per dropped frame. The buffer stays full until the consumer catches up, so those forty lines were one event — and with #116's new error counter in the session bar they read as forty separate faults. Same pattern the mid-stream frame-size warning already used.

## The message outline that never went out

> the commutator is working fine. this warning is fine but it adds a yellow outline to the messaging box. If this was temporary it would be fine

The outline was bound straight to the session's cumulative counts, so `warningCount > 0` was true forever after one warning. It is now an **alert that expires**: it takes the severity of the newest message and fades back after 15 s for a warning, 60 s for an error. An error still showing is not downgraded (or extended) by a warning landing on top of it.

The header counts are unchanged and still cover the whole session — #116's reason for having them — so the warning stays on the record, it just stops shouting.

## Video-window panels on a small pane

> The controls that pop in from the sides of the video windows take up way too much of the view when the video window is small. This is particularly important as many of the controls, especially miniscope controls, need to be done while seeing the live view.

Measured, and the problem was the *shape*: the rail was a fixed `width: 250` **and the full height of the window**, the dock expanded to 240, and both were ~87% opaque overlays.

| Pane width | Rail (was 250 px) | Dock expanded |
|---|---|---|
| 630 px — three devices on a 1920 monitor | 40% of the width, full height | 38% |
| 450 px — three devices on a 1366 laptop | 56% | 53% |

Both open left essentially no video. Now:

- Both are `panelWidth = round(min(250, max(150, width * 0.34)))` — floored where a slider row stops being usable, capped at the old value.
- The rail is `min(contentHeight + margins, paneHeight)` and centred, not full height. Its controls come to ~400 px; the rest was an opaque slab over nothing. Worst case on a 600×900 pane goes from 250×900 (42% of the pane) to 204×~420 (~10%).
- **The dock collapses while the rail is out**, even pinned, so the two can never sandwich the video. One-directional on purpose — a rail that depended on the dock in turn would make the two bindings a cycle.

Labels shortened to match (`Show saturation` → `Saturation`, `Apply LUT colormap` → `Colormap`, `Select recording ROI…` → `Recording ROI…`), with the dropped wording and the meaning of the icon-only `alpha`/`beta` sliders moved into tooltips. `UiSwitch` labels now elide like `UiButton`'s — the indicator alone is 40 px, so in a 150 px rail the label was being cut mid-word.

## Enable switches that got missed

> Even I have opened up that section, added in the com port, but forgot to toggle it on. Part of the issue might be that the toggle switch is all the way over to the right but the heading is all the way over to the left

Exactly right, and the bundled `Reference-AllOptions.json` ships that state: `commutator.port` = `COM3`, `commutator.enabled` = `false`.

The switch now sits immediately after the title — the subtitle moved to its own row underneath, since its wrapping full width was what pushed the switch to the far edge — states itself in words (*Enabled* / *Disabled*, itself a click target, since reading a small pill's position is the hard part), and a card that is **open but disabled** says so in its body:

```
Disabled — nothing here takes effect until you turn it on.   [Enable]
```

Open is exactly when someone is filling the settings in and about to forget the switch. The fields stay editable while it is off — the port has to be typed before enabling makes sense — so this nudges rather than blocks. All three switch-cards get it: Commutator, Trace display, Behavior tracker.

## Testing

12/12 pass on Windows. Every change bench-tested on a real three-device rig as it landed.

- `tst_sessionlifecycle::producersHeldUntilConsumerReady` — three playback cameras at 500 fps. Each takes ~0.5 s to construct, far longer than the first needs to fill 128 slots. Asserts no full-buffer message **and** that all three are acquiring afterwards, so a hold left permanently on fails too.
- `tst_sessionlifecycle::messageAlertExpires` — a warning raises the ring, an error outranks it, a later warning does not downgrade it, and expiry returns the border to normal while the counts survive.
- `tst_sessionlifecycle::videoWindowPanelsScaleToPane` — the three width regimes, the rail under 90% of the pane height, and the dock/rail exclusion including the pinned case.
- `tst_configform::enableSwitchSitsWithItsHeading` — drives the reference config's real failure case and measures the switch against **its title**, not the card width, so the assertion holds at any width.
- `tst_videostreambase::bufferFullWarningOncePerEpisode` — one message per episode, re-armed when the buffer drains.

All three behaviour changes were verified to fail before their fix:

```
FAIL!  : producersHeldUntilConsumerReady() '!line.contains("buffer is full")' returned FALSE.
         (a device streamed before the DataSaver existed: 16:45:32  Error: FastCamA frame buffer is full…)
FAIL!  : messageAlertExpires() Compared values are not the same     # count-driven border restored
```

Two test-harness notes for anyone extending these: an embedded pane's container owns its window geometry, so `view->setWidth()` does not stick and the shell item has to be driven directly; and `border.color` is a grouped property, so it needs `QQmlProperty::read`, not `QObject::property`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
