### PR TITLE
Add dual-color Miniscope device support

### DIFF
--- a/deviceConfigs/userConfigProps.json
+++ b/deviceConfigs/userConfigProps.json
@@ -299,6 +299,22 @@
                     "type": "Bool",
                     "tips": "When true, the led0 slider runs 0 to 255 and addresses every hardware step of the LED driver individually instead of 0 to 100 percent, giving 2.55x finer steps for very dim illumination. Both mappings span the same brightness range. Leave off (default) to keep the exact LED output of existing configs."
                 },
+                "led1": {
+                    "type": "Integer",
+                    "tips": "Initial intensity of the second excitation LED, on dual-color scopes only (Miniscope_V4_2C_Manual). Same 0 to 100 scale as led0. Ignored by single-LED devices."
+                },
+                "led1FineSteps": {
+                    "type": "Boolean",
+                    "tips": "The led1 equivalent of led0FineSteps: runs the second LED's slider 0 to 255 over the driver's individual hardware steps instead of 0 to 100 percent."
+                },
+                "optoPeriod": {
+                    "type": "Integer",
+                    "tips": "Optogenetic stimulation period in seconds, measured burst-start to burst-start. Only applies to scopes whose catalog entry declares it; no shipped entry does yet. 0 disables stimulation, which is the default; both optoPeriod and optoDuration must be non-zero before the scope emits any stimulation light."
+                },
+                "optoDuration": {
+                    "type": "Integer",
+                    "tips": "Length of each optogenetic burst, in camera frames. Only applies to scopes whose catalog entry declares it; no shipped entry does yet. The opto LED is lit only while the sensor is integrating, so the delivered pulse train follows the frame rate. 0 disables stimulation, which is the default."
+                },
                 "frameRate": {
                     "type": "String",
                     "tips": "This sets the initial FPS of the video device. Acceptable values usually go in increments of 5 between 10 and 30 and have the form of: \"20FPS\" for example."

--- a/deviceConfigs/userConfigSchema.json
+++ b/deviceConfigs/userConfigSchema.json
@@ -341,6 +341,27 @@
                             "type": "boolean",
                             "description": "When true, the led0 slider runs 0-255 and addresses the LED driver's 255 hardware steps individually instead of 0-100%, giving 2.55x finer steps - useful for very dim illumination. Both mappings span the same brightness range. Off by default: existing configs keep their exact LED output."
                         },
+                        "led1": {
+                            "type": "number",
+                            "minimum": 0,
+                            "description": "Second excitation LED power at startup on dual-color scopes (Miniscope_V4_2C_Manual), in the led1 slider's units (0-100 by default; 0-255 with led1FineSteps). Ignored by single-LED devices."
+                        },
+                        "led1FineSteps": {
+                            "type": "boolean",
+                            "description": "The led1 equivalent of led0FineSteps: runs the second LED's slider 0-255 over the driver's individual hardware steps instead of 0-100%."
+                        },
+                        "optoPeriod": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 255,
+                            "description": "Optogenetic stimulation period in seconds, burst-start to burst-start. Only applies to scopes whose catalog entry declares it; no shipped entry does yet. 0 disables stimulation and is the default; both optoPeriod and optoDuration must be non-zero before any stimulation light is emitted."
+                        },
+                        "optoDuration": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 255,
+                            "description": "Length of each optogenetic burst in camera frames. Only applies to scopes whose catalog entry declares it; no shipped entry does yet. 0 disables stimulation and is the default."
+                        },
                         "ewl": {
                             "type": "number",
                             "description": "Electrowetting lens (focus) starting value."

--- a/deviceConfigs/videoDevices.json
+++ b/deviceConfigs/videoDevices.json
@@ -661,6 +661,295 @@
 
         ]
     },
+    "Miniscope_V4_2C_Manual": {
+        "qmlFile": "qrc:/Miniscope_V4_BNO.qml",
+        "sensor": "PYTHON480",
+        "frameRate": "adjustable",
+        "width": 608,
+        "height": 608,
+        "pixelClock": 16.6,
+        "headOrientation": true,
+        "isColor": false,
+        "controlSettings": {
+            "gain": {
+                "displaySpinBoxValues": [
+                    "Low",
+                    "Medium",
+                    "High"
+                ],
+                "displayTextValues": [
+                    1,
+                    2,
+                    3.5
+                ],
+                "outputValues": [
+                    225,
+                    228,
+                    36
+                ],
+                "startValue": "Low",
+                "sendCommand": [
+                    {
+                        "protocol": "I2C",
+                        "addressW": "0b00100000",
+                        "regLength": "1",
+                        "reg0": "0x05",
+                        "dataLength": "4",
+                        "data0": "0x00",
+                        "data1": "0xCC",
+                        "data2": "valueH",
+                        "data3": "valueL"
+                    }
+                ]
+            },
+            "frameRate": {
+                "displaySpinBoxValues": [
+                    "2FPS",
+                    "5FPS",
+                    "10FPS",
+                    "15FPS",
+                    "20FPS",
+                    "25FPS",
+                    "30FPS"
+                ],
+                "displayTextValues": [
+                    2,
+                    5,
+                    10,
+                    15,
+                    20,
+                    25,
+                    30
+                ],
+                "outputValues": [
+                    50000,
+                    20000,
+                    10000,
+                    6667,
+                    5000,
+                    4000,
+                    3300
+                ],
+                "startValue": "20FPS",
+                "sendCommand": [
+                    {
+                        "protocol": "I2C",
+                        "addressW": "0b00100000",
+                        "regLength": "1",
+                        "reg0": "0x05",
+                        "dataLength": "4",
+                        "data0": "0x00",
+                        "data1": "0xC9",
+                        "data2": "valueH",
+                        "data3": "valueL"
+                    }
+                ]
+            },
+            "led0": {
+                "startValue": 0,
+                "min": 0,
+                "max": 100,
+                "stepSize": 1,
+                "displayValueScale": -2.55,
+                "displayValueOffset": -255,
+                "fineSteps": {
+                    "max": 255,
+                    "displayValueScale": -1
+                },
+                "sendCommand": [
+                    {
+                        "protocol": "I2C",
+                        "addressW": "0b00100000",
+                        "regLength": "1",
+                        "reg0": "0x01",
+                        "dataLength": "1",
+                        "data0": "value"
+                    },
+                    {
+                        "protocol": "I2C",
+                        "addressW": "0b01011000",
+                        "regLength": "1",
+                        "reg0": "0x00",
+                        "dataLength": "1",
+                        "data0": "value"
+                    }
+                ]
+            },
+            "led1": {
+                "startValue": 0,
+                "min": 0,
+                "max": 100,
+                "stepSize": 1,
+                "displayValueScale": -2.55,
+                "displayValueOffset": -255,
+                "fineSteps": {
+                    "max": 255,
+                    "displayValueScale": -1
+                },
+                "sendCommand": [
+                    {
+                        "protocol": "I2C",
+                        "addressW": "0b00100000",
+                        "regLength": "1",
+                        "reg0": "0x02",
+                        "dataLength": "1",
+                        "data0": "value"
+                    },
+                    {
+                        "protocol": "I2C",
+                        "addressW": "0b01011000",
+                        "regLength": "1",
+                        "reg0": "0x01",
+                        "dataLength": "1",
+                        "data0": "value"
+                    }
+                ]
+            },
+            "ewl": {
+                "startValue": 0,
+                "min": -127,
+                "max": 127,
+                "stepSize": 1,
+                "displayValueScale": 1,
+                "displayValueOffset": -127,
+                "sendCommand": [
+                    {
+                        "protocol": "I2C",
+                        "addressW": "0b11101110",
+                        "regLength": "1",
+                        "reg0": "0x08",
+                        "dataLength": "2",
+                        "data0": "value",
+                        "data1": "0x02"
+                    }
+                ]
+            }
+        },
+        "initialize": [
+            {
+                "description": "Speed up i2c bus timer to 50us max",
+                "protocol": "I2C",
+                "addressW": "0xC0",
+                "regLength": "1",
+                "reg0": "0x22",
+                "dataLength": "1",
+                "data0": "0b00000010"
+            },
+            {
+                "description": "Decrease BCC timeout, units in 2ms XX",
+                "protocol": "I2C",
+                "addressW": "0xC0",
+                "regLength": "1",
+                "reg0": "0x20",
+                "dataLength": "1",
+                "data0": "0b00001010"
+            },
+            {
+                "description": "Make sure DES has SER ADDR",
+                "protocol": "I2C",
+                "addressW": "0xC0",
+                "regLength": "1",
+                "reg0": "0x07",
+                "dataLength": "1",
+                "data0": "0xB0"
+            },
+            {
+                "description": "Speed up I2c bus timer to 50u Max",
+                "protocol": "I2C",
+                "addressW": "0xB0",
+                "regLength": "1",
+                "reg0": "0x0F",
+                "dataLength": "1",
+                "data0": "0b00000010"
+            },
+            {
+                "description": "Decrease BCC timeout, units in 2ms",
+                "protocol": "I2C",
+                "addressW": "0xB0",
+                "regLength": "1",
+                "reg0": "0x1E",
+                "dataLength": "1",
+                "data0": "0b00001010"
+            },
+            {
+                "description": "sets allowable i2c addresses to send through serializer",
+                "protocol": "I2C",
+                "addressW": "0xC0",
+                "regLength": "1",
+                "reg0": "0x08",
+                "dataLength": "4",
+                "device0": "MCU",
+                "data0": "0b00100000",
+                "device1": "EWL Driver",
+                "data1": "0b11101110",
+                "device2": "Digital Pot",
+                "data2": "0b10100000",
+                "device3": "BNO",
+                "data3": "0b01010000"
+            },
+            {
+                "description": "sets sudo allowable i2c addresses to send through serializer",
+                "protocol": "I2C",
+                "addressW": "0xC0",
+                "regLength": "1",
+                "reg0": "0x10",
+                "dataLength": "4",
+                "device0": "MCU",
+                "data0": "0b00100000",
+                "device1": "EWL Driver",
+                "data1": "0b11101110",
+                "device2": "Digital Pot Sudo",
+                "data2": "0b01011000",
+                "device3": "BNO",
+                "data3": "0b01010000"
+            },
+            {
+                "description": "Remap BNO axes, and sign",
+                "protocol": "I2C",
+                "addressW": "0b01010000",
+                "regLength": "1",
+                "reg0": "0x41",
+                "dataLength": "2",
+                "data0": "0b00001001",
+                "data1": "0b00000101"
+            },
+            {
+                "description": "Set BNO operation mode to NDOF",
+                "protocol": "I2C",
+                "addressW": "0b01010000",
+                "regLength": "1",
+                "reg0": "0x3D",
+                "dataLength": "1",
+                "data0": "0b00001100"
+            },
+            {
+                "description": "Enable BNO streaming in DAQ",
+                "protocol": "I2C",
+                "addressW": "0xFE",
+                "regLength": "1",
+                "reg0": "0x00",
+                "dataLength": "0"
+            },
+            {
+                "description": "Enable EWL Driver",
+                "protocol": "I2C",
+                "addressW": "0b11101110",
+                "regLength": "1",
+                "reg0": "0x03",
+                "dataLength": "1",
+                "data0": "0x03"
+            },
+            {
+                "description": "Set Mode: both excitation LEDs held on, under manual control",
+                "protocol": "I2C",
+                "addressW": "0b00100000",
+                "regLength": "1",
+                "reg0": "0x04",
+                "dataLength": "1",
+                "data0": "0x03"
+            }
+        ]
+    },
     "Miniscope_V3": {
         "qmlFile": "qrc:/Miniscope_V4_BNO.qml",
         "sensor": "MT9V032",

--- a/source/VideoWindowShell.qml
+++ b/source/VideoWindowShell.qml
@@ -28,9 +28,10 @@ import Miniscope.Theme 1.0
 //   root signals: takeScreenShotSignal, vidPropChangedSignal, dFFSwitchChanged,
 //     saturationSwitchChanged, lutSwitchChanged, setRoiClicked,
 //     addTraceRoiClicked, camPropsClicked
-//   objectNames: vD (VideoDisplay), gain / frameRate / led0 / ewl (control
-//     rows; C++ makes the catalog-defined ones visible and configures their
-//     ranges), saturationSwitch, lutSwitch, addTraceRoi, camProps, bno
+//   objectNames: vD (VideoDisplay), gain / frameRate / led0 / led1 /
+//     optoPeriod / optoDuration / ewl (control rows; C++ makes the
+//     catalog-defined ones visible and configures their ranges),
+//     saturationSwitch, lutSwitch, addTraceRoi, camProps, bno
 //   root properties: recording (pushed by VideoDevice on record start/stop)
 Item {
     id: root
@@ -321,7 +322,8 @@ Item {
         // width and making it transparent instead.
         readonly property bool hasControls:
             gainCtl.visible || frameRateCtl.visible || led0Ctl.visible
-            || led1Ctl.visible || ewlCtl.visible
+            || led1Ctl.visible || optoPeriodCtl.visible || optoDurationCtl.visible
+            || ewlCtl.visible
 
         width: hasControls ? (hwExpanded ? expandedWidth : collapsedWidth) : 0
         // Never taller than the pane (minus a margin); the ScrollView handles
@@ -401,6 +403,31 @@ Item {
                     iconPath: "img/icon/led.png"
                     onValueChangedSignal: (displayValue, i2cValue, i2cValue2) =>
                         root.vidPropChangedSignal("led1", displayValue, i2cValue, i2cValue2)
+                }
+                // Optogenetic burst timing. Wired up ahead of the catalog entry
+                // that will use them - no shipped device declares these yet, so
+                // both stay hidden. Raw byte values straight to the scope's MCU;
+                // 0 means stimulation off, so a catalog startValue of 0 disarms
+                // opto at connect.
+                VideoSliderControl {
+                    id: optoPeriodCtl
+                    objectName: "optoPeriod"
+                    visible: false
+                    Layout.fillWidth: true
+                    expanded: hwDock.hwExpanded
+                    iconPath: "img/icon/led.png"
+                    onValueChangedSignal: (displayValue, i2cValue, i2cValue2) =>
+                        root.vidPropChangedSignal("optoPeriod", displayValue, i2cValue, i2cValue2)
+                }
+                VideoSliderControl {
+                    id: optoDurationCtl
+                    objectName: "optoDuration"
+                    visible: false
+                    Layout.fillWidth: true
+                    expanded: hwDock.hwExpanded
+                    iconPath: "img/icon/led.png"
+                    onValueChangedSignal: (displayValue, i2cValue, i2cValue2) =>
+                        root.vidPropChangedSignal("optoDuration", displayValue, i2cValue, i2cValue2)
                 }
                 VideoSliderControl {
                     id: ewlCtl

--- a/source/backend.cpp
+++ b/source/backend.cpp
@@ -383,10 +383,13 @@ void backEnd::enrichDeviceDefaults(QJsonObject &device, const QString &category,
         device["ROI"] = roi;
     }
 
-    // Control settings (gain / frameRate / led0 / ewl): use the catalog's
-    // startValue for whichever ones this device template actually has.
+    // Control settings: use the catalog's startValue for whichever ones this
+    // device template actually has. led1 covers the dual-color scopes' second
+    // excitation LED. optoPeriod/optoDuration are wired up ahead of the opto
+    // catalog entry, so they seed correctly whenever one starts declaring them.
     const QJsonObject controls = cat.value("controlSettings").toObject();
-    const QStringList controlKeys = { "gain", "frameRate", "led0", "ewl" };
+    const QStringList controlKeys = { "gain", "frameRate", "led0", "led1",
+                                      "optoPeriod", "optoDuration", "ewl" };
     for (const QString &ck : controlKeys) {
         if (device.contains(ck) && controls.contains(ck)) {
             const QJsonValue sv = controls.value(ck).toObject().value("startValue");

--- a/tests/tst_configvalidator.cpp
+++ b/tests/tst_configvalidator.cpp
@@ -218,16 +218,31 @@ void TestConfigValidator::catalogFineStepsBlocksAreWellFormed()
         }
     }
 
-    // The shipped feature: both V4 variants carry the led0 mapping (0-255,
-    // one hardware step per tick on the inverted register).
-    for (const QString &devName : {QStringLiteral("Miniscope_V4"), QStringLiteral("Miniscope_V4_BNO")}) {
-        const QJsonObject fineSteps = catalog[devName].toObject()["controlSettings"]
-                                          .toObject()["led0"].toObject()["fineSteps"].toObject();
-        QVERIFY2(!fineSteps.isEmpty(), qPrintable(devName + " lost its led0 fineSteps block"));
+    // The shipped feature: every LED slider in the catalog carries the 0-255
+    // mapping (one hardware step per tick on the inverted register) - led0 on
+    // the single-LED V4 variants, and both LEDs on the dual-color scopes,
+    // whose second excitation LED runs the same driver through the other
+    // wiper of the same digital pot.
+    struct LedFineSteps { const char *device; const char *control; };
+    static const LedFineSteps expected[] = {
+        {"Miniscope_V4",           "led0"},
+        {"Miniscope_V4_BNO",       "led0"},
+        {"Miniscope_V4_2C_Manual", "led0"},
+        {"Miniscope_V4_2C_Manual", "led1"},
+    };
+    for (const LedFineSteps &led : expected) {
+        const QString where = QString::fromLatin1(led.device) + "/"
+                              + QString::fromLatin1(led.control);
+        const QJsonObject fineSteps =
+            catalog[QString::fromLatin1(led.device)].toObject()["controlSettings"]
+                .toObject()[QString::fromLatin1(led.control)].toObject()["fineSteps"].toObject();
+        QVERIFY2(!fineSteps.isEmpty(), qPrintable(where + " lost its fineSteps block"));
         QCOMPARE(fineSteps["max"].toDouble(), 255.0);
         QCOMPARE(fineSteps["displayValueScale"].toDouble(), -1.0);
     }
-    QCOMPARE(fineStepsBlocks, 2);
+    // Pinned against the list above rather than a literal, so adding an LED
+    // slider means adding it here too - a catalog-only edit still trips this.
+    QCOMPARE(fineStepsBlocks, int(sizeof(expected) / sizeof(expected[0])));
 }
 
 QTEST_MAIN(TestConfigValidator)


### PR DESCRIPTION
Feeds #95.

The device catalog has carried no dual-color scope since the Qt 6 port. The window shell has had a `led1` slider the whole time, but nothing declared the control, so C++ never made it visible or registered its I2C commands — the second excitation LED had no path to the hardware at all.

## The device

`Miniscope_V4_2C_Manual` — a PYTHON480 entry built on `Miniscope_V4_BNO` that holds both excitation LEDs on and lets each be set independently (`SET_MODE 0x03`, constant-LED).

It drives the LEDs the way the board is wired: the scope's MCU gates the two LTC3218 drivers' enable lines (regs `0x01`/`0x02`), while brightness comes from the TPL0102 dual digital pot the host writes directly (wiper `0x00` for LED1, `0x01` for LED2). That mapping is carried over from the pre-Qt6 `miniscopes.json` 2C entries rather than re-derived.

**Verified on hardware:** both LEDs independently controllable from the dock, against MCU firmware 0x12.

## What is deliberately not here

Frame-alternating (`0x02`) and optogenetic (`0x04`) variants are still being decided on, so no catalog entry ships for them. The dropdown lists every catalog key, so an entry becomes visible the moment it exists — leaving them out is the only way to keep them out of the UI.

The plumbing they need is in place and inert: `optoPeriod` and `optoDuration` exist as objectNames in `VideoWindowShell` and, with `led1`, join the `controlKeys` that `enrichDeviceDefaults` seeds startValues from. No shipped entry declares the opto pair, so both controls stay hidden and cost nothing at runtime. All four keys are documented in the user config schema and props.

The firmware already supports both modes, and its opto parameters are fail-safe (0 = disabled), so nothing stimulates without a catalog entry deliberately asking for it.

## Test change

Both of the new entry's LEDs carry the `led0` fineSteps mapping, which trips the count pinned in `catalogFineStepsBlocksAreWellFormed`. Rather than bump the literal, the test now lists every (device, control) pair that should carry the mapping, checks each one's contents, and derives the expected count from that list. A catalog-only edit still trips it, and the failure now names the offending pair.

## Firmware dependency

Needs MCU firmware **0x12 or newer** (`Miniscope-v4-Dual-Color/MCU-Firmware`), whose mode-aware LED gating is what makes both LEDs settable by hand. Older firmware refuses to drive ENT1 outside its sequencing modes, so the second LED stays dark.

## Testing

- `ctest`: **11/11 passing** (Release, Windows, Qt 6.11.1).
- `qmllint` on `VideoWindowShell.qml`: 49 warnings before and after, 0 syntax errors.
- Catalog JSON parses clean, no duplicate keys, indentation consistent with the rest of the file.
- Hardware-verified as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)