### PR TITLE
Make macOS builds shareable: pin the deployment target, and fix the macOS 15 launch docs

### DIFF
--- a/BUILD_MACOS.md
+++ b/BUILD_MACOS.md
@@ -99,12 +99,69 @@ plugins + QML into the `.app` with `macdeployqt`, ad-hoc signs it, and wraps
 it in a DMG. The release CI runs the same script, so a tagged release ships
 Windows + Linux + macOS together.
 
-**First launch on another Mac:** the bundle is ad-hoc signed, not notarized,
-so Gatekeeper warns about an unidentified developer. Right-click the app >
-Open > Open (needed once). If macOS claims the app "is damaged", clear the
-quarantine flag instead: `xattr -cr /Applications/MiniscopeDAQ.app`.
-Proper Developer ID signing + notarization can be added to the script later
-without changing anything else.
+**Minimum macOS is pinned to 12.0, deliberately.** `CMakeLists.txt` sets
+`CMAKE_OSX_DEPLOYMENT_TARGET` before `project()`. Without it AppleClang stamps
+the *build machine's* OS version into the binary as its minimum, so a DMG built
+on a new macOS is refused on every older one with "You can't use this version
+of the application with this version of macOS" — regardless of the
+`LSMinimumSystemVersion` in `Info.plist`, because LaunchServices goes by the
+Mach-O. That silently made shared builds unusable for anyone not on the
+builder's macOS version. 12.0 is the bundle's real floor (the highest `minos`
+across everything `macdeployqt` bundles) and matches `Info.plist.in`. Check a
+build with:
+
+```bash
+vtool -show-build build-dmg/MiniscopeDAQ.app/Contents/MacOS/MiniscopeDAQ | grep minos
+```
+
+Raising it requires updating `LSMinimumSystemVersion` in
+`packaging/macos/Info.plist.in` to match, so the plist and the binary keep
+agreeing.
+
+### First launch on someone else's Mac (bench-verified on macOS 15.7.8)
+
+The bundle is **ad-hoc signed, not notarized**, so Gatekeeper blocks it on any
+machine it is copied to. Anything that transfers the DMG — Slack, email, a
+browser download, AirDrop — tags it with the `com.apple.quarantine` flag, and
+that flag is what makes macOS refuse to launch it.
+
+**On macOS 15 (Sequoia) and newer there is no click-through escape.** Apple
+removed the old right-click > Open bypass, and the only remaining GUI route
+(System Settings > Privacy & Security > "Open Anyway") authenticates as an
+**admin** — a dead end for the typical lab member, who is not one. Clearing the
+flag from the terminal is the way through, and it needs no admin rights:
+
+```bash
+# Wherever the app ended up (~/Applications, ~/Desktop, /Applications, ...):
+xattr -dr com.apple.quarantine ~/Applications/MiniscopeDAQ.app
+
+# MUST print nothing. If it still lists quarantine lines, the removal failed.
+xattr -r -l ~/Applications/MiniscopeDAQ.app | grep quarantine
+```
+
+Then open the app normally. Once the flag is gone it stays gone; moving the
+app afterwards does not re-apply it.
+
+Notes, so nothing here looks alarming:
+
+- **`spctl -a -t exec <app>` keeps reporting `rejected`, and that is expected.**
+  It reports what Gatekeeper *would* assess, and an unnotarized app always
+  fails that assessment. The launch gate is the quarantine flag, not `spctl`:
+  with the flag cleared macOS stops consulting Gatekeeper at all. Do not read
+  `rejected` as "the fix did not work" — the test is whether the app opens.
+- Moving or dragging the app does **not** clear quarantine. Only removing the
+  attribute does. A drag to another folder on its own changes nothing.
+- `xattr -dr com.apple.quarantine` is preferred over `xattr -cr`, which strips
+  *every* extended attribute rather than just the quarantine flag.
+- If macOS instead says the app "is damaged", that is the same quarantine flag
+  — the command above is still the fix.
+
+**This is the cost of ad-hoc signing, not a bug in the build**, and every person
+the DMG is shared with hits it. Proper Developer ID signing + notarization
+removes it permanently (signed builds just open: no terminal, no admin, no
+quarantine step). That needs an Apple Developer Program membership; the ad-hoc
+`codesign` step in `packaging/macos/build-dmg.sh` can be swapped for it without
+changing anything else in the pipeline.
 
 **iPhone / Continuity Camera interference (bench-verified):** a nearby iPhone
 joins the Mac's camera list via Continuity Camera and macOS actively promotes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,23 @@
 # ---------------------------------------------------------------------------
 cmake_minimum_required(VERSION 3.21)
 
+# macOS: pin the deployment target. Without it AppleClang stamps the BUILD
+# machine's OS version into the binary as its MINIMUM, so a DMG built on a new
+# macOS is refused by LaunchServices on any older one with "You can't use this
+# version of the application with this version of macOS" - even though
+# Info.plist.in declares LSMinimumSystemVersion 12.0. That made shared builds
+# silently unusable for anyone not on the builder's macOS version.
+# Must be set BEFORE project(), which is when the compiler is probed.
+# Keep in step with LSMinimumSystemVersion in packaging/macos/Info.plist.in.
+# Tested with `NOT <var>` rather than `NOT DEFINED <var>`: CMake pre-defines
+# this as an EMPTY cache entry on Apple, so `NOT DEFINED` would be false and
+# never fire. An explicit -DCMAKE_OSX_DEPLOYMENT_TARGET=... is non-empty and
+# still wins.
+if(APPLE AND NOT CMAKE_OSX_DEPLOYMENT_TARGET)
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "12.0"
+        CACHE STRING "Minimum macOS version the build must run on")
+endif()
+
 project(MiniscopeDAQ VERSION 2.0.0 LANGUAGES CXX)
 
 # OFF by default: the embedded-Python DLC-Live tracker is used by very few


### PR DESCRIPTION
Both commits come from one real failure: a lab member on an M3 / macOS 15.7.8 could not open a DMG built here. Two separate walls, one after the other.

## 1. Pin the macOS deployment target

Her first error:

> You can't use this version of the application with this version of macOS

Nothing set `CMAKE_OSX_DEPLOYMENT_TARGET`, so AppleClang stamps the **build machine's** OS version into the Mach-O as the binary's *minimum*. The bundle declared `LSMinimumSystemVersion` 12.0 in `Info.plist`, but the Mach-O underneath demanded 26.0 — and LaunchServices goes by the Mach-O, not the plist.

Measured on the built app:

```
minos 26.0   (before)
minos 12.0   (after)
```

**Not limited to hand-built DMGs.** The release CI builds the macOS DMG on `macos-latest` with no target pinned either, so every published macOS DMG has carried whatever the runner's macOS happened to be, silently unusable below it. That's the main reason this belongs upstream.

**Why 12.0** — it's the bundle's actual floor, not a guess. Highest `minos` across everything `macdeployqt` bundles:

| Component | `minos` |
|---|---|
| 61 bundled dylibs | 12.0 |
| 299 bundled dylibs | 11.0 |
| All Qt plugins | 11.0 |
| conda-forge Qt 6.11.1 | 11.0 |

Max is exactly 12.0, matching the `LSMinimumSystemVersion` already in `Info.plist.in` — so plist and binary now agree instead of contradicting each other.

Two easy-to-get-wrong details, both commented in the diff:

- **Set before `project()`**, which is when CMake probes the compiler. Setting it afterwards is silently ignored.
- **`NOT <var>`, not `NOT DEFINED <var>`.** CMake pre-defines this as an *empty* cache entry on Apple, so `NOT DEFINED` is false and the block would never fire. An explicit `-D` override is non-empty and still wins.

## 2. Fix the macOS 15 launch instructions

With the version gate cleared she hit Gatekeeper, and `BUILD_MACOS.md` sent her down a path that no longer exists: it led with right-click > Open, **which Apple removed in macOS 15 (Sequoia)**. The only GUI route left — System Settings > Privacy & Security > "Open Anyway" — authenticates as an **admin**, which she isn't. Following the docs was a dead end.

Rewritten around what actually works and needs no admin: clear the `com.apple.quarantine` flag the transfer (Slack, in this case) applied. Verified end-to-end on her machine.

The section also records the parts that cost real diagnostic time:

- **Moving or dragging the app does not clear quarantine.** Only removing the attribute does — "I dragged it to the Desktop" changes nothing. This sent us down a wrong path for a round.
- **`spctl` still reports `rejected` afterwards, and that's expected.** An unnotarized app always fails that assessment; the launch gate is the quarantine flag, not `spctl`. Without this note, `rejected` reads as "the fix didn't work."
- Prefer `xattr -dr com.apple.quarantine` over `xattr -cr`, which strips every extended attribute rather than just the flag.
- Verify with a grep that **must print nothing** — silent failure here is indistinguishable from success until the app refuses to open again.

Plus a note on why the deployment target is pinned to 12.0, so the CMake block from commit 1 doesn't get "cleaned up" later and quietly reintroduce the first failure, with the `vtool` one-liner to check a build.

## Verification

- Clean DMG rebuild (`rm -rf build-dmg dist` — a stale CMake cache retains the old target), confirmed on the shipped artifact inside the mounted DMG: `minos 12.0`, `sdk 26.5`, ad-hoc signature verifies, no build-machine paths leaked into any bundled binary.
- The documented `xattr` procedure was confirmed working on the affected macOS 15.7.8 machine — the app opens.

Not verified: a launch on macOS 12 or 13 specifically. `minos` is what the OS gates on, so this should be conclusive, but a real run on an older macOS is the only true proof and is worth having before the next release tag.

## Not addressed here

The underlying cause of section 2 is that the app **isn't notarized**, and macOS 15 removed the click-through escape that used to make ad-hoc builds shareable. Every recipient hits this, and every workaround is terminal gymnastics a lab member shouldn't need. Developer ID signing + notarization fixes it permanently; the ad-hoc `codesign` step in `build-dmg.sh` can be swapped for it without touching the rest of the pipeline. Out of scope for this PR, but it's the durable fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFED97LVqUze521U9N7PYB