### PR TITLE
Actually apply the macOS deployment target in existing build trees

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,9 +27,16 @@ cmake_minimum_required(VERSION 3.21)
 # this as an EMPTY cache entry on Apple, so `NOT DEFINED` would be false and
 # never fire. An explicit -DCMAKE_OSX_DEPLOYMENT_TARGET=... is non-empty and
 # still wins.
+# FORCE is required, and is safe BECAUSE of the guard above it: CMake seeds
+# this as an empty cache entry on Apple, and a plain `set(... CACHE ...)` will
+# not overwrite an entry that already exists - so without FORCE this silently
+# did nothing in any build tree configured earlier, and only fresh ones got the
+# fix. The guard means FORCE only ever replaces an EMPTY value; an explicit
+# -DCMAKE_OSX_DEPLOYMENT_TARGET=... is non-empty, fails the guard, and is left
+# alone.
 if(APPLE AND NOT CMAKE_OSX_DEPLOYMENT_TARGET)
     set(CMAKE_OSX_DEPLOYMENT_TARGET "12.0"
-        CACHE STRING "Minimum macOS version the build must run on")
+        CACHE STRING "Minimum macOS version the build must run on" FORCE)
 endif()
 
 project(MiniscopeDAQ VERSION 2.0.0 LANGUAGES CXX)


### PR DESCRIPTION
Follow-up to #120. That fix only worked in **fresh** build directories — I caught this while verifying the merge, and it's my miss in the original PR.

## The gap

CMake seeds `CMAKE_OSX_DEPLOYMENT_TARGET` as an **empty cache entry** on Apple, and `set(... CACHE ...)` without `FORCE` will not overwrite a cache entry that already exists. So in any build tree configured before #120 landed, the guard passed, the `set()` ran, and the empty value stayed put.

Measured in this repo's own `build/` right after merging #120:

```
CMAKE_OSX_DEPLOYMENT_TARGET:STRING=      (still empty)
minos 26.0                               (still wrong)
```

**Why #120's verification missed it:** `build-dmg.sh` is run after `rm -rf build-dmg`, so it always configures from scratch — the one path that happened to work. Every existing developer checkout, and any CI that caches its build directory, would have kept producing binaries stamped with the build machine's OS version, which is exactly the failure #120 set out to fix.

## The fix

Add `FORCE`. It's safe *because* of the guard that's already there: the block only runs when the value is empty, so `FORCE` can only ever replace an empty value. An explicit `-DCMAKE_OSX_DEPLOYMENT_TARGET=...` is non-empty, fails the guard, and is never touched.

## Verification

Tested both directions, since `FORCE` is the kind of thing that quietly stomps user intent:

| Case | Result |
|---|---|
| Pre-existing `build/` stuck at empty / `minos 26.0` | reconfigure → cache `12.0`, rebuilt binary `minos 12.0` |
| Fresh configure with `-DCMAKE_OSX_DEPLOYMENT_TARGET=13.0` | stays `13.0` |
| That same tree reconfigured again | still `13.0` — `FORCE` does not clobber it |
| `ctest` | 14/14 green |

## Note for anyone with an existing checkout

Merging this is not enough on its own — you need to **reconfigure** for the cache to pick it up:

```bash
cmake -B build -S .        # rewrites the cached value to 12.0
cmake --build build
vtool -show-build build/MiniscopeDAQ.app/Contents/MacOS/MiniscopeDAQ | grep minos
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFED97LVqUze521U9N7PYB