### PR TITLE
Show only real capture devices in the Linux device scan and ID list

### DIFF
--- a/source/AddDeviceDialog.qml
+++ b/source/AddDeviceDialog.qml
@@ -57,12 +57,21 @@ Dialog {
         detectedDevices = backend.scanVideoDevices();
     }
 
-    // Keep OK disabled until the name is usable (backend.addDevice also guards,
-    // but a silently-refused Add looked like nothing happened at all).
+    // True when there is no ID left to assign, i.e. every detected device is
+    // already in the config. The dropdown offers only detected devices, so it
+    // can legitimately come up empty - and then there is no ID to add under
+    // (deviceID would silently fall back to 0, which is likely already taken).
+    readonly property bool noFreeDeviceID: idCombo.model.length === 0
+
+    // Keep OK disabled until the name is usable and an ID is actually selected
+    // (backend.addDevice also guards, but a silently-refused Add looked like
+    // nothing happened at all).
     Component.onCompleted: {
         var ok = control.standardButton(Dialog.Ok);
         if (ok)
-            ok.enabled = Qt.binding(function () { return control.nameProblem.length === 0; });
+            ok.enabled = Qt.binding(function () {
+                return control.nameProblem.length === 0 && !control.noFreeDeviceID;
+            });
     }
 
     GridLayout {
@@ -117,8 +126,13 @@ Dialog {
         Text {
             objectName: "deviceNameProblem"
             Layout.fillWidth: true
-            visible: control.nameProblem.length > 0
-            text: "⚠ " + control.nameProblem
+            visible: control.noFreeDeviceID || control.nameProblem.length > 0
+            // The missing-ID case wins: no ID means Add can't work at all, so
+            // saying that is more use than naming a fixable name clash.
+            text: "⚠ " + (control.noFreeDeviceID
+                          ? "Every detected device is already in the config. "
+                            + "Connect another camera, or use Scan Devices to check what is detected."
+                          : control.nameProblem)
             font: Theme.fontSmall
             color: Theme.warning
             wrapMode: Text.WordWrap

--- a/source/backend.cpp
+++ b/source/backend.cpp
@@ -548,7 +548,8 @@ bool backEnd::addDevice(const QString &category, const QString &deviceType,
 
 // Public entry (wired to the "Scan Devices" button): dispatch to the OS-specific
 // scan at compile time. Each backend builds its own report because the device
-// model differs (DirectShow index on Windows vs V4L2 capture/metadata nodes).
+// model differs (DirectShow/AVFoundation list index on Windows and macOS vs
+// V4L2 node number on Linux).
 QString backEnd::scanVideoDevices()
 {
 #if defined(Q_OS_WINDOWS)
@@ -564,8 +565,8 @@ QString backEnd::scanVideoDevices()
 
 #if defined(Q_OS_WINDOWS) || defined(Q_OS_MACOS)
 // Shared Scan-Devices report for the platforms whose enumerator returns a
-// plain name list whose position == the config deviceID (Linux formats its
-// own richer capture-vs-metadata report).
+// plain name list whose position == the config deviceID (Linux keys its report
+// by V4L2 node number instead, so it formats its own).
 static QString formatDeviceScan(const QStringList &names, const QString &trailerNote)
 {
     if (names.isEmpty())
@@ -630,13 +631,15 @@ QString backEnd::scanVideoDevicesWindows()
 }
 
 #elif defined(Q_OS_LINUX)
-QString backEnd::scanVideoDevicesLinux()
+// Connected V4L2 capture nodes as {deviceID -> name}. A single physical UVC
+// camera usually exposes two /dev/videoN nodes - one for video capture and one
+// for metadata - and only the capture node can ever stream, so the metadata
+// nodes are dropped here instead of being listed as unusable. Keyed by node
+// number because that IS the deviceID on Linux, and it is sparse once the
+// metadata nodes are gone (a lone camera can well be /dev/video2).
+QMap<int, QString> backEnd::enumerateVideoDevicesLinux()
 {
-    // Enumerate /dev/videoN via V4L2. Each physical UVC camera usually exposes
-    // two nodes (a capture node and a metadata node), so we query each node's
-    // capabilities and mark which one to use as the deviceID.
-    struct Node { int id; QString name; bool capture; };
-    QVector<Node> nodes;
+    QMap<int, QString> devices;   // QMap iterates in ascending key order
 
     QDir v4lDir(QStringLiteral("/sys/class/video4linux"));
     const QStringList entries = v4lDir.entryList(QStringList() << QStringLiteral("video*"),
@@ -647,13 +650,7 @@ QString backEnd::scanVideoDevicesLinux()
         if (!ok)
             continue;
 
-        // Human-readable name from sysfs.
-        QString name;
-        QFile nameFile(QStringLiteral("/sys/class/video4linux/%1/name").arg(entry));
-        if (nameFile.open(QIODevice::ReadOnly | QIODevice::Text))
-            name = QString::fromUtf8(nameFile.readLine()).trimmed();
-
-        // Capture capability via VIDIOC_QUERYCAP.
+        // Capture capability via VIDIOC_QUERYCAP; skip metadata/other nodes.
         bool isCapture = false;
         const QString devPath = QStringLiteral("/dev/%1").arg(entry);
         const int fd = ::open(devPath.toLocal8Bit().constData(), O_RDONLY | O_NONBLOCK);
@@ -666,25 +663,31 @@ QString backEnd::scanVideoDevicesLinux()
             }
             ::close(fd);
         }
-        nodes.append({id, name.isEmpty() ? QStringLiteral("(unknown)") : name, isCapture});
+        if (!isCapture)
+            continue;
+
+        // Human-readable name from sysfs.
+        QString name;
+        QFile nameFile(QStringLiteral("/sys/class/video4linux/%1/name").arg(entry));
+        if (nameFile.open(QIODevice::ReadOnly | QIODevice::Text))
+            name = QString::fromUtf8(nameFile.readLine()).trimmed();
+
+        devices.insert(id, name.isEmpty() ? QStringLiteral("(unknown)") : name);
     }
+    return devices;
+}
 
-    if (nodes.isEmpty())
-        return QStringLiteral("No video devices detected (no /dev/video* nodes).");
-
-    std::sort(nodes.begin(), nodes.end(), [](const Node &a, const Node &b){ return a.id < b.id; });
+QString backEnd::scanVideoDevicesLinux()
+{
+    const QMap<int, QString> devices = enumerateVideoDevicesLinux();
+    if (devices.isEmpty())
+        return QStringLiteral("No video devices detected (no capture-capable /dev/video* nodes).");
 
     QStringList lines;
-    for (const Node &n : nodes)
-        lines << QString("    deviceID %1:  %2  %3")
-                     .arg(n.id)
-                     .arg(n.name)
-                     .arg(n.capture ? QStringLiteral("[capture - use this]")
-                                    : QStringLiteral("[metadata/other - not usable]"));
+    for (auto it = devices.cbegin(); it != devices.cend(); ++it)
+        lines << QString("    deviceID %1:  %2").arg(it.key()).arg(it.value());
     return QStringLiteral("Detected video devices:\n") + lines.join("\n")
-           + QStringLiteral("\n\nUse the [capture] deviceID for each device in your user "
-                            "config. A single camera often lists two nodes; only the "
-                            "[capture] one streams video.");
+           + QStringLiteral("\n\nUse these deviceID numbers in your user config.");
 }
 #elif defined(Q_OS_MACOS)
 // One line per AVFoundation camera; the list position IS the OpenCV
@@ -722,6 +725,24 @@ QStringList backEnd::availableDeviceIDs()
         for (const QString &n : devNames)
             used << section.value(n).toObject().value("deviceID").toInt();
     }
+
+#if defined(Q_OS_LINUX)
+    // The deviceID is the /dev/videoN node number here, so offer exactly the
+    // capture nodes actually present - each labelled with its name - instead of
+    // a synthetic 0..15 range that mostly maps to nothing.
+    const QMap<int, QString> detected = enumerateVideoDevicesLinux();
+    if (!detected.isEmpty()) {
+        QStringList out;
+        for (auto it = detected.cbegin(); it != detected.cend(); ++it) {
+            if (used.contains(it.key()))
+                continue;
+            out << QString("%1  (%2)").arg(it.key()).arg(it.value());
+        }
+        return out;
+    }
+    // Nothing enumerated (e.g. no read access to /dev/video*): fall through to
+    // the generic range so a device can still be added by hand.
+#endif
 
     // One entry per connected device (fall back to 0..15 if none detected), and
     // always at least one ID past the highest used so the list is never empty.

--- a/source/backend.h
+++ b/source/backend.h
@@ -8,6 +8,7 @@
 #include <QThread>
 #include <QString>
 #include <QStringList>
+#include <QMap>
 #include <QUrl>
 
 #include "miniscope.h"
@@ -333,6 +334,12 @@ private:
     // deviceID (order == the OpenCV backend's index: DirectShow on Windows,
     // AVFoundation on macOS) and is also used by availableDeviceIDs().
     QStringList enumerateVideoDevices();
+    // Linux can't use that "index == deviceID" form: there the deviceID is the
+    // V4L2 node number itself (/dev/video2 -> deviceID 2), which is sparse once
+    // the non-capture nodes are skipped. So the Linux enumerator returns
+    // {deviceID -> name} for capture-capable nodes only, and likewise feeds both
+    // scanVideoDevicesLinux() and availableDeviceIDs().
+    QMap<int, QString> enumerateVideoDevicesLinux();
     QString scanVideoDevicesWindows();
     QString scanVideoDevicesLinux();
     QString scanVideoDevicesMac();


### PR DESCRIPTION
On Linux a single UVC camera registers two `/dev/videoN` nodes — one for video capture and one for metadata — so **Scan Devices** listed every device twice, half of them tagged `[metadata/other - not usable]`. A Miniscope DAQ is worse: it exposes four nodes, only two of which can stream.

On the test machine (Ubuntu 24.04, V4 Miniscope + USB webcam) the scan listed **six** devices where there are three usable ones:

| node | card | capability | after this PR |
|---|---|---|---|
| video0 | USB2.0 HD UVC WebCam | capture | kept |
| video1 | USB2.0 HD UVC WebCam | metadata | dropped |
| video2 | MINISCOPE | capture | kept |
| video3 | MINISCOPE | metadata | dropped |
| video4 | MINISCOPE | capture | kept |
| video5 | MINISCOPE | metadata | dropped |

## The ID dropdown had a related, larger problem

`availableDeviceIDs()` only populated its name list under `#if defined(Q_OS_WINDOWS) || defined(Q_OS_MACOS)`, so on Linux it always fell through to the synthetic `0..15` fallback — sixteen bare numbers, at most a couple of which mapped to a real device.

It could not do better, because the "index in the list == the deviceID" contract those platforms rely on does not hold on Linux: there the deviceID is the V4L2 node number itself (`/dev/video2` → deviceID 2), and it is sparse once the metadata nodes are skipped.

## What changed

- Factor the Linux enumeration out as `enumerateVideoDevicesLinux()`, returning `{deviceID -> name}` for capture-capable nodes only, and feed both the scan report and the dropdown from it. Capture detection is unchanged (`VIDIOC_QUERYCAP`, preferring `device_caps` when `V4L2_CAP_DEVICE_CAPS` is set); the non-capture nodes are now skipped rather than listed as unusable.
- The dropdown now offers exactly the detected devices, each labelled with its name (e.g. `2  (MINISCOPE)`). `QMap` keeps them in ascending ID order, replacing the explicit sort.
- Windows and macOS paths are untouched.

## One behavioural edge worth reviewing

Offering only detected devices makes an **empty** dropdown possible for the first time — when every detected device is already in the config. `deviceID` would then silently fall back to `0` (likely already taken), so OK is now gated on having an ID selected, and the existing "why OK is disabled" line explains it. If enumeration turns up nothing at all (e.g. no read access to `/dev/video*`), it falls through to the old generic range so a device can still be added by hand.

## Testing

- Built Release with the `environment.yml` conda env (Qt 6.11.1, `USE_PYTHON=OFF`); no new compiler warnings.
- Full suite passes: **11/11**.
- Capture-vs-metadata classification verified against the attached hardware with a standalone program mirroring the patch's ioctl logic — results in the table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)