### PR TITLE
Bundle fontconfig so the AppImage starts on older distros

### DIFF
--- a/packaging/linux/build-appimage.sh
+++ b/packaging/linux/build-appimage.sh
@@ -64,10 +64,14 @@ export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:${LD_LIBRARY_PATH:-}"
       --icon-file "$APPDIR/usr/share/icons/hicolor/256x256/apps/miniscope-daq.png" \
       --plugin qt
 
-echo "### bundle transitive deps linuxdeploy excludes (OpenCV BLAS, libusb)"
+echo "### bundle transitive deps linuxdeploy excludes (OpenCV BLAS, libusb, fontconfig)"
 CONDA_LIB="$CONDA_PREFIX/lib"
+# NB the executable is still called MiniscopeDAQ at this point - it only becomes
+# MiniscopeDAQ.bin when the launcher wrapper is installed further down. Naming
+# the .bin here silently skipped the main binary, so this only ever scanned
+# usr/lib and never the executable's own dependencies.
 for _ in 1 2 3 4 5; do
-    missing=$(for f in "$APPDIR"/usr/lib/*.so* "$APPDIR"/usr/bin/MiniscopeDAQ.bin; do
+    missing=$(for f in "$APPDIR"/usr/lib/*.so* "$APPDIR"/usr/bin/MiniscopeDAQ; do
                 LD_LIBRARY_PATH="$APPDIR/usr/lib" ldd "$f" 2>/dev/null
               done | awk '/not found/{print $1}' | sort -u || true)
     [ -z "$missing" ] && break
@@ -77,6 +81,38 @@ for _ in 1 2 3 4 5; do
     done
 done
 cp -L "$CONDA_LIB/libusb-1.0.so.0" "$APPDIR/usr/lib/" 2>/dev/null || true
+
+# The loop above only recovers libraries ldd reports as "not found". A library
+# that IS present on the user's system but is OLDER than the one our bundled libs
+# were linked against is invisible to it, and fails at runtime instead:
+#
+#   MiniscopeDAQ.bin: symbol lookup error: .../libpangoft2-1.0.so.0:
+#       undefined symbol: FcConfigSetDefaultSubstitute
+#
+# linuxdeploy excludes libfontconfig as a "system library", but the conda-forge
+# pango we bundle (1.56.x) needs fontconfig >= 2.16 symbols, while Ubuntu 24.04
+# ships 2.15. Bundling pango without its matching fontconfig cannot work, so
+# bundle fontconfig too.
+cp -L "$CONDA_LIB/libfontconfig.so.1" "$APPDIR/usr/lib/" 2>/dev/null || true
+
+echo "### verify the bundle has no unresolved symbols"
+# Catches the version-mismatch class of bug above at build time instead of on a
+# user's machine. Resolve libraries the way the app will: bundled dir first.
+unresolved=""
+for f in "$APPDIR"/usr/lib/*.so* "$APPDIR"/usr/bin/MiniscopeDAQ; do
+    [ -f "$f" ] || continue
+    out=$(LD_LIBRARY_PATH="$APPDIR/usr/lib" ldd -r "$f" 2>&1 || true)
+    if grep -q "undefined symbol" <<<"$out"; then
+        unresolved+="  $(basename "$f")"$'\n'
+        unresolved+="$(grep 'undefined symbol' <<<"$out" | sed 's/^/    /' | head -5)"$'\n'
+    fi
+done
+if [ -n "$unresolved" ]; then
+    printf 'ERROR: unresolved symbols in the bundle. A bundled library needs a\n' >&2
+    printf '       newer system library than the host provides - bundle it too:\n' >&2
+    printf '%s' "$unresolved" >&2
+    exit 1
+fi
 
 echo "### install first-run launcher wrapper"
 mv "$APPDIR/usr/bin/MiniscopeDAQ" "$APPDIR/usr/bin/MiniscopeDAQ.bin"


### PR DESCRIPTION
The published Linux AppImage **does not launch on Ubuntu 24.04**. It dies before any window appears, exit 127:

```
MiniscopeDAQ.bin: symbol lookup error: .../usr/lib/libpangoft2-1.0.so.0:
    undefined symbol: FcConfigSetDefaultSubstitute
```

## Why

We bundle conda-forge pango, whose `libpangoft2` imports `FcConfigSetDefaultSubstitute` — a fontconfig ≥ 2.16 symbol. But linuxdeploy excludes `libfontconfig` as a "system library", so at runtime it resolves against the host's copy:

| | version | exports `FcConfigSetDefaultSubstitute` |
|---|---|---|
| bundled `libpangoft2` (conda-forge pango 1.56.4) | — | imports it |
| bundled `libfontconfig` | *not bundled* | — |
| Ubuntu 24.04 `libfontconfig.so.1` | 2.15.0 (`.so.1.12.1`) | **no** |
| conda-forge `libfontconfig.so.1` | 2.17.0 | yes |

Bundling pango without a matching fontconfig cannot work. So bundle fontconfig too, next to the existing `libusb` line.

## The existing recovery loop could not have caught this

It only rescues libraries `ldd` reports as `not found`. A library that is *present but too old* looks perfectly fine to it — which is exactly why this shipped.

So this also adds a build-time gate that resolves every bundled library and the executable the way the app will (bundled dir first) and fails the build on any unresolved symbol. That turns this class of bug into a red CI run instead of a broken download.

## Drive-by fix in the same loop

The loop scanned `usr/bin/MiniscopeDAQ.bin`, but the executable is only renamed to `.bin` further down, when the launcher wrapper is installed. So the path never existed at that point and the loop silently skipped the main binary, only ever scanning `usr/lib`. Now corrected to `usr/bin/MiniscopeDAQ`.

In practice this pulled in **no** new libraries — verified by diffing the bundle against a CI-built AppImage — so it's a correctness fix for future cases rather than a change in output.

## Testing

Ran this script end to end on Ubuntu 24.04 (Qt 6.11.1, `USE_PYTHON=OFF`):

- All stages pass; the new gate reports nothing.
- The resulting AppImage **launches**, and `/proc/<pid>/maps` shows `libfontconfig.so.1` resolved from inside the mounted bundle, with no system copy loaded.
- Bundled library set is otherwise identical to a CI build (only version bumps of jxl/openjph/openvino, from a newer conda env).

For contrast, the current CI-built 2.0.0 AppImage fails on the same machine with the error above; adding only this library to that bundle and repacking it makes it start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)