### PR TITLE
Fail loudly when a build tool doesn't download

### DIFF
--- a/packaging/linux/build-appimage.sh
+++ b/packaging/linux/build-appimage.sh
@@ -39,8 +39,54 @@ echo "### fetch linuxdeploy + qt plugin (cached in $TOOLS)"
 mkdir -p "$TOOLS"
 LD="$TOOLS/linuxdeploy-x86_64.AppImage"
 LDQT="$TOOLS/linuxdeploy-plugin-qt-x86_64.AppImage"
-[ -f "$LD" ]   || curl -sSL -o "$LD"   "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
-[ -f "$LDQT" ] || curl -sSL -o "$LDQT" "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage"
+
+# An AppImage starts with the ELF magic. Anything else (an HTML/text error page,
+# a truncated download) is not a tool we can run.
+is_elf() {
+    [ -f "$1" ] || return 1
+    [ "$(head -c4 "$1" 2>/dev/null | od -An -tx1 | tr -d ' \n')" = "7f454c46" ]
+}
+
+# Fetch a tool unless a VALID copy is already cached.
+#
+# curl needs --fail here. Without it an HTTP error response is written to the
+# output file and curl still exits 0, so a transient 404 on the "continuous"
+# rolling release got chmod +x'd and executed, failing much later and very
+# confusingly with:
+#
+#   .../linuxdeploy-x86_64.AppImage: line 1: Not: command not found
+#
+# The ELF check then covers the rest: a cache poisoned before this guard existed
+# (locally that file is reused forever, since only its existence was checked), a
+# truncated download, or an error page served with a 200.
+fetch_tool() {
+    local path="$1" url="$2" name
+    name="$(basename "$path")"
+    if is_elf "$path"; then
+        echo "    $name: cached"
+        return 0
+    fi
+    if [ -e "$path" ]; then
+        echo "    $name: cached copy is not an executable, refetching"
+    fi
+    rm -f "$path"
+    if ! curl -sSL --fail --retry 3 --retry-delay 5 -o "$path" "$url"; then
+        rm -f "$path"
+        echo "ERROR: could not download $name from $url" >&2
+        exit 1
+    fi
+    if ! is_elf "$path"; then
+        echo "ERROR: $name from $url is not an executable. It starts with:" >&2
+        head -c 200 "$path" >&2
+        echo >&2
+        rm -f "$path"
+        exit 1
+    fi
+    echo "    $name: downloaded"
+}
+
+fetch_tool "$LD"   "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
+fetch_tool "$LDQT" "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage"
 chmod +x "$LD" "$LDQT"
 
 echo "### stage AppDir"


### PR DESCRIPTION
The Linux CI job [failed](https://github.com/Aharoni-Lab/Miniscope-DAQ-QT-Software/actions/runs/30674584931) while bundling Qt, with an error that points nowhere near the real cause:

```
.../build-appimage/tools/linuxdeploy-x86_64.AppImage: line 1: Not: command not found
Process completed with exit code 127
```

## What actually happened

We fetch linuxdeploy from a `continuous` rolling release tag, and that URL had momentarily 404'd. `curl -sSL` without `--fail` writes the HTTP error response into the output file and **still exits 0**:

```console
$ curl -sSL -o /tmp/demo ".../continuous/nonexistent-file.AppImage"; echo "rc=$?"
rc=0
$ head -c 40 /tmp/demo
Not Found
```

So the two-word body `Not Found` landed where the tool should be, got `chmod +x`'d, and was executed as a shell script — producing that message two stages after the thing that went wrong. Both URLs return 200 again now, so nothing upstream is broken; it will simply recur.

## The fix

- `--fail`, so an HTTP error is an error instead of file content.
- `--retry 3 --retry-delay 5`, since a rolling tag can 404 while it is being republished — precisely this failure.
- Verify the result is an ELF executable before using it. That additionally covers an error page served with a 200 and a truncated download.

The ELF check matters most **locally**. The old guard was `[ -f "$LD" ] || curl ...`, testing only existence — so a poisoned file in a working tree is reused forever, and every build fails with `Not: command not found` until someone thinks to delete it by hand. Now it is spotted and refetched.

## Testing

Each path exercised directly:

| case | result |
|---|---|
| planted `Not Found` file in the cache | detected, refetched, succeeds |
| valid cached copy | reused, no download attempted |
| URL 404s | aborts with a clear message, leaves no file behind |
| fresh download | succeeds |

Then ran the whole script with `build-appimage/tools` removed so both tools came down through the new path: all stages pass, the gate reports nothing, and the AppImage builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)