### PR TITLE
Stop an undocked pane from vanishing on Linux

### DIFF
--- a/source/backend.cpp
+++ b/source/backend.cpp
@@ -1306,7 +1306,23 @@ void backEnd::setPaneEmbedded(QObject *paneWindow, bool embedded, double aspect)
         view->setLockedAspectRatio(0);
         view->setMinimumSize(QSize(0, 0));
     } else {
+#ifdef Q_OS_LINUX
+        // Undocking used to make the pane vanish here. Releasing the window from
+        // its WindowContainer unmaps the native window, and Qt's own visibility
+        // state stays true throughout - the window WAS visible, inside the
+        // container - so the show() below saw nothing to change and never mapped
+        // anything. The pane still reported isVisible() and still rendered
+        // (grabWindow() returned live frames), so only the screen disagreed.
+        // Drop the visibility state and the platform window with it, so show()
+        // builds and maps a fresh top-level rather than trying to revive the
+        // surface the container has already torn down. Windows and macOS re-map
+        // on their own, so they keep the original path.
+        view->setVisible(false);
+        view->setParent(nullptr);
+        view->destroy();
+#else
         view->setParent(nullptr); // release from the container -> top-level again
+#endif
 #ifdef Q_OS_WINDOWS
         // Same flags createView uses: resizable + minimizable, but no maximize
         // (it would break the locked aspect ratio).


### PR DESCRIPTION
Reported on Linux: popping a pane out of the Acquire grid makes it disappear. No window shows up anywhere, while the grid slot swaps to the "floating" placeholder as though it had worked.

## Cause

Releasing the window from its `WindowContainer` unmaps the native window. Qt's own visibility state stays `true` across that — the window *was* visible, inside the container — so `setPaneEmbedded`'s `show()` saw nothing to change and never mapped anything.

Nothing inside the app noticed. The window still reported `isVisible()`, still rendered, and `grabWindow()` still returned live frames; only the screen disagreed. That is also why the existing `MINISCOPE_PANE_TEST` screenshot hook never caught this — it grabs window contents, which were fine.

Measured with the harness, reading X11 map state directly:

```
t=1.55s  pane window IsViewable      (docked)
t=3.91s  pane window IsUnMapped      (undocked - and never recovers)
```

In-app, at the moment of undock:

```
t+0ms     visible=true exposed=true
t+50ms    visible=true exposed=false     <-- unmapped underneath us
t+2000ms  visible=true exposed=false
```

No `visibilityChanged` ever fires, so nothing in the app can react.

## Fix

Showing it harder cannot work — the surface the container tore down is gone. Drop the visibility state and the platform window with it, so `show()` builds and maps a fresh top-level.

```cpp
view->setVisible(false);
view->setParent(nullptr);
view->destroy();
...
view->show();
```

**Scoped to Linux.** Windows and macOS re-map correctly today and I have no way to test a change to their path, so they keep the original one. If macOS turns out to have the same problem, the same three lines should apply — I just can't verify it.

## Testing

Ubuntu 24.04, XWayland (`xcb`), webcam on deviceID 0:

| | undock |
|---|---|
| before | pane window `IsUnMapped`, permanently — nothing on screen |
| after | `IsViewable` with a WM frame, live video at 29.9 FPS |

Docking back still re-embeds (the window's parent is the container again), and the full suite passes 11/11.

Two things a reviewer may want to weigh in on:

- I also tried reordering the QML so the container's detach lands before the window is reconfigured (`Qt.callLater` in `AcquireView.setFloating`). On its own it does **not** fix this. Combined, it removes a ~200 ms window where the new top-level is not yet exposed. I left it out: making `setFloating` async risks the "pop-out snaps back on drag" behaviour that function explicitly warns about, and the transient is self-correcting.
- `destroy()` drops the scene graph for that window. Streams keep running and the window re-renders immediately in testing, but that is the part of this change worth a careful look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)