### PR TITLE
Fix the Add-Device ID guard throwing before the dialog opens

### DIFF
--- a/source/AddDeviceDialog.qml
+++ b/source/AddDeviceDialog.qml
@@ -61,7 +61,10 @@ Dialog {
     // already in the config. The dropdown offers only detected devices, so it
     // can legitimately come up empty - and then there is no ID to add under
     // (deviceID would silently fall back to 0, which is likely already taken).
-    readonly property bool noFreeDeviceID: idCombo.model.length === 0
+    // (Guard the model too: an undefined one would throw here, and a binding
+    // that throws leaves this false - quietly re-enabling the OK button this is
+    // meant to gate.)
+    readonly property bool noFreeDeviceID: !idCombo.model || idCombo.model.length === 0
 
     // Keep OK disabled until the name is usable and an ID is actually selected
     // (backend.addDevice also guards, but a silently-refused Add looked like
@@ -110,7 +113,10 @@ Dialog {
         UiComboBox {
             id: idCombo
             Layout.fillWidth: true
-            // Populated in onAboutToShow with only the unused IDs.
+            // Replaced in onAboutToShow with only the unused IDs. Starts as an
+            // empty list rather than undefined so noFreeDeviceID can read its
+            // length before the dialog has ever been opened.
+            model: []
         }
 
         Label { text: "Name"; font: Theme.fontBody; color: Theme.textPrimary }


### PR DESCRIPTION
Self-inflicted, from #123. The `noFreeDeviceID` guard reads `idCombo.model.length`, but the model is only assigned in `onAboutToShow` — so the binding runs against an undefined model the moment the component completes, and every session start logs:

```
qrc:/AddDeviceDialog.qml:64: TypeError: Cannot read property 'length' of undefined
```

The consequence is worse than the noise: **a QML binding that throws leaves the property at `false`**, which quietly re-enables the OK button the guard exists to disable. It recovered once the dialog was first opened and a real model assigned, so the only visible symptom was the error line — but the guard was not actually holding beforehand.

## Fix

- Give the combo `model: []` to start from, so there is always a length to read.
- Guard the binding too (`!idCombo.model || ...`), so an undefined model can never silently switch the check off again.

## Testing

With the autorun harness on Ubuntu 24.04, `TypeError` occurrences went **1 → 0** in a run that verifiably started a session, and the suite passes 11/11.

Found while investigating the undocked-pane bug (#126) — it showed up in the same log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)