### PR TITLE
Follow-ups to the macOS MiniCAM fix: derive the backend, shorten the format lock, catch the next dead connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ published together from CI.
 
 ### Added
 
+**Diagnostics**
+- **MiniCAM support on macOS.** A MiniCAM now streams at its native 1024x768
+  instead of connecting and delivering nothing. It is Miniscope DAQ hardware,
+  so it needed the DAQ control channel (its sensor and FPD-Link SERDES pair are
+  brought up over I2C) and its own capture format — previously every device was
+  pinned to the DAQ's default 608x608, which is correct only for a Miniscope.
+- **Optional file log.** Set `MINISCOPE_LOG_FILE` to a path and the app tees its
+  log there, timestamped and with the thread id and logging category. Off unless
+  the variable is set. This is the way to capture a field problem on Windows,
+  where the app is a GUI-subsystem binary whose output otherwise goes to the
+  debugger and cannot be redirected:
+  ```
+  $env:MINISCOPE_LOG_FILE = "C:\path\to\miniscope.log"
+  $env:QT_LOGGING_RULES  = "miniscope.diag=true"   # optional: frame/DAQ detail
+  ```
+
 **User interface (v3 rewrite)**
 - **Single-window app**: a launcher-less shell with two modes — *Setup*
   (recent configs plus a form-based config editor) and *Acquire*. Ending a
@@ -160,9 +176,9 @@ published together from CI.
   since the device catalog moved to `videoDevices.json`, but they looked
   authoritative and old wiki instructions pointed users at them.
 - **Bundled example configs replaced.** The `UserConfigExample-*` files are
-  gone, superseded by five ready-to-run configs — `01-Miniscope-V4`,
+  gone, superseded by six ready-to-run configs — `01-Miniscope-V4`,
   `02-Miniscope-V4-plus-WebCam`, `03-Miniscope-V4-plus-2-WebCams`,
-  `04-WebCam-only`, `05-Miniscope-V4-plus-Commutator` — plus
+  `04-WebCam-only`, `05-Miniscope-V4-plus-Commutator`, `06-MiniCAM` — plus
   `Reference-AllOptions.json`, the annotated file documenting every key. The
   numbered ones run as shipped: `dataDirectory` is `./Data` instead of
   `C:/FILL/OUT/THIS/PATH` (which failed at record time), scopes are

--- a/deviceConfigs/userConfigSchema.json
+++ b/deviceConfigs/userConfigSchema.json
@@ -397,8 +397,19 @@
                 { "$ref": "#/definitions/videoDeviceCommon" },
                 {
                     "properties": {
-                        "gain": { "type": ["string", "number"] },
-                        "frameRate": { "type": ["string", "number"] }
+                        "gain": {
+                            "type": ["string", "number"],
+                            "description": "Sensor gain; a MiniCAM uses \"1X\"/\"8X\"/\"16X\"/\"32X\". Ignored by plain webcams."
+                        },
+                        "frameRate": {
+                            "type": ["string", "number"],
+                            "description": "Frame rate; a MiniCAM uses strings like \"30FPS\". Ignored by plain webcams."
+                        },
+                        "led0": {
+                            "type": "number",
+                            "minimum": 0,
+                            "description": "Illumination LED power at startup, 0-100. Applies to a MiniCAM (which is on Miniscope DAQ hardware); plain webcams have no LED."
+                        }
                     }
                 }
             ]

--- a/source/avfframegrabbermac.h
+++ b/source/avfframegrabbermac.h
@@ -16,7 +16,8 @@
 // wrong camera by construction.
 //
 // Frames are delivered as 8UC3 BGR cv::Mat (matching what the OpenCV path
-// produced), scaled by CoreVideo to the requested size when one is given.
+// produced), at the device's own format where the requested size is one of the
+// modes it advertises, and rescaled by CoreVideo only where it is not.
 class AvfFrameGrabber
 {
 public:
@@ -26,7 +27,10 @@ public:
     AvfFrameGrabber &operator=(const AvfFrameGrabber &) = delete;
 
     // uniqueID: AVCaptureDevice.uniqueID (see AvfCameraInfo). width/height > 0
-    // requests scaled output buffers; 0 keeps the device's native size.
+    // puts the DEVICE in that mode when it advertises a matching format, and
+    // falls back to CoreVideo-scaled output buffers when it does not (logged as
+    // a warning - it means the frames are resampled). 0 keeps whatever format
+    // the device defaults to.
     bool open(const QString &uniqueID, int width = 0, int height = 0);
     bool isOpened() const;
     void release();

--- a/source/avfframegrabbermac.mm
+++ b/source/avfframegrabbermac.mm
@@ -95,15 +95,22 @@ struct AvfFrameGrabber::Impl {
     MSFrameSink *sink = nil;
     dispatch_queue_t queue = nil;
     uint64_t consumedSequence = 0;
-    // Device whose configuration lock we still hold, or nil. Holding the lock
-    // for the session's whole lifetime is what stops AVCaptureSession from
-    // reconfiguring activeFormat out from under us (see open()).
-    AVCaptureDevice *lockedDevice = nil;
 };
 
 AvfFrameGrabber::~AvfFrameGrabber()
 {
     release();
+}
+
+// The device format matching the requested geometry, or nil if it advertises none.
+static AVCaptureDeviceFormat *formatMatching(AVCaptureDevice *device, int width, int height)
+{
+    for (AVCaptureDeviceFormat *f in device.formats) {
+        const CMVideoDimensions dim = CMVideoFormatDescriptionGetDimensions(f.formatDescription);
+        if (dim.width == width && dim.height == height)
+            return f;
+    }
+    return nil;
 }
 
 bool AvfFrameGrabber::open(const QString &uniqueID, int width, int height)
@@ -127,12 +134,19 @@ bool AvfFrameGrabber::open(const QString &uniqueID, int width, int height)
             return false;
         }
 
+        const QString deviceLabel = QString::fromNSString(device.localizedName);
+        const QString geometry = QStringLiteral("%1x%2").arg(width).arg(height);
+
         AVCaptureSession *session = [[AVCaptureSession alloc] init];
         if (![session canAddInput:input]) {
             m_lastError = QStringLiteral("capture session rejected %1 (in use by another app?)")
-                              .arg(QString::fromNSString(device.localizedName));
+                              .arg(deviceLabel);
             return false;
         }
+
+        // One configuration transaction for input + device format + output, so the
+        // device is reconfigured once rather than on each separate mutation.
+        [session beginConfiguration];
         [session addInput:input];
 
         // Put the DEVICE in the requested geometry, rather than taking whatever
@@ -145,40 +159,35 @@ bool AvfFrameGrabber::open(const QString &uniqueID, int width, int height)
         // MiniCAM delivered one 608x608 frame and then stalled.
         //
         // macOS has no AVCaptureSessionPresetInputPriority (iOS-only) to declare
-        // that the device's own format wins, and the session WILL reconfigure
-        // the device on startRunning() - measured: a MiniCAM pinned to 1024x768
-        // came back as 1296x972. Holding the configuration lock across
-        // startRunning() is what makes the choice stick, so the lock is released
-        // in release(), not here. The read-back after startRunning() verifies it.
-        const QString deviceLabel = QString::fromNSString(device.localizedName);
+        // that the device's own format wins, so the session reconfigures the
+        // device when it starts: measured, a MiniCAM assigned 1024x768 and then
+        // unlocked came back as 1296x972. Holding the configuration lock across
+        // startRunning() is what makes the choice stick. The lock is dropped as
+        // soon as the read-back confirms the format, so the exclusive (and
+        // cross-process) claim lasts milliseconds rather than the whole session.
+        //
+        // Verified on a MacBook Pro camera (7 formats, defaults to 1920x1080):
+        // requesting 1280x720 holds through startRunning and stays held for the
+        // rest of the session after the unlock. Whether the configuration
+        // transaction above would on its own be enough was NOT tested - the lock
+        // is what the revert was measured against, so it stays. If the read-back
+        // below ever starts firing, that is the assumption to re-measure.
         AVCaptureDevice *lockedDevice = nil;
-        bool formatSelected = false;
         if (width > 0 && height > 0) {
-            AVCaptureDeviceFormat *match = nil;
-            for (AVCaptureDeviceFormat *f in device.formats) {
-                const CMVideoDimensions dim =
-                    CMVideoFormatDescriptionGetDimensions(f.formatDescription);
-                if (dim.width == width && dim.height == height) {
-                    match = f;
-                    break;
-                }
-            }
-            if (match == nil) {
-                qWarning() << "AVF:" << deviceLabel << "advertises no" << width << "x" << height
+            AVCaptureDeviceFormat *match = formatMatching(device, width, height);
+            NSError *lockError = nil;
+            if (match == nil)
+                qWarning().noquote() << "AVF:" << deviceLabel << "advertises no" << geometry
                            << "format; falling back to CoreVideo scaling of its default format";
-            } else {
-                NSError *lockError = nil;
-                if (![device lockForConfiguration:&lockError]) {
-                    qWarning() << "AVF: could not lock" << deviceLabel << "to select" << width
-                               << "x" << height << "-"
-                               << QString::fromNSString(lockError.localizedDescription);
-                } else {
+            else if (![device lockForConfiguration:&lockError])
+                qWarning().noquote() << "AVF: could not lock" << deviceLabel << "to select" << geometry
+                           << "-" << QString::fromNSString(lockError.localizedDescription);
+            else {
+                // activeFormat is sticky across opens, so skip the redundant
+                // format re-negotiation when the device is already in this mode.
+                if (device.activeFormat != match)
                     device.activeFormat = match;
-                    lockedDevice = device;   // stays locked until release()
-                    formatSelected = true;
-                    qInfo().nospace() << "[diag] " << deviceLabel << " activeFormat set to "
-                                      << width << "x" << height;
-                }
+                lockedDevice = device;
             }
         }
 
@@ -186,9 +195,10 @@ bool AvfFrameGrabber::open(const QString &uniqueID, int width, int height)
         NSMutableDictionary *settings = [@{
             (id)kCVPixelBufferPixelFormatTypeKey : @(kCVPixelFormatType_32BGRA)
         } mutableCopy];
-        if (width > 0 && height > 0 && !formatSelected) {
-            // Only when no matching device format exists. Resampling imaging
-            // data is lossy, so it stays a fallback rather than the mechanism.
+        if (width > 0 && height > 0 && lockedDevice == nil) {
+            // Only when the device could not be put in this geometry itself.
+            // Resampling imaging data is lossy, so it stays a fallback rather
+            // than the mechanism.
             settings[(id)kCVPixelBufferWidthKey] = @(width);
             settings[(id)kCVPixelBufferHeightKey] = @(height);
         }
@@ -201,32 +211,34 @@ bool AvfFrameGrabber::open(const QString &uniqueID, int width, int height)
         [output setSampleBufferDelegate:sink queue:queue];
         if (![session canAddOutput:output]) {
             m_lastError = QStringLiteral("capture session rejected the video output");
+            [session commitConfiguration];
             [lockedDevice unlockForConfiguration];   // no-op when nil
             return false;
         }
         [session addOutput:output];
+        [session commitConfiguration];
         [session startRunning];
 
         // Did the format survive session start? A silent revert here is the
         // difference between imaging the sensor's real geometry and imaging a
-        // rescaled crop of someone else's, so it must be loud.
-        if (formatSelected) {
+        // rescaled crop of another mode's, so it must be loud.
+        if (lockedDevice != nil) {
             const CMVideoDimensions actual =
                 CMVideoFormatDescriptionGetDimensions(device.activeFormat.formatDescription);
             if (actual.width != width || actual.height != height)
-                qWarning() << "AVF:" << deviceLabel << "reverted to" << actual.width << "x"
-                           << actual.height << "when the session started (asked for" << width
-                           << "x" << height << ")";
+                qWarning().noquote() << "AVF:" << deviceLabel << "reverted to"
+                           << QStringLiteral("%1x%2").arg(actual.width).arg(actual.height)
+                           << "when the session started (asked for" << geometry << ")";
             else
-                qInfo().nospace() << "[diag] " << deviceLabel << " activeFormat held at "
-                                  << width << "x" << height << " after session start";
+                qInfo().nospace().noquote() << "[diag] " << deviceLabel << " activeFormat held at "
+                                  << geometry << " after session start";
+            [lockedDevice unlockForConfiguration];
         }
 
         m_impl = new Impl;
         m_impl->session = session;
         m_impl->sink = sink;
         m_impl->queue = queue;
-        m_impl->lockedDevice = lockedDevice;
     }
     m_lastError.clear();
     return true;
@@ -246,11 +258,6 @@ void AvfFrameGrabber::release()
         for (AVCaptureOutput *out in m_impl->session.outputs)
             if ([out isKindOfClass:[AVCaptureVideoDataOutput class]])
                 [(AVCaptureVideoDataOutput *)out setSampleBufferDelegate:nil queue:nil];
-        // Held since open() to pin activeFormat; drop it only now that the
-        // session is stopped, so the device is left configurable for the next
-        // open (ours or another app's).
-        [m_impl->lockedDevice unlockForConfiguration];   // no-op when nil
-        m_impl->lockedDevice = nil;
     }
     delete m_impl;   // ARC releases the session/sink/queue with the Impl
     m_impl = nullptr;

--- a/source/behaviorcam.cpp
+++ b/source/behaviorcam.cpp
@@ -16,19 +16,7 @@
 #include <QVariant>
 
 BehaviorCam::BehaviorCam(QObject *parent, QJsonObject ucDevice, qint64 softwareStartTime) :
-    // A MiniCAM is Miniscope DAQ hardware - its MT9P031 sensor, FPD-Link SERDES
-    // pair and LED driver are all brought up over the DAQ's I2C tunnel - so it
-    // needs the direct-control backend exactly like a Miniscope does. Without
-    // this it lands on VideoStreamOCV, whose macOS path has no control channel
-    // and DISCARDS the whole command queue (VideoStreamOCV::sendCommands), so
-    // the sensor is never configured and no frame ever arrives.
-    //
-    // Same webcam/MiniCAM test as isMiniCAM below, duplicated here rather than
-    // shared because the base ctor picks the backend before this ctor's body
-    // runs and so cannot read the member.
-    VideoDevice(parent, ucDevice, softwareStartTime,
-                /*preferDirectControl=*/!ucDevice.value("deviceType").toString()
-                                             .toLower().contains("webcam")),
+    VideoDevice(parent, ucDevice, softwareStartTime),
     m_softwareStartTime(softwareStartTime)
 {
     m_ucDevice = ucDevice; // hold user config for this device

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -50,22 +50,24 @@
 // a failed connect) with no log to send. Off unless the variable is set, and it
 // still forwards everything to the default handler.
 static QtMessageHandler g_previousMessageHandler = nullptr;
-static QFile g_logFile;
-static QMutex g_logMutex;
+// Heap-allocated and deliberately never freed: the handler stays installed for
+// the life of the process, so file-scope objects would be destroyed while a
+// later-destroyed translation unit could still log through them.
+static QFile *g_logFile = nullptr;
+static QMutex *g_logMutex = nullptr;
 
 static void fileMessageHandler(QtMsgType type, const QMessageLogContext &context,
                                const QString &msg)
 {
+    // qFormatLogMessage applies the pattern installed below - or the user's
+    // QT_MESSAGE_PATTERN, which still wins - so the file and stderr can never
+    // disagree about format, and file/line/function stay available to it.
+    const QByteArray line = qFormatLogMessage(type, context, msg).toUtf8() + '\n';
     {
-        QMutexLocker locker(&g_logMutex);
-        if (g_logFile.isOpen()) {
-            static const char *levels[] = {"debug", "warning", "critical", "fatal", "info"};
-            const int level = (type >= 0 && type <= QtInfoMsg) ? int(type) : 0;
-            QTextStream out(&g_logFile);
-            out << QDateTime::currentDateTime().toString(Qt::ISODateWithMs) << " ["
-                << levels[level] << "] "
-                << (context.category ? context.category : "default") << ": " << msg << "\n";
-            out.flush();
+        QMutexLocker locker(g_logMutex);
+        if (g_logFile->isOpen()) {
+            g_logFile->write(line);
+            g_logFile->flush();   // a crash is the case this exists for; never buffer
         }
     }
     if (g_previousMessageHandler)
@@ -77,9 +79,21 @@ static void installFileLogIfRequested()
     const QString path = qEnvironmentVariable("MINISCOPE_LOG_FILE");
     if (path.isEmpty())
         return;
-    g_logFile.setFileName(path);
-    if (!g_logFile.open(QIODevice::WriteOnly | QIODevice::Append | QIODevice::Text)) {
-        qWarning() << "Could not open log file" << path << "-" << g_logFile.errorString();
+
+    // The thread id earns its place: every device captures on its own thread, so
+    // a multi-device stall log is interleaved and otherwise unattributable.
+    qSetMessagePattern(QStringLiteral("%{time yyyy-MM-ddTHH:mm:ss.zzz} [%{type}] "
+                                      "%{threadid} %{if-category}%{category}: %{endif}"
+                                      "%{message}"));
+
+    g_logFile = new QFile(path);
+    g_logMutex = new QMutex;
+    // A path inside a folder that does not exist yet is the usual way this
+    // silently produces nothing, and the warning below is itself unreadable on
+    // the Windows GUI-subsystem binary the feature exists for.
+    QDir().mkpath(QFileInfo(path).absolutePath());
+    if (!g_logFile->open(QIODevice::WriteOnly | QIODevice::Append | QIODevice::Text)) {
+        qWarning() << "Could not open log file" << path << "-" << g_logFile->errorString();
         return;
     }
     g_previousMessageHandler = qInstallMessageHandler(fileMessageHandler);

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -14,17 +14,15 @@
 #include <QQuickStyle>
 #include <QStyleHints>
 
-#include <QDateTime>
+#include <QDir>
 #include <QFile>
+#include <QFileInfo>
 #include <QMutex>
-#include <QTextStream>
 
 #include "backend.h"
 #include "themecontroller.h"
 #if defined(Q_OS_MACOS) || defined(Q_OS_WIN)
 #include "bundlepaths.h"
-#include <QDir>
-#include <QFileInfo>
 #endif
 
 #include <opencv2/core/version.hpp>   // CV_VERSION (e.g. "4.13.0"); macro-only header

--- a/source/videodevice.cpp
+++ b/source/videodevice.cpp
@@ -19,6 +19,21 @@
 #include <QQmlApplicationEngine>
 #include <QVector>
 
+// Does this device type talk to its sensor through a Miniscope DAQ's I2C tunnel?
+// Answered from what the device type DECLARES rather than from what it is called:
+// a non-empty "initialize" array is exactly the list of I2C commands that bring
+// the DAQ's SERDES pair, sensor and LED driver up, so having one is what makes a
+// device need the direct-control backend. Every DAQ-based type in
+// videoDevices.json has one (a MiniCAM has 15); every plain WebCam type has none.
+//
+// Deriving it beats testing the deviceType string: a new camera type cannot get
+// the wrong backend by being named badly, and there is no OpenCV fallback if it
+// does - connect2Camera() just fails and the device never opens.
+static bool needsDaqControlChannel(const QJsonObject &cDevice)
+{
+    return !cDevice.value("initialize").toArray().isEmpty();
+}
+
 VideoDevice::VideoDevice(QObject *parent, QJsonObject ucDevice, qint64 softwareStartTime, bool preferDirectControl) :
     QObject(parent),
     m_camConnected(false),
@@ -69,26 +84,31 @@ VideoDevice::VideoDevice(QObject *parent, QJsonObject ucDevice, qint64 softwareS
     const int devHeight = m_cDevice.value("height").toInt(-1);
     const double devPixelClock = m_cDevice.value("pixelClock").toDouble(-1);
 
-    // Miniscopes need a direct-control backend where plain OpenCV can't reach
-    // the DAQ's control channel (see videostreambase.h): libuvc on Linux (the
-    // kernel uvcvideo driver caches UVC control reads), and the AVFoundation +
-    // IOKit hybrid on macOS (AVFoundation exposes no UVC controls at all). A
-    // real live camera (deviceID) is required - video-file playback always
-    // uses OpenCV.
+    // Devices on Miniscope DAQ hardware need a direct-control backend where plain
+    // OpenCV can't reach the DAQ's control channel (see videostreambase.h): libuvc
+    // on Linux (the kernel uvcvideo driver caches UVC control reads), and the
+    // AVFoundation + IOKit hybrid on macOS (AVFoundation exposes no UVC controls
+    // at all). This covers a MiniCAM as well as a Miniscope - it is the same DAQ,
+    // and without the control channel VideoStreamOCV DISCARDS the queued I2C
+    // commands, so the sensor is never configured and no frame ever arrives. A
+    // real live camera (deviceID) is required - video-file playback always uses
+    // OpenCV.
     deviceStream = nullptr;
     const bool liveCamera = m_ucDevice.contains("deviceID") && !m_ucDevice.value("deviceID").isNull();
+    const bool directControl =
+        (m_preferDirectControlBackend || needsDaqControlChannel(m_cDevice)) && liveCamera;
 #if defined(HAVE_LIBUVC)
-    if (m_preferDirectControlBackend && liveCamera) {
+    if (directControl) {
         deviceStream = new VideoStreamLibUVC(nullptr, devWidth, devHeight, devPixelClock);
         qDebug() << "Using libuvc capture backend for" << m_deviceName;
     }
 #elif defined(Q_OS_MACOS)
-    if (m_preferDirectControlBackend && liveCamera) {
+    if (directControl) {
         deviceStream = new VideoStreamMac(nullptr, devWidth, devHeight, devPixelClock);
         qDebug() << "Using AVFoundation+IOKit hybrid capture backend for" << m_deviceName;
     }
 #endif
-    Q_UNUSED(liveCamera);
+    Q_UNUSED(directControl);
     if (deviceStream == nullptr)
         deviceStream = new VideoStreamOCV(nullptr, devWidth, devHeight, devPixelClock);
     deviceStream->setDeviceName(m_deviceName);
@@ -278,11 +298,8 @@ void VideoDevice::createView()
         QObject::connect(rootObject, SIGNAL( vidPropChangedSignal(QString, double, double, double) ),
                              this, SLOT( handlePropChangedSignal(QString, double, double, double) ));
 
-        // dFFSwitchChanged is wired in Miniscope::setupDisplayObjectPointers():
-        // dF/F is a Miniscope-only display mode and handleDFFSwitchChange() only
-        // exists there, so connecting it here failed at runtime for every
-        // behavior camera ("No such slot BehaviorCam::handleDFFSwitchChange") -
-        // once per device per session, in the log a user would send us.
+        // dFFSwitchChanged is wired in Miniscope::setupDisplayObjectPointers() -
+        // dF/F is Miniscope-only, so it must not be connected on this base.
 
         QObject::connect(rootObject, SIGNAL( saturationSwitchChanged(bool) ),
                              this, SLOT( handleSaturationSwitchChanged(bool) ));
@@ -316,8 +333,10 @@ void VideoDevice::createView()
         else if (lutName == "Green")   m_lutColormap = 1;
         else { m_lutColormap = 1; lutOn = false; } // "None" / unrecognized
         vidDisplay->setLutMode(lutOn ? m_lutColormap : 0);
+        // The shared VideoWindowShell always carries lutSwitch (it is merely
+        // invisible for a behavior camera), so this guard is defensive only.
         QQuickItem *lutSwitch = rootObject->findChild<QQuickItem*>("lutSwitch");
-        if (lutSwitch) // only the Miniscope window has the switch
+        if (lutSwitch)
             lutSwitch->setProperty("checked", lutOn);
 
         // Set ROI Stuff

--- a/tests/tst_sessionlifecycle.cpp
+++ b/tests/tst_sessionlifecycle.cpp
@@ -24,6 +24,7 @@
 #include <QSGRendererInterface>
 #include <QTemporaryDir>
 #include <QFileInfo>
+#include <QRegularExpression>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
@@ -40,6 +41,7 @@ class TestSessionLifecycle : public QObject
 
 private slots:
     void initTestCase();
+    void init();
     void runEndRunCycle();
     void configEditsBetweenRunsAreHonored();
     void producersHeldUntilConsumerReady();
@@ -112,6 +114,23 @@ QString TestSessionLifecycle::writeConfig(const QString &fileName,
     f.write(QJsonDocument(config).toJson());
     f.close();
     return path;
+}
+
+// Fail on a signal/slot connect that did not resolve. Qt reports those as a
+// warning, not an error, so a broken string-based connect() runs forever in
+// silence: the dF/F switch was connected on the shared VideoDevice base to a slot
+// that only Miniscope declares, and THIS test - which builds a behavior camera
+// and drives Run/endSession - printed "No such slot
+// BehaviorCam::handleDFFSwitchChange" on every CI run and still passed. QML
+// signals have to be connected by name, so no compile-time check is available
+// and this is the only thing that can catch the next one.
+//
+// It must live in init(), not initTestCase(): failOnWarning() only holds for the
+// duration of the test function that calls it, and initTestCase() is itself one -
+// setting it there silently protects nothing.
+void TestSessionLifecycle::init()
+{
+    QTest::failOnWarning(QRegularExpression("No such (slot|signal)"));
 }
 
 void TestSessionLifecycle::initTestCase()


### PR DESCRIPTION
Post-merge review follow-ups to #122. The MiniCAM path itself is unchanged — it still streams at native 1024x768 — but the fix is chosen and held at a better altitude, and the class of bug it came from is now caught by CI.

Two of these matter; the rest ride along.

## Pick the backend from what a device *declares*, not what it's called

#122 (mine) keyed the direct-control backend on `!deviceType.contains("webcam")`. That's the wrong signal. `videoDevices.json` is user-editable, and anything added there whose name lacks "webcam" — `ArduCam-OV2311`, `FLIR-Blackfly` — gets routed to the DAQ backend, where the control-channel probe finds no Miniscope, returns 0, and falls through to *"cannot connect to camera. Check deviceID."* with **no OpenCV fallback**. The deviceID would be fine. Nobody would guess why.

Nothing is broken today — every current WebCam type happens to contain "webcam" — but there's a standing `// TODO: Handle cases where there is more than webcams and MiniCAMs`, so adding types is expected. This is a trap #122 planted.

The catalog already states the real property structurally: a non-empty `initialize` array **is** the I²C bring-up for the DAQ's SERDES pair, sensor and LED driver.

| device type | `initialize` commands |
|---|---|
| `Minicam-Mono-XGA` | 15 |
| `Miniscope_V4_BNO` / `V4` / `V3` / … | 8–12 |
| every `WebCam*` | **0** |

`VideoDevice` loads that catalog entry *before* it picks a backend, so it can just ask. This also deletes the duplicated predicate and the ctor-argument gymnastics from `behaviorcam.cpp` entirely — the diff there reverts to zero.

## Fail the tests on an unresolved signal/slot connect

The best finding here. #122's dF/F fix was for a connect naming a slot only `Miniscope` declares. `tst_sessionlifecycle` builds a behavior camera and drives Run/endSession — it printed `No such slot BehaviorCam::handleDFFSwitchChange` on **every CI run and passed anyway**, because Qt reports a failed connect as a warning.

QML signals must be connected by name, so no compile-time check is possible for the 21 string-based connects left in `source/`. `QTest::failOnWarning` is the only thing that can catch the next one.

Verified by reintroducing the original bug and confirming the test fails on it:

```
FAIL!  : TestSessionLifecycle::runEndRunCycle() Received a warning that resulted in a failure:
QObject::connect: No such slot BehaviorCam::handleDFFSwitchChange(bool)
```

It lives in `init()`, not `initTestCase()` — `failOnWarning` only holds for the duration of the calling test function, so in `initTestCase` it silently protects nothing. My first attempt had exactly that bug and I only caught it because I checked the guard could fail.

## Hold the device config lock for milliseconds, not the session

The lock stops `AVCaptureSession` overriding `activeFormat` on `startRunning()`, but #122 held it until `release()` — an exclusive, **cross-process** claim on the camera for the entire run, blocking other apps from configuring it and outliving ~1 s of stall-diagnosis sleeps. The revert happens *during* `startRunning()`, so the lock only has to span that call; it's now dropped as soon as the read-back confirms the format.

Also: input/format/output move into one `begin`/`commitConfiguration` transaction, and a redundant `activeFormat` write is skipped when the device is already in that mode.

## Smaller

- `formatMatching()` extracted; `formatSelected` dropped (it only restated `lockedDevice != nil`); geometry formatted once instead of open-coded at five sites with inconsistent spacing; `.noquote()` so it doesn't log as `"1280x720"`; one success log instead of two.
- Header documented the *old* contract (scaled output buffers) — now documents the real one, including that `open()` takes the device's config lock.
- `MINISCOPE_LOG_FILE` formats via `qFormatLogMessage` + `qSetMessagePattern`: drops the hand-rolled level table, respects a user's `QT_MESSAGE_PATTERN`, and adds the **thread id** (the log exists to diagnose multiple devices whose per-thread lines interleave). Creates the parent directory — a missing one is the usual way it silently produces nothing, and the warning about it is unreadable on the Windows GUI binary this is for. Sink is heap-allocated so a late log can't touch a destroyed `QFile`.
- Camera schema declares `led0`, which `06-MiniCAM.json` uses and which validated only because nothing sets `additionalProperties`.
- CHANGELOG: MiniCAM + log entries, config count five → six.

## Testing

**14/14 tests pass.**

The shortened lock window was measured on a MacBook Pro camera, which exercises the same path as a MiniCAM — 7 advertised formats, defaulting to 1920x1080, so a 1280x720 request is a real switch away from the default:

```
activeFormat held at 1280x720 after session start
grabber pixel format 'BGRA' 1280x720 stride=5120
heartbeat  acqFrame=100 → acqFrame=1400      (43 s, no revert, no reconnect)
```

It held through `startRunning` and stayed held for the whole session *after* the unlock — that was the residual risk. The no-matching-format fallback was checked the same way with a 320x240 request: warns and resamples as intended. The MiniCAM streaming result itself is unchanged from #122 and was verified on that hardware before these cleanups.

## Not addressed here

- **User-facing `sendMessage` diagnostics still don't reach `MINISCOPE_LOG_FILE`.** Reconnect warnings, "frame buffer is full", recording failures all live in an in-memory ring and die with the process — so they're absent from exactly the log a user sends us. Routing `ControlPanel::receiveMessage` through `qInfo()` turned the 26 s test suite into a **2787 s timeout**, so this needs a sink that bypasses Qt's message stream.
- Giving top-level executables a default output directory, so the Windows release folder is opt-in rather than opt-out (`MiniscopeLauncher` already opts out by hand). Untestable here.
- Sharing the `msDiag` logging category with `avfgrabber_mac`, which doesn't link its definition — needs the category extracted to its own target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFED97LVqUze521U9N7PYB