### PR TITLE
Put the user-facing message log into MINISCOPE_LOG_FILE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,12 @@ published together from CI.
   pinned to the DAQ's default 608x608, which is correct only for a Miniscope.
 - **Optional file log.** Set `MINISCOPE_LOG_FILE` to a path and the app tees its
   log there, timestamped and with the thread id and logging category. Off unless
-  the variable is set. This is the way to capture a field problem on Windows,
-  where the app is a GUI-subsystem binary whose output otherwise goes to the
-  debugger and cannot be redirected:
+  the variable is set. It includes the messages shown in the Acquire window's
+  message panel — device connect failures, reconnect warnings, "frame buffer is
+  full", recording failures — which previously existed only on screen and were
+  lost when the app closed. This is the way to capture a field problem on
+  Windows, where the app is a GUI-subsystem binary whose output otherwise goes
+  to the debugger and cannot be redirected:
   ```
   $env:MINISCOPE_LOG_FILE = "C:\path\to\miniscope.log"
   $env:QT_LOGGING_RULES  = "miniscope.diag=true"   # optional: frame/DAQ detail

--- a/source/controlpanel.cpp
+++ b/source/controlpanel.cpp
@@ -1,5 +1,6 @@
 #include "controlpanel.h"
 
+#include <QDebug>
 #include <QJsonArray>
 #include <QJsonValue>
 #include <QProcess>
@@ -17,6 +18,19 @@ ControlPanel::ControlPanel(QObject *parent, QJsonObject userConfig) :
 
 void ControlPanel::receiveMessage(QString msg)
 {
+    // Every user-facing diagnostic in the app arrives here as a sendMessage:
+    // reconnect warnings, "frame buffer is full", "Recording NOT started", device
+    // connect failures. Without this they would live only in m_messageLog, an
+    // in-memory ring that dies with the process - absent from exactly the log a
+    // user sends us when reporting a field problem. Deliberately uncategorised:
+    // these are always relevant, unlike the msDiag bench heartbeats, so
+    // QT_LOGGING_RULES should not be able to silence them.
+    //
+    // Safe to log from here only because no installed message handler emits a
+    // signal (see fileMessageHandler in main.cpp, which writes and chains) - one
+    // that reached sendMessage would recurse.
+    qInfo().noquote() << msg;
+
     const QString stamp = QTime::currentTime().toString("HH:mm:ss");
     m_messageLog.append(stamp + "  " + msg);
     while (m_messageLog.size() > 500) // enough scrollback; never unbounded


### PR DESCRIPTION
Closes the gap left open by #122/#130: the file log captured the half of the diagnostics nobody asks for, and none of the half they do.

## The problem

Every user-facing diagnostic in the app arrives at `ControlPanel::receiveMessage` as a `sendMessage` — device connect failures, `"Attempting to reconnect"`, `"frame buffer is full"`, `"Recording NOT started"` — and went only into `m_messageLog`, a 500-line in-memory ring feeding the Acquire window's message panel. It dies with the process.

So `MINISCOPE_LOG_FILE` collected `qDebug`/`qWarning` output and the `msDiag` frame heartbeats, but not the messages a user would actually be asked about. Someone reporting a field problem could send a log that omits the reconnect warning explaining it.

## The change

One `qInfo()` in `receiveMessage`, so those messages join the same stream and land in the log file with the same timestamp/level/thread formatting as everything else.

Deliberately **uncategorised** rather than under `msDiag`: unlike the bench heartbeats these are always relevant, so `QT_LOGGING_RULES` should not be able to silence them.

The comment also records why logging from this slot is safe — no installed message handler emits a signal, so there's no path back into `sendMessage`. `fileMessageHandler` writes and chains to the previous handler; one that reached `sendMessage` would recurse.

## Verified end to end

A webcam session's log now contains the two lines that previously only ever appeared on screen:

```
2026-07-31T22:15:20.858 [info] 7217834 BehaviorCam connected using Direct Show.
2026-07-31T22:15:20.951 [info] 7217834 BehaviorCam is connected.
```

**14/14 tests pass.**

## Correcting the record

`613fde3` (on master, from #130) lists this change as unshippable, claiming it *"turned a 26 s test into a 2787 s timeout"*. **That is wrong**, and this PR's commit message says so.

Re-measured on a quiet machine with the line in place:

| | with the change |
|---|---|
| each of 6 `tst_sessionlifecycle` functions | 2.7–7.5 s |
| whole `tst_sessionlifecycle` binary | 26.0 s, 38 `receiveMessage` calls |
| full 14-test ctest suite | 28.5 s |

Indistinguishable from without it. The original timeout was environmental — concurrent app soak runs and a backgrounded ctest contending for the macOS window server — not caused by this code. Message volume was never near a concern either: a full session emits tens of messages, not thousands. A working change was reverted on bad evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFED97LVqUze521U9N7PYB