### PR TITLE
Prepare the v2.0.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -369,6 +369,9 @@ jobs:
           set -euo pipefail
           cmake_ver=$(sed -nE 's/^project\(MiniscopeDAQ[[:space:]]+VERSION[[:space:]]+([0-9.]+).*/\1/p' CMakeLists.txt | head -1)
           tag_ver="${TAG#v}"
+          # project(VERSION) only accepts numerics, so a pre-release tag
+          # (v2.0.0-rc1) is compared on its numeric part only.
+          tag_ver="${tag_ver%%-*}"
           echo "tag=$tag_ver  CMakeLists.txt=$cmake_ver"
           if [ "$cmake_ver" != "$tag_ver" ]; then
             echo "::error::Tag $TAG (version $tag_ver) != CMakeLists.txt project() version $cmake_ver. Bump CMakeLists.txt to match the tag (or retag), then push again."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Every pull request that changes behavior should add a line to the
 **[Unreleased]** section below; the section is renamed to the version number
 when a release is tagged.
 
-## [Unreleased] — v2.0.0, first release of the Qt 6 generation
+## [2.0.0] — 2026-07-31 — first release of the Qt 6 generation
 
 This is one final major release of the Qt desktop software before it is
 superseded long-term by the [miniscope-io](https://github.com/Aharoni-Lab/miniscope-io)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -25,8 +25,13 @@ and ship the same `USE_PYTHON=OFF` configuration (no embedded DeepLabCut-Live).
    ```sh
    pip install conda-lock
    conda-lock lock -f environment.yml -p win-64 -p linux-64 -p osx-arm64 \
+       --virtual-package-spec packaging/conda-virtual-packages.yml \
        --lockfile conda-lock.yml
    ```
+
+   The `--virtual-package-spec` file tells the solver to assume macOS 12.0
+   (the app's real minimum); without it the osx-arm64 solve fails on
+   packages that require `__osx >= 12.0` (see the file's header comment).
 
    Commit the updated `conda-lock.yml`. (Day-to-day builds and CI use
    `environment.yml`, which floats on patch releases within its major.minor

--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -13,16 +13,16 @@
 version: 1
 metadata:
   content_hash:
-    win-64: 5d2bc73be2785ef6cb29875da6822c74404b534f1f56234b1ee26268849e7bc8
-    linux-64: 6900c7855ce12d8d5a7f387c5115033cf6d0194f0916d8fb55ba471f2500c5ee
-    osx-arm64: 55aa9fc57f7735d7265383f41933077a94b01668c5faa1092e8794ffdea3b24a
+    win-64: bfaf9a141077ac1792c65b919ab8221b8f57b89b94325e4a69f043fdb91079e4
+    linux-64: 1e6d282a469be10402153b289fd73fd19adaf2881bb29c3f51aab1f7bc94bf68
+    osx-arm64: 2b793eb2d25bd9165e4307551939c3a131683869b0a48fe444c8a5b1cc315b9d
   channels:
   - url: conda-forge
     used_env_vars: []
   platforms:
-  - win-64
   - linux-64
   - osx-arm64
+  - win-64
   sources:
   - environment.yml
 package:
@@ -712,7 +712,7 @@ package:
   category: main
   optional: false
 - name: cmake
-  version: 4.4.0
+  version: 4.4.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -728,14 +728,14 @@ package:
     ncurses: '>=6.6,<7.0a0'
     rhash: '>=1.4.6,<2.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/cmake-4.4.0-hc85cc9f_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/cmake-4.4.2-hc85cc9f_0.conda
   hash:
-    md5: d76e52d46d803df5080a220ed0a9d730
-    sha256: 673384f97c558a083e0944bf4d14627bd7ce29c09efd33965e4ab7b609d04402
+    md5: c7d7ad5d723ffc37a7892d9dd9dd115d
+    sha256: 5c8027d6f51e4aea86dfa74a09481f6e275742a620c5a88b132ec01405e9bd6e
   category: main
   optional: false
 - name: cmake
-  version: 4.4.0
+  version: 4.4.2
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -750,14 +750,14 @@ package:
     ncurses: '>=6.6,<7.0a0'
     rhash: '>=1.4.6,<2.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cmake-4.4.0-h8cb302d_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cmake-4.4.2-h8cb302d_0.conda
   hash:
-    md5: 11da6a57bdd85561dda6182321039659
-    sha256: e1dd4d6f3e3c19a39c6d25abc77ed6a1a286e70a141c9d78f3cc059279abab2c
+    md5: 952ccf9c6e8204dd1bdda021f274a5bb
+    sha256: 64c89fbb4a70eb192883fee4a16c0cdb0e6eb9921e3b63b1a8125a98e9c856e6
   category: main
   optional: false
 - name: cmake
-  version: 4.4.0
+  version: 4.4.2
   manager: conda
   platform: win-64
   dependencies:
@@ -770,10 +770,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc14_runtime: '>=14.44.35208'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/win-64/cmake-4.4.0-hdcbee5b_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/cmake-4.4.2-hdcbee5b_0.conda
   hash:
-    md5: 0b1ae7fbb1f4a245e21ce32854c97f7c
-    sha256: 630771ba1c428fc0144ada4dd4b14b8f97199182c4bcff85cfa674b81e3b13d1
+    md5: 0603f36777dc08a502a48bf50d9a4f00
+    sha256: 6c6b1c4d05a30bdd6c0cac0c9c7799f929bb632c76e251da20a7868103dd0f2c
   category: main
   optional: false
 - name: cyrus-sasl
@@ -998,15 +998,15 @@ package:
     fontconfig: '>=2.18.1,<3.0a0'
     fonts-conda-ecosystem: ''
     gmp: '>=6.3.0,<7.0a0'
-    harfbuzz: '>=14.2.1'
-    lame: '>=3.100,<3.101.0a0'
-    libass: '>=0.17.4,<0.17.5.0a0'
+    lame: '>=4.0,<4.1.0a0'
+    libass: '>=0.17.5,<0.17.6.0a0'
     libcxx: '>=19'
     libexpat: '>=2.8.1,<3.0a0'
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
+    libharfbuzz: '>=14.2.1'
     libiconv: '>=1.18,<2.0a0'
-    libjxl: '>=0.11,<0.12.0a0'
+    libjxl: '>=0.12.0,<0.13.0a0'
     liblzma: '>=5.8.3,<6.0a0'
     libopenvino: '>=2026.2.1,<2026.2.2.0a0'
     libopenvino-arm-cpu-plugin: '>=2026.2.1,<2026.2.2.0a0'
@@ -1032,14 +1032,14 @@ package:
     openh264: '>=2.6.0,<2.6.1.0a0'
     openssl: '>=3.5.7,<4.0a0'
     sdl2: '>=2.32.56,<3.0a0'
-    shaderc: '>=2026.2,<2026.3.0a0'
-    svt-av1: '>=4.0.1,<4.0.2.0a0'
+    shaderc: '>=2026.3,<2026.4.0a0'
+    svt-av1: '>=4.2.0,<4.2.1.0a0'
     x264: '>=1!164.3095,<1!165'
     x265: '>=3.5,<3.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-8.1.2-gpl_haa6735b_101.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-8.1.2-gpl_h82c4c68_104.conda
   hash:
-    md5: 294718155b73c528320bb2ee565c9e81
-    sha256: 5cef33f3dc9eae9a12f70f2e91c2d41103cb74f10c91eb9f03f59443a384b1e3
+    md5: 22b80699e835aa985fabf2718e5efc80
+    sha256: 112923a8048eccb8f9a2cb54db844095f599f5af362a8f21514db1e21b31cd49
   category: main
   optional: false
 - name: ffmpeg
@@ -1488,12 +1488,12 @@ package:
   category: main
   optional: false
 - name: glib
-  version: 2.88.2
+  version: 2.88.3
   manager: conda
   platform: win-64
   dependencies:
-    glib-tools: ==2.88.2
-    libglib: ==2.88.2
+    glib-tools: ==2.88.3
+    libglib: ==2.88.3
     libintl: '>=0.22.5,<1.0a0'
     libintl-devel: ''
     packaging: ''
@@ -1501,27 +1501,27 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/glib-2.88.2-h395db07_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/glib-2.88.3-h3750008_0.conda
   hash:
-    md5: 7d203837b88a2255b32dca555d37ca50
-    sha256: b67107959a71dbf9f5c2e95511f18095d9ac6f0001f0de4a1b6e14282162989e
+    md5: 9ffa1092d169f71c63d67391e6f25348
+    sha256: 83422a7831b2fd2c85cf98ad3e74e6a93dac008ac14dd73f9846ddcc8c3714db
   category: main
   optional: false
 - name: glib-tools
-  version: 2.88.2
+  version: 2.88.3
   manager: conda
   platform: win-64
   dependencies:
     libffi: ''
-    libglib: ==2.88.2
+    libglib: ==2.88.3
     libintl: '>=0.22.5,<1.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.88.2-h74ecf4c_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.88.3-h81395b3_0.conda
   hash:
-    md5: 63c615f0c525ee64f72e557e583b6257
-    sha256: c604b6ca42c6271f281b1c0616e0d50bd800f8fc913a91a2753c2551b3b6b16c
+    md5: e247bb0f21e2e49097a663facd4fa554
+    sha256: cb4c3fb7a4dac04def4d78a6f01f031900e18b7b90e6b0b9e72accd500942654
   category: main
   optional: false
 - name: glslang
@@ -1754,10 +1754,10 @@ package:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h54a6638_2.conda
   hash:
-    md5: 3c7763347873f07adfd87e8001b5b1d1
-    sha256: c054e32ac4c14426006edf9d01981dc564559b4065af7c13c26be904e1babf04
+    md5: 4ef4b977bb216a3001a3334696a80850
+    sha256: d7c260b7e1cf22ce04d6ba8a86eabf4e6c50bc96a5c27fe2ecb32298af3e88eb
   category: main
   optional: false
 - name: icu
@@ -1766,10 +1766,10 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hc7cc350_2.conda
   hash:
-    md5: 65353f302fa35a03c8872580d76f6085
-    sha256: c8d3440ed03419d8a517e85e35a71f03ce0d86496823c592a2ed6080320c1968
+    md5: 6133ddbb17ba2b50700dd88e9303ce27
+    sha256: f0b22bc30e4cc29e29ba3234cb38497fe8def2c2aae4b775d42fe5b378a018c9
   category: main
   optional: false
 - name: icu
@@ -1780,10 +1780,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/icu-78.3-h637d24d_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/icu-78.3-h5112557_2.conda
   hash:
-    md5: e3232ea6dafd9f12663f860a3194d6dc
-    sha256: 61f16ae57ee8956d5c1f69e703f7abaebb972d0def1edc5704d7198430398295
+    md5: e596942e8ee6ee17fdcf1e6a77757a66
+    sha256: 75c549b55b673e15de8785a8e5dd85bca7eb612eee0ff4dc8d7bdaa15eacbdbb
   category: main
   optional: false
 - name: imath
@@ -1948,14 +1948,16 @@ package:
   category: main
   optional: false
 - name: lame
-  version: '3.100'
+  version: '4.0'
   manager: conda
   platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lame-3.100-h1a8c8d9_1003.tar.bz2
+  dependencies:
+    __osx: '>=11.0'
+    mpg123: '>=1.32.9,<1.33.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/lame-4.0-h9fa95f5_0.conda
   hash:
-    md5: bff0e851d66725f78dc2fd8b032ddb7e
-    sha256: f40ce7324b2cf5338b766d4cdb8e0453e4156a4f83c2f31bbfff750785de304c
+    md5: c472f03d82184ebd2190e1a5807efe2f
+    sha256: a91dfd1c78aa769994d3b7bbb6a76fa7d778ebcedd8f893fa287617336f38918
   category: main
   optional: false
 - name: lame
@@ -2016,44 +2018,44 @@ package:
   category: main
   optional: false
 - name: lerc
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.2.0-hdb68285_0.conda
   hash:
-    md5: a752488c68f2e7c456bcbd8f16eec275
-    sha256: f84cb54782f7e9cea95e810ea8fef186e0652d0fa73d3009914fa2c1262594e1
+    md5: fb9d356b1a57d6d54768be7ebd5fce09
+    sha256: bf9fdebf55d8bc99d83531cdffda00703f4dc5f93a1a956768c147362c72feda
   category: main
   optional: false
 - name: lerc
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.1.0-h1eee2c3_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.2.0-h1eee2c3_0.conda
   hash:
-    md5: 095e5749868adab9cae42d4b460e5443
-    sha256: 66e5ffd301a44da696f3efc2f25d6d94f42a9adc0db06c44ad753ab844148c51
+    md5: e429aec4037d5cb8fd34ded9f5dadd39
+    sha256: c97aa17d16d2ac332ba9f184e82ce8f72dcb10e9a10c5f299030be2d44e191b9
   category: main
   optional: false
 - name: lerc
-  version: 4.1.0
+  version: 4.2.0
   manager: conda
   platform: win-64
   dependencies:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/lerc-4.1.0-hd936e49_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/lerc-4.2.0-hd936e49_0.conda
   hash:
-    md5: 54b231d595bc1ff9bff668dd443ee012
-    sha256: 45df58fca800b552b17c3914cc9ab0d55a82c5172d72b5c44a59c710c06c5473
+    md5: add59e2b60ac9d4299d17c938185c75a
+    sha256: 93d666f63f284ef77b87b0b1f77b70f7d36d315a132f9afa64bc0012d937ba39
   category: main
   optional: false
 - name: level-zero
@@ -2085,16 +2087,16 @@ package:
   category: main
   optional: false
 - name: libabseil
-  version: '20260107.1'
+  version: '20260526.0'
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20260107.1-cxx17_h2062a1b_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20260526.0-cxx17_h2062a1b_1.conda
   hash:
-    md5: bb65152e0d7c7178c0f1ee25692c9fd1
-    sha256: 756611fbb8d2957a5b4635d9772bd8432cb6ddac05580a6284cca6fdc9b07fca
+    md5: 8adfdc0215e979a0ce31be676883e0b3
+    sha256: 450026eb01a52acd0ff122e331ec9b8546c93790143214b73e1c14bc2b075b22
   category: main
   optional: false
 - name: libabseil
@@ -2174,23 +2176,23 @@ package:
   category: main
   optional: false
 - name: libass
-  version: 0.17.4
+  version: 0.17.5
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    fontconfig: '>=2.15.0,<3.0a0'
+    fontconfig: '>=2.18.1,<3.0a0'
     fonts-conda-ecosystem: ''
-    fribidi: '>=1.0.10,<2.0a0'
-    harfbuzz: '>=11.0.1'
-    libfreetype: '>=2.13.3'
-    libfreetype6: '>=2.13.3'
+    fribidi: '>=1.0.16,<2.0a0'
+    harfbuzz: '>=14.2.1'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
     libiconv: '>=1.18,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libass-0.17.4-hcbd7ca7_0.conda
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libass-0.17.5-h3245dfc_0.conda
   hash:
-    md5: 0977f4a79496437ff3a2c97d13c4c223
-    sha256: 079f5fdf7aace970a0db91cd2cc493c754dfdc4520d422ecec43d2561021167a
+    md5: baae8eafd053d3e6bd88c6d053c6f624
+    sha256: b006fccaa3e4d122188bd3db71d630d4d3a7d2f99fbcdef5ac53b3299c65909d
   category: main
   optional: false
 - name: libavif16
@@ -2219,11 +2221,11 @@ package:
     aom: '>=3.14.1,<3.15.0a0'
     dav1d: '>=1.2.1,<1.2.2.0a0'
     rav1e: '>=0.8.1,<0.9.0a0'
-    svt-av1: '>=4.0.1,<4.0.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libavif16-1.4.2-hb274fc6_2.conda
+    svt-av1: '>=4.2.0,<4.2.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libavif16-1.4.2-h84013e8_3.conda
   hash:
-    md5: 7f5ec48626c409825086d6b76ea9cbca
-    sha256: 64eab781121ef9a020c55ca05b33514cf30c525a96ccf54fb158a597bbbd7ffd
+    md5: c180959743b896db9689e9e2d581af9a
+    sha256: 4ca37f5e0a48348578914f707bd45efef08d42a081d30a8471125f059be82d8b
   category: main
   optional: false
 - name: libavif16
@@ -2478,15 +2480,15 @@ package:
     krb5: '>=1.22.2,<1.23.0a0'
     libgcc: '>=14'
     libnghttp2: '>=1.68.1,<2.0a0'
-    libpsl: '>=0.22.0,<0.23.0a0'
+    libpsl: '>=0.23.0,<0.24.0a0'
     libssh2: '>=1.11.1,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     openssl: '>=3.5.7,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-hae6b9f4_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-heca4667_4.conda
   hash:
-    md5: f9c59d277a16ec8f272b2d5dd2ec3335
-    sha256: ba8354084b34fce56d5697982fce4a384c148e972e15c0ab891187617fe7ec29
+    md5: 3f2fd5617cfacac49c85f6dc63842ea1
+    sha256: aff8ef75636d0825ce34911e0bef2f26816e7afd090a9dcb4b9bacab75cbf584
   category: main
   optional: false
 - name: libcurl
@@ -2497,15 +2499,15 @@ package:
     __osx: '>=11.0'
     krb5: '>=1.22.2,<1.23.0a0'
     libnghttp2: '>=1.68.1,<2.0a0'
-    libpsl: '>=0.22.0,<0.23.0a0'
+    libpsl: '>=0.23.0,<0.24.0a0'
     libssh2: '>=1.11.1,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     openssl: '>=3.5.7,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.21.0-h1359186_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.21.0-hf618e03_4.conda
   hash:
-    md5: dfe89fb0539ad4611998a5c6905692ff
-    sha256: b21aec36796a7d9b3c8b634f2d466c1d0a2658b2e57aa4686285cf4c10d5c227
+    md5: 66cf9c5003ee81ecdb0dc9f9df17bbe5
+    sha256: d25be36712d7f854a5f93513b9fbf1b0ee3219975b7fef4a3ee071b021b10167
   category: main
   optional: false
 - name: libcurl
@@ -2514,16 +2516,16 @@ package:
   platform: win-64
   dependencies:
     krb5: '>=1.22.2,<1.23.0a0'
-    libpsl: '>=0.22.0,<0.23.0a0'
+    libpsl: '>=0.23.0,<0.24.0a0'
     libssh2: '>=1.11.1,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.21.0-h51a1c48_2.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.21.0-hdb0ef4a_4.conda
   hash:
-    md5: 88c875a8f34785d6f6185ceb646154fa
-    sha256: e9a9231e6c04b82979a6a1a4f90b8a697dc3a42884e709dee8ba5d0355b45296
+    md5: 5e9c5b83929cf7ab2c04121af771e7b5
+    sha256: af17c990ec52b6aba29e052c438d7ac61bfd541d6d183a8f09aa4f2c532c9bab
   category: main
   optional: false
 - name: libcxx
@@ -2870,89 +2872,89 @@ package:
   category: main
   optional: false
 - name: libgcc
-  version: 15.2.0
+  version: 16.1.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     _openmp_mutex: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda
   hash:
-    md5: 57736f29cc2b0ec0b6c2952d3f101b6a
-    sha256: 8e0a3b5e41272e5678499b5dfc4cddb673f9e935de01eb0767ce857001229f46
+    md5: 5a7d954665c707c93311657cd779c705
+    sha256: d5cb8475131c31680f8fd30512c418f373064e272e452063276a8fb14c9fa42f
   category: main
   optional: false
 - name: libgcc
-  version: 15.2.0
+  version: 16.1.0
   manager: conda
   platform: osx-arm64
   dependencies:
     _openmp_mutex: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-16.1.0-h3cf6597_1.conda
   hash:
-    md5: 644058123986582db33aebd4ae2ca184
-    sha256: 06644fa4d34d57c9e48f4d84b1256f9e5f654fdb37f43acc8a58a396952d42b7
+    md5: 0124dc2e6f70f3e8ebea643b42b18abb
+    sha256: fdd1502babb50b802d090496586231f56236d7a6fc042a4e1ac2dee48da8366b
   category: main
   optional: false
 - name: libgcc-ng
-  version: 15.2.0
+  version: 16.1.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc: 15.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
+    libgcc: 16.1.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-16.1.0-h69a702a_1.conda
   hash:
-    md5: 331ee9b72b9dff570d56b1302c5ab37d
-    sha256: 9dcf54adfaa5e861123c2da4f2f0451a685464ea7e5a41ad91cf67b31d658d98
+    md5: 7ed870c014a6f23c7dfafda53d2763a9
+    sha256: 225275c562337a1cd61705da0ee4235dde7bba7504de1c34b74c894adb2b0eee
   category: main
   optional: false
 - name: libgfortran
-  version: 15.2.0
+  version: 16.1.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgfortran5: 15.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
+    libgfortran5: 16.1.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.1.0-h69a702a_1.conda
   hash:
-    md5: 42bf7eca1a951735fa06c0e3c0d5c8e6
-    sha256: 561a42758ef25b9ce308c4e2cf56daee4f06138385a17e29a492cd928e00be6f
+    md5: 2fbed65cc90cf0724e1ec4de13696737
+    sha256: 9e82d410a50bd4e5e47cbbb026454c3eb543954baca4db23929575b571bf56a3
   category: main
   optional: false
 - name: libgfortran
-  version: 15.2.0
+  version: 16.1.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    libgfortran5: 15.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
+    libgfortran5: 16.1.0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-16.1.0-h07b0088_1.conda
   hash:
-    md5: 1ea03f87cdb1078fbc0e2b2deb63752c
-    sha256: d4837b3b9b30af3132d260225e91ab9dde83be04c59513f500cc81050fb37486
+    md5: d6f10dbb9c5830f540904c91ea5b252a
+    sha256: d7c6dd601dbbde495ab213a76d690b2fec19455d26c595ec0257cfde3e80166b
   category: main
   optional: false
 - name: libgfortran5
-  version: 15.2.0
+  version: 16.1.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15.2.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
+    libgcc: '>=16.1.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.1.0-h79bb938_1.conda
   hash:
-    md5: 85072b0ad177c966294f129b7c04a2d5
-    sha256: 057978bb69fea29ed715a9b98adf71015c31baecc4aeb2bfc20d4fd5d83579d4
+    md5: dd51ed33e8c70995f8e33cc9dc537297
+    sha256: 05078ab464d506dff971860cb1a553b35bc27c0b5ce8ec29b8bfaca5f2359652
   category: main
   optional: false
 - name: libgfortran5
-  version: 15.2.0
+  version: 16.1.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    libgcc: '>=15.2.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
+    libgcc: '>=16.1.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-16.1.0-h32cdfcc_1.conda
   hash:
-    md5: ba36d8c606a6a53fe0b8c12d47267b3d
-    sha256: d0a68b7a121d115b80c169e24d1265dcc25a3fe58d107df1bbc430797e226d88
+    md5: c1c10ea48f95054aa9b93c2315a0a74a
+    sha256: 3e8cb79a421e0c350566717febdba9079574cbbe204591b4fd4b4081ea89cb92
   category: main
   optional: false
 - name: libgl
@@ -2984,7 +2986,7 @@ package:
   category: main
   optional: false
 - name: libglib
-  version: 2.88.2
+  version: 2.88.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -2994,14 +2996,14 @@ package:
     libiconv: '>=1.18,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     pcre2: '>=10.47,<10.48.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.2-h0d30a3d_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.3-h0d30a3d_0.conda
   hash:
-    md5: 889febc66cd9e4190f80ef9718fa239b
-    sha256: 4bee10e62796f01e4fa2b5849135b1cc061337fe9cf5eb9bd79e9664922ae0e4
+    md5: 17c3b7b6bcbd35b688c933eb4834c0bc
+    sha256: 69ea4df61403531e5b3e5f3d52ba2837423df361b4eb8727f5b63aaf6de6768a
   category: main
   optional: false
 - name: libglib
-  version: 2.88.2
+  version: 2.88.3
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -3011,14 +3013,14 @@ package:
     libintl: '>=0.25.1,<1.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     pcre2: '>=10.47,<10.48.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.88.2-ha08bb59_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.88.3-ha08bb59_0.conda
   hash:
-    md5: 03123cafdc96cef79fc8a615f9119b79
-    sha256: 68ac66904a284a7dfbb3bdf9225380eaf20750b2d414215e6d7af5caa3ed1a63
+    md5: 4a9309d9502a08a2d29b1743dcfb0e7f
+    sha256: a14417ae1f3f4a92c5766354eb280342fa6aae72a09af86bf7fcfc12a8c9225c
   category: main
   optional: false
 - name: libglib
-  version: 2.88.2
+  version: 2.88.3
   manager: conda
   platform: win-64
   dependencies:
@@ -3030,10 +3032,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/libglib-2.88.2-h7ce1215_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libglib-2.88.3-h7ce1215_0.conda
   hash:
-    md5: 5be116480ef34a5646894d7f7cd7ae41
-    sha256: 20d4a182b8aa1d71b331579fae281bb3ccb1a199257ce15fadc53786031a7408
+    md5: 2f43ad5d918b2e6968bd61cc8daff62c
+    sha256: 016bebb5832f5ca5f9cb29a19e1a8fabe66e5a5b5bbbbdf738142e7fb36e3117
   category: main
   optional: false
 - name: libglvnd
@@ -3078,15 +3080,15 @@ package:
   category: main
   optional: false
 - name: libgomp
-  version: 15.2.0
+  version: 16.1.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda
   hash:
-    md5: faac990cb7aedc7f3a2224f2c9b0c26c
-    sha256: 5abe4ab9d93f6c9757d654f1969ae2267d4505315c1f2f8fe705fd60af084f1b
+    md5: 88f2d91cb1533194c323534253094d23
+    sha256: 62cb599ad0539d99386515326d9d5e8f51f75a60c69c2131b21df76edf35bd89
   category: main
   optional: false
 - name: libharfbuzz
@@ -3451,7 +3453,7 @@ package:
   category: main
   optional: false
 - name: libjxl
-  version: 0.11.2
+  version: 0.12.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -3460,10 +3462,10 @@ package:
     libbrotlienc: '>=1.2.0,<1.3.0a0'
     libcxx: '>=19'
     libhwy: '>=1.4.0,<1.5.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libjxl-0.11.2-h934fa54_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libjxl-0.12.0-h934fa54_1.conda
   hash:
-    md5: 05bead8980f5ae6a070117dacec38b5b
-    sha256: 948cf1370abb58e06a7c9554838c68672ef1d78e01c3fc4e62ccfc3072579645
+    md5: a7040219e41397bf619b7062aaa88de1
+    sha256: 83b69f759845ddc12444f5a812bdf08782ab2b0156ae08b706b26777918416c3
   category: main
   optional: false
 - name: libjxl
@@ -3813,9 +3815,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    __osx: '>=11.0'
+    __osx: '>=12.0'
     ffmpeg: '>=8.1.2,<9.0a0'
-    harfbuzz: '>=14.2.1'
     hdf5: '>=2.1.0,<3.0a0'
     imath: '>=3.2.2,<3.2.3.0a0'
     libavif16: '>=1.4.2,<2.0a0'
@@ -3824,9 +3825,10 @@ package:
     libexpat: '>=2.8.1,<3.0a0'
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
+    libharfbuzz: '>=14.2.1'
     libiconv: '>=1.18,<2.0a0'
     libjpeg-turbo: '>=3.1.4.1,<4.0a0'
-    libjxl: '>=0.11,<0.12.0a0'
+    libjxl: '>=0.12,<0.13.0a0'
     liblapack: '>=3.9.0,<4.0a0'
     liblapacke: '>=3.9.0,<4.0a0'
     libopenvino: '>=2026.2.1,<2026.2.2.0a0'
@@ -3841,17 +3843,17 @@ package:
     libopenvino-tensorflow-frontend: '>=2026.2.1,<2026.2.2.0a0'
     libopenvino-tensorflow-lite-frontend: '>=2026.2.1,<2026.2.2.0a0'
     libpng: '>=1.6.58,<1.7.0a0'
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-    libtiff: '>=4.7.1,<4.8.0a0'
+    libprotobuf: '>=7.35.1,<7.35.2.0a0'
+    libtiff: '>=4.7.2,<4.8.0a0'
     libwebp-base: '>=1.6.0,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     openexr: '>=3.4.13,<3.5.0a0'
     openjpeg: '>=2.5.4,<3.0a0'
     qt6-main: '>=6.11.1,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopencv-4.13.0-qt6_h73155a5_612.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopencv-4.13.0-qt6_h7cc65be_614.conda
   hash:
-    md5: 0fd3eacba04dae0fc549535caf6016ea
-    sha256: e362f634d1e9797ef6ccf33a1a17f2d67eeb22a1d1d739d56931d6b0f3ed23df
+    md5: 86ea6f5a023a9ab7354fbb6903fc1a16
+    sha256: eb80b8717c15b334c6fbbd6d55d541436505642ada2f6aeae76df2ee7a61ada2
   category: main
   optional: false
 - name: libopencv
@@ -3922,14 +3924,14 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    __osx: '>=11.0'
+    __osx: '>=12.0'
     libcxx: '>=19'
     pugixml: '>=1.15,<1.16.0a0'
     tbb: '>=2023.0.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-2026.2.1-hd05642e_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-2026.2.1-hfa24db2_1.conda
   hash:
-    md5: c97c467b953b3723a645ae98872d321a
-    sha256: d4ba0b190ca76c44e7eb10c07ca89cf71c4c56c3203e9b02ae135340cae80d7c
+    md5: 90b340215b818adcf12b0fd65b5d76e7
+    sha256: c528307f4a3086e8c33395777b026cf88c23efe3fe3c69a5789af8ab98ccba93
   category: main
   optional: false
 - name: libopenvino
@@ -3953,15 +3955,15 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    __osx: '>=11.0'
+    __osx: '>=12.0'
     libcxx: '>=19'
     libopenvino: 2026.2.1
     pugixml: '>=1.15,<1.16.0a0'
     tbb: '>=2023.0.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-arm-cpu-plugin-2026.2.1-hd05642e_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-arm-cpu-plugin-2026.2.1-hfa24db2_1.conda
   hash:
-    md5: 616c52a19cc52ba63663d3c6893f569c
-    sha256: 40df92e57446d5fb982f170fddf11382e84311e86591e393ab2c7f163d656935
+    md5: 03fdaf6ab791b935b9ab48d4f3e2db60
+    sha256: cc4ac427fea98eac92a140323a43fd4806a0fd4813731f2d6461fbc72b6cd85f
   category: main
   optional: false
 - name: libopenvino-auto-batch-plugin
@@ -3985,14 +3987,14 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    __osx: '>=11.0'
+    __osx: '>=12.0'
     libcxx: '>=19'
     libopenvino: 2026.2.1
     tbb: '>=2023.0.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-batch-plugin-2026.2.1-h4f620ee_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-batch-plugin-2026.2.1-ha718330_1.conda
   hash:
-    md5: 63444448cc5815092c549d69de1d0d2f
-    sha256: 669fce76be51fbeccd16aa856c05427b6787be07d454965f48ad17d659916424
+    md5: d48adb2a5752924c25c558e597ca1037
+    sha256: a4eaa64bf1d4e6f50fe6f086c78adcbac5968990ea04c9fa5552babcdd0e55c3
   category: main
   optional: false
 - name: libopenvino-auto-batch-plugin
@@ -4032,14 +4034,14 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    __osx: '>=11.0'
+    __osx: '>=12.0'
     libcxx: '>=19'
     libopenvino: 2026.2.1
     tbb: '>=2023.0.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-plugin-2026.2.1-h4f620ee_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-plugin-2026.2.1-ha718330_1.conda
   hash:
-    md5: 0a74d4168cadc60ecfcd264849c68273
-    sha256: f5fff21231e01541631ab4f86016a1b5160d0f5556d21ff00c78b55cc9b4f23c
+    md5: 6d544d2751c6c795b35ad52c6c8d6953
+    sha256: 8910f0823bae3e2b7cb39373717e5e56ebc33c96c534145e06ddde82fb5d0f5e
   category: main
   optional: false
 - name: libopenvino-auto-plugin
@@ -4079,14 +4081,14 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    __osx: '>=11.0'
+    __osx: '>=12.0'
     libcxx: '>=19'
     libopenvino: 2026.2.1
     pugixml: '>=1.15,<1.16.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-hetero-plugin-2026.2.1-h85cbfa6_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-hetero-plugin-2026.2.1-h08494e5_1.conda
   hash:
-    md5: b81669add82aeb3cd91cece122fc8cec
-    sha256: a2745c64b7888e52b6c1d2d2142013694b03c6585bb183dc41473441a898539a
+    md5: 6dda6d7faa9817537c68c5d4162ebc9c
+    sha256: d3b04addaa599802c3fd4eb48dab54e413d28aaf8273cb200fcb3057dd2d8289
   category: main
   optional: false
 - name: libopenvino-hetero-plugin
@@ -4214,14 +4216,14 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    __osx: '>=11.0'
+    __osx: '>=12.0'
     libcxx: '>=19'
     libopenvino: 2026.2.1
     pugixml: '>=1.15,<1.16.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-ir-frontend-2026.2.1-h85cbfa6_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-ir-frontend-2026.2.1-h08494e5_1.conda
   hash:
-    md5: 28abf17a1e589c38e548e3d0ca82b080
-    sha256: 669fbff967cd8855dbdb24a5542060eab373ff592681524fd26e91a49585482e
+    md5: 842a5bcc53e10e77a8f6861f42e891a9
+    sha256: 6387d2667fe5bd1db6324a8abb77fa9c7df5a7dc2a2cebcce86cc0e9286ce938
   category: main
   optional: false
 - name: libopenvino-ir-frontend
@@ -4262,15 +4264,15 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    __osx: '>=11.0'
-    libabseil: '*,>=20260107.1,<20260108.0a0'
+    __osx: '>=12.0'
+    libabseil: '*,>=20260526.0,<20260527.0a0'
     libcxx: '>=19'
     libopenvino: 2026.2.1
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-onnx-frontend-2026.2.1-h41365f2_0.conda
+    libprotobuf: '>=7.35.1,<7.35.2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-onnx-frontend-2026.2.1-he3901d5_1.conda
   hash:
-    md5: 0666441b9449e2881a9b8779bcadd0d6
-    sha256: 5d0dd01475470bc88d2566a3b0790df771df8c67b28001802f095d219479c3fc
+    md5: 4e9daab1c7c95165c14d7e28ea3b1973
+    sha256: f38d5234ca3a5d2e7915e15ad397c1f85e6c2fe7e83186b20adf284012321a2c
   category: main
   optional: false
 - name: libopenvino-onnx-frontend
@@ -4312,15 +4314,15 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    __osx: '>=11.0'
-    libabseil: '*,>=20260107.1,<20260108.0a0'
+    __osx: '>=12.0'
+    libabseil: '*,>=20260526.0,<20260527.0a0'
     libcxx: '>=19'
     libopenvino: 2026.2.1
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-paddle-frontend-2026.2.1-h41365f2_0.conda
+    libprotobuf: '>=7.35.1,<7.35.2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-paddle-frontend-2026.2.1-he3901d5_1.conda
   hash:
-    md5: bd7d05e44936cb51bc913ed8c8531d40
-    sha256: 6006c9a19f78845699fc26fbb3baa2a965fe7c1149b8705b5052809e957319f3
+    md5: 44ba0d325b8efcc49c64b4f420c52547
+    sha256: d6bad39c3a8630aeb3477f5e79f8d7be3093ad75b1c3e60794315c76b8545748
   category: main
   optional: false
 - name: libopenvino-paddle-frontend
@@ -4360,13 +4362,13 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    __osx: '>=11.0'
+    __osx: '>=12.0'
     libcxx: '>=19'
     libopenvino: 2026.2.1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-pytorch-frontend-2026.2.1-hf6b4638_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-pytorch-frontend-2026.2.1-hc79b7da_1.conda
   hash:
-    md5: 233ec3d2f810275a790334ba594d7ee7
-    sha256: d9fd6f86116bc41a75c68883324981027b97774aa6b00a9b2fd9a3f0f614b8c5
+    md5: 7c0fd3b190dac287d024364c0a6d97c0
+    sha256: aa7d967a9adc461a6616e3d78ae987b85ea8c3e4e1fd0740287a852e630bf84b
   category: main
   optional: false
 - name: libopenvino-pytorch-frontend
@@ -4407,16 +4409,16 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    __osx: '>=11.0'
-    libabseil: '*,>=20260107.1,<20260108.0a0'
+    __osx: '>=12.0'
+    libabseil: '*,>=20260526.0,<20260527.0a0'
     libcxx: '>=19'
     libopenvino: 2026.2.1
-    libprotobuf: '>=6.33.5,<6.33.6.0a0'
+    libprotobuf: '>=7.35.1,<7.35.2.0a0'
     snappy: '>=1.2.2,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-frontend-2026.2.1-hc295da0_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-frontend-2026.2.1-hd0d7238_1.conda
   hash:
-    md5: dffdf1bd0585e7c569ee5d55ec8ce520
-    sha256: 973b0e61befcdb0c2024248b1d41b1597207a26a6aa3222a3f56a24ee38614b6
+    md5: 87b4dff3afccff268042a80b55fc21ac
+    sha256: 6b9e348d40828976f639fd49ca4f24ca0393601ee1344d34e636ec0136f6218e
   category: main
   optional: false
 - name: libopenvino-tensorflow-frontend
@@ -4457,13 +4459,13 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    __osx: '>=11.0'
+    __osx: '>=12.0'
     libcxx: '>=19'
     libopenvino: 2026.2.1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-lite-frontend-2026.2.1-hf6b4638_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-lite-frontend-2026.2.1-hc79b7da_1.conda
   hash:
-    md5: fb12b5fa9aef86a20fb9b0d93eb5d948
-    sha256: 3aab3b73105c6d894fcb1e75a8d1aa77da55e260db6abb1bbad760bde950de3f
+    md5: 590fa0df3e6c01e911dabdde0d4239c8
+    sha256: 49ac425bff783350b0605982d321f2af34113fec1d8082e127995bcfc0e83ac1
   category: main
   optional: false
 - name: libopenvino-tensorflow-lite-frontend
@@ -4557,15 +4559,15 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    lcms2: '>=2.19,<3.0a0'
+    lcms2: '>=2.19.1,<3.0a0'
     libcxx: '>=19'
-    libdovi: '>=3.3.2,<4.0a0'
+    libdovi: '>=3.4.0,<4.0a0'
     libvulkan-loader: '>=1.4.341.0,<2.0a0'
-    shaderc: '>=2026.2,<2026.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libplacebo-7.360.1-h176d363_0.conda
+    shaderc: '>=2026.3,<2026.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libplacebo-7.360.1-hca394fb_1.conda
   hash:
-    md5: 7402fdef0c155dcd18c0ff4c5853c4b2
-    sha256: e9b39572e2feaef496167ba9f4ab75ed3afa4c16c3aeb0bb8c71adc515a74536
+    md5: dff7f8dd3053f3253d79171216aa1db7
+    sha256: 7b50ecb8b110540b5b980ba94499fe760947e079bc119a7fac02dfb3df9cfb53
   category: main
   optional: false
 - name: libpng
@@ -4660,18 +4662,18 @@ package:
   category: main
   optional: false
 - name: libprotobuf
-  version: 6.33.5
+  version: 7.35.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    __osx: '>=11.0'
-    libabseil: '*,>=20260107.1,<20260108.0a0'
+    __osx: '>=12.0'
+    libabseil: '*,>=20260526.0,<20260527.0a0'
     libcxx: '>=19'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-6.33.5-hb82ec63_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-7.35.1-h8daa630_2.conda
   hash:
-    md5: fa6df7c5daaa2c0f22da8c742da223ec
-    sha256: 619d06e4cd3f2501c7cfce3b64739726609da79cc000f66090b753a6f4ed472c
+    md5: 7f77d9a99dd9e79e1f5be50d6632f675
+    sha256: 782d30325e61249e3240979e0f76d9dbf67867b1f38424cfdb1abb3a0f2cfa95
   category: main
   optional: false
 - name: libprotobuf
@@ -4691,7 +4693,7 @@ package:
   category: main
   optional: false
 - name: libpsl
-  version: 0.22.0
+  version: 0.23.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -4699,28 +4701,28 @@ package:
     icu: '>=78.3,<79.0a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.22.0-h49b2146_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.23.0-hf670292_0.conda
   hash:
-    md5: af5ddfb52ad25d833c70c7511478d4eb
-    sha256: 71118885feab91c61bea4e9532ec46e0653b24f02e563681f822915aee8435bb
+    md5: 075e9aafb806c06f190e4757506d2631
+    sha256: bbb184b81f28a868528b05a81db2448a232a762e47c983330d57b98e1211ae32
   category: main
   optional: false
 - name: libpsl
-  version: 0.22.0
+  version: 0.23.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     icu: '>=78.3,<79.0a0'
     libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpsl-0.22.0-h92480b3_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpsl-0.23.0-h7a62e17_0.conda
   hash:
-    md5: 9bced3ae8f4bc78a5b22f7247554c9ee
-    sha256: 1dd03b21e74f41ed7af31d82f61129d94e3cce31485eb221e3acecba26ab34bf
+    md5: 1aecee022672c6c97c827ceb6b0e2ead
+    sha256: f71026a40df9ef28ada6d97c0f441e7ca9bafa03d0ae0c3f5f03d1971acb656b
   category: main
   optional: false
 - name: libpsl
-  version: 0.22.0
+  version: 0.23.0
   manager: conda
   platform: win-64
   dependencies:
@@ -4728,10 +4730,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/libpsl-0.22.0-h25e0afd_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libpsl-0.23.0-h9b16d47_0.conda
   hash:
-    md5: ba200e33e10ccf0d730c4ce87badbdf1
-    sha256: 040d4adabae2634b13183203e383c21f74ed98028b5d50bf9bae4968dd05aaa5
+    md5: 826ae14cd895bd1bf9d98a16ecba030e
+    sha256: f3e3f69cefe8a999fc5dd20f774273dc60b55516d25bdc7d09e128e6b2b47089
   category: main
   optional: false
 - name: librsvg
@@ -4816,44 +4818,46 @@ package:
   category: main
   optional: false
 - name: libsqlite
-  version: 3.53.3
+  version: 3.53.4
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
+    icu: '>=78.3,<79.0a0'
     libgcc: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.3-h0c1763c_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-hf4e2dac_0.conda
   hash:
-    md5: 4aed8e657e9ff156bdbe849b4df44389
-    sha256: 365376f4815e5e80def2b3462a2419708b7c292da0da85278386c2618621fff4
+    md5: df088a279cd5e6fd2790b4c196434da1
+    sha256: 72023efc207fe681e26b65fc9d668062cf0b4f0eacf3431e6eb099b95c1f2efd
   category: main
   optional: false
 - name: libsqlite
-  version: 3.53.3
+  version: 3.53.4
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.3-h1b79a29_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-h1ae2325_0.conda
   hash:
-    md5: 7184d95871a58b8258a8ea124ed5aabc
-    sha256: a73a8acd97a6599fd6e561514db9f101ca7fd984cdc0cfd91ba74c8aa9dbe067
+    md5: 0e3477c0c3e718dcf2eb74ccc8f68570
+    sha256: 745662565e103f290e9dc4263bbd88285082f8cf699854fe2d5f1e35a4a0d326
   category: main
   optional: false
 - name: libsqlite
-  version: 3.53.3
+  version: 3.53.4
   manager: conda
   platform: win-64
   dependencies:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.53.3-hf5d6505_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.53.4-hf5d6505_0.conda
   hash:
-    md5: 051f1b2228e7517a2ef8cca5146c8967
-    sha256: 692dfb73a22c873656d5e393b8f1e2b019a3c8a6486c97cb6900552e64e38c25
+    md5: ca0d59f40a02a15e9b5d0ff8db0f85e3
+    sha256: 62e1c45ec71ab2e5deeeb0e47e7df6a609991e91d46348f16df50c68fee145c8
   category: main
   optional: false
 - name: libssh2
@@ -4901,28 +4905,28 @@ package:
   category: main
   optional: false
 - name: libstdcxx
-  version: 15.2.0
+  version: 16.1.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc: 15.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+    libgcc: 16.1.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
   hash:
-    md5: 5794b3bdc38177caf969dabd3af08549
-    sha256: dff1058c76ec6b8759e41cefa2508162d00e4a5e6721aa68ec3fd10094e702dc
+    md5: aed6cf89adc1e9b846e4367ac538e434
+    sha256: 79721dd08aeb0ab9e773f1f9ef41cf4e6c17477e3d72319147619045bce05a09
   category: main
   optional: false
 - name: libstdcxx-ng
-  version: 15.2.0
+  version: 16.1.0
   manager: conda
   platform: linux-64
   dependencies:
-    libstdcxx: 15.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_19.conda
+    libstdcxx: 16.1.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-16.1.0-hdf11a46_1.conda
   hash:
-    md5: e5ce228e579726c07255dbf90dc62101
-    sha256: 0672b6b6e1791c92e8eccad58081a99d614fcf82bca5841f9dfa3c3e658f83b9
+    md5: c94f06123272d8e129d4acf3a25ffb35
+    sha256: 2876ca4463d1b394eb969ce4a84d1620aa63fb8202a6397837d1e45ec76c1208
   category: main
   optional: false
 - name: libsystemd0
@@ -5245,46 +5249,46 @@ package:
   category: main
   optional: false
 - name: libvulkan-loader
-  version: 1.4.341.0
+  version: 1.4.357.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-    xorg-libx11: '>=1.8.12,<2.0a0'
+    xorg-libx11: '>=1.8.13,<2.0a0'
     xorg-libxrandr: '>=1.5.5,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libvulkan-loader-1.4.341.0-h5279c79_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libvulkan-loader-1.4.357.0-h5279c79_0.conda
   hash:
-    md5: 31ad065eda3c2d88f8215b1289df9c89
-    sha256: a68280d57dfd29e3d53400409a39d67c4b9515097eba733aa6fe00c880620e2b
+    md5: 9d8c72f797f6f2d1c32897603d70824c
+    sha256: 1e30138cff1e6ba5739ce3ec787b24ef22ac6e2008d8a2073df334e9e5f8690b
   category: main
   optional: false
 - name: libvulkan-loader
-  version: 1.4.341.0
+  version: 1.4.357.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libvulkan-loader-1.4.341.0-h3feff0a_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libvulkan-loader-1.4.357.0-h3feff0a_0.conda
   hash:
-    md5: 6b4c9a5b130759136a0dde0c373cb0ea
-    sha256: d2790dafc9149b1acd45b9033d02cfa3f3e9ee5af97bd61e0a5718c414a0a135
+    md5: 0996a81de4f2e102521aed02fa6d95eb
+    sha256: 0ce6db16d80c6e1992d25661bdcc0eac041e9f0a2e8b7f7ccd01fb667382f742
   category: main
   optional: false
 - name: libvulkan-loader
-  version: 1.4.341.0
+  version: 1.4.357.0
   manager: conda
   platform: win-64
   dependencies:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/libvulkan-loader-1.4.341.0-h477610d_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libvulkan-loader-1.4.357.0-h477610d_0.conda
   hash:
-    md5: 804880b2674119b84277d6c16b01677d
-    sha256: 0f0965edca8b255187604fc7712c53fe9064b31a1845a7dfb2b63bf660de84a7
+    md5: 63d913ed8ee946e25b1ebf7d9f477b67
+    sha256: 432d4796261bc4a4525e8ecf262361c3f69d815af823ebf60242093e47333674
   category: main
   optional: false
 - name: libwebp-base
@@ -5496,10 +5500,10 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
   hash:
-    md5: d87ff7921124eccd67248aa483c23fec
-    sha256: 55044c403570f0dc26e6364de4dc5368e5f3fc7ff103e867c487e2b5ab2bcda9
+    md5: 0de0122d9570a8ab637c6b73db268389
+    sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
   category: main
   optional: false
 - name: libzlib
@@ -5508,10 +5512,10 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
   hash:
-    md5: bc5a5721b6439f2f62a84f2548136082
-    sha256: 361415a698514b19a852f5d1123c5da746d4642139904156ddfca7c922d23a05
+    md5: f39288f0ea63ae962e1a2e4f355a0d75
+    sha256: a18fa5d5bac452401459f966cf0d872224e8080c4ff93c77e168d43ab42ef9d7
   category: main
   optional: false
 - name: libzlib
@@ -5522,10 +5526,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.2-hfd05255_2.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.2-hfd05255_3.conda
   hash:
-    md5: dbabbd6234dea34040e631f87676292f
-    sha256: 88609816e0cc7452bac637aaf65783e5edf4fee8a9f8e22bdc3a75882c536061
+    md5: 5d2ff29d465097458cc3ff6569151991
+    sha256: 0629c2cc0404d3bb29d6baa7b4ba62da80797015e86de050db81ea5a07050527
   category: main
   optional: false
 - name: llvm-openmp
@@ -5552,6 +5556,19 @@ package:
   hash:
     md5: c7f302fd11eeb0987a6a5e1f3aed6a21
     sha256: 39c4700fb3fbe403a77d8cc27352fa72ba744db487559d5d44bf8411bb4ea200
+  category: main
+  optional: false
+- name: mpg123
+  version: 1.32.9
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=18'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/mpg123-1.32.9-hf642e45_0.conda
+  hash:
+    md5: d2b4857bdc3b76c36e23236172d09840
+    sha256: 070bbbbb96856c325c0b6637638ce535afdc49adbaff306e2238c6032d28dddf
   category: main
   optional: false
 - name: mpg123
@@ -5743,11 +5760,11 @@ package:
     libgcc: '>=14'
     libstdcxx: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-    openjph: '>=0.30.1,<0.31.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.4.13-hf734b31_1.conda
+    openjph: '>=0.31.0,<0.32.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.4.13-h6de6307_2.conda
   hash:
-    md5: 9db8aff65eaea058afc9fe93569b4b14
-    sha256: 17e3d2769dfc018748f0c09757b95744a5e942f74325b605d06303a69ee7955d
+    md5: 7161bd368507413012914284f8182712
+    sha256: 2404399799fd4f6c76af77a57a12c01af2295d24146bd8a4b7dda5a33b066ea2
   category: main
   optional: false
 - name: openexr
@@ -5760,11 +5777,11 @@ package:
     libcxx: '>=19'
     libdeflate: '>=1.25,<1.26.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    openjph: '>=0.30.1,<0.31.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openexr-3.4.13-hafff71b_1.conda
+    openjph: '>=0.31.0,<0.32.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openexr-3.4.13-he09da85_2.conda
   hash:
-    md5: f062abba9ac3103008873dee4f9eb2d7
-    sha256: c541230d27685e192333d081c66a16baf8318ac95997a683b935303592bfa274
+    md5: a4ed37864e4051d409ec9d5cbe1c3d7b
+    sha256: 5e6249b5034158c9007651b0dbfdbc0254d90e1c7967f6c15bdaf6ef0c5413ec
   category: main
   optional: false
 - name: openexr
@@ -5775,14 +5792,14 @@ package:
     imath: '>=3.2.2,<3.2.3.0a0'
     libdeflate: '>=1.25,<1.26.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-    openjph: '>=0.30.1,<0.31.0a0'
+    openjph: '>=0.31.0,<0.32.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/openexr-3.4.13-hd20f895_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/openexr-3.4.13-hea798b2_2.conda
   hash:
-    md5: cb83fa215048c5da5dc8a14c7fe37485
-    sha256: a00088687b2eb0c22041be2e74fa3222c44b42667415e10e8312365a245d061c
+    md5: 69e94c883d2db783bc5938bb15901b8e
+    sha256: 3e8e10219afde61e8c4562844c640b9258d8f4fea35072b9e2dc012d26ae5db9
   category: main
   optional: false
 - name: openh264
@@ -5877,47 +5894,47 @@ package:
   category: main
   optional: false
 - name: openjph
-  version: 0.30.1
+  version: 0.31.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-    libtiff: '>=4.7.1,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openjph-0.30.1-h8d634f6_0.conda
+    libtiff: '>=4.7.2,<4.8.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/openjph-0.31.0-h8d634f6_0.conda
   hash:
-    md5: 6143d4af035262f7e1b954e1cba9156d
-    sha256: e405a62cc16604c4274d1d64387fa62ba5466cc65fa087ae45451d0150f4b698
+    md5: 49ca947333c62d5985a88cbdd8f59468
+    sha256: 3c7a4118c678c43952ea10183388f175a4bcee16a1c61d90dab2fbdafddc45d7
   category: main
   optional: false
 - name: openjph
-  version: 0.30.1
+  version: 0.31.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=19'
-    libtiff: '>=4.7.1,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openjph-0.30.1-h2a4d681_0.conda
+    libtiff: '>=4.7.2,<4.8.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openjph-0.31.0-h2a4d681_0.conda
   hash:
-    md5: 1b1d7b258c71a33d01458ad1c8e04d44
-    sha256: d4022be925a3d6ad3e4d482da914a98076b2031737b0ca79b2bcc2db9f162963
+    md5: 2afb97479668cfb83c386074f8050ad6
+    sha256: 853c41f0e041a5c1acce60490ec065e4ca1b43d7b63fbad504980de3a822f719
   category: main
   optional: false
 - name: openjph
-  version: 0.30.1
+  version: 0.31.0
   manager: conda
   platform: win-64
   dependencies:
-    libtiff: '>=4.7.1,<4.8.0a0'
+    libtiff: '>=4.7.2,<4.8.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/openjph-0.30.1-hf13a347_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/openjph-0.31.0-hf13a347_0.conda
   hash:
-    md5: 47ed976bdc702ab527737d6dc0d7e6d7
-    sha256: 5deaf995e476e6928dedced3254025b568a70a905f04ad23fd150d9abe558b91
+    md5: 2f8560599ae249579d698f80d48df455
+    sha256: 37a5104c0adb4bbdccc856dd9458c631fc260da4ba1aaced3fb27b4a08a0c341
   category: main
   optional: false
 - name: openldap
@@ -6032,75 +6049,75 @@ package:
   category: main
   optional: false
 - name: pango
-  version: 1.56.4
+  version: 1.58.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     cairo: '>=1.18.4,<2.0a0'
-    fontconfig: '>=2.17.1,<3.0a0'
+    fontconfig: '>=2.18.2,<3.0a0'
     fonts-conda-ecosystem: ''
     fribidi: '>=1.0.16,<2.0a0'
-    harfbuzz: '>=13.2.1'
-    libexpat: '>=2.7.4,<3.0a0'
-    libfreetype: '>=2.14.2'
-    libfreetype6: '>=2.14.2'
+    libexpat: '>=2.8.1,<3.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
     libgcc: '>=14'
-    libglib: '>=2.86.4,<3.0a0'
-    libpng: '>=1.6.55,<1.7.0a0'
+    libglib: '>=2.88.2,<3.0a0'
+    libharfbuzz: '>=14.2.1'
+    libpng: '>=1.6.58,<1.7.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hda50119_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pango-1.58.0-hda50119_0.conda
   hash:
-    md5: d53ffc0edc8eabf4253508008493c5bc
-    sha256: 315b52bfa6d1a820f4806f6490d472581438a28e21df175290477caec18972b0
+    md5: ef685e254006246695cbc36cf3fda159
+    sha256: ec020fd570ba116c06592af8d8ce05f41c20b6d673d1a8a7a5a98fecad0f4b14
   category: main
   optional: false
 - name: pango
-  version: 1.56.4
+  version: 1.58.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     cairo: '>=1.18.4,<2.0a0'
-    fontconfig: '>=2.17.1,<3.0a0'
+    fontconfig: '>=2.18.2,<3.0a0'
     fonts-conda-ecosystem: ''
     fribidi: '>=1.0.16,<2.0a0'
-    harfbuzz: '>=13.2.1'
-    libexpat: '>=2.7.4,<3.0a0'
-    libfreetype: '>=2.14.2'
-    libfreetype6: '>=2.14.2'
-    libglib: '>=2.86.4,<3.0a0'
-    libpng: '>=1.6.55,<1.7.0a0'
+    libexpat: '>=2.8.1,<3.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libglib: '>=2.88.2,<3.0a0'
+    libharfbuzz: '>=14.2.1'
+    libpng: '>=1.6.58,<1.7.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pango-1.56.4-hf80efc4_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pango-1.58.0-hf80efc4_0.conda
   hash:
-    md5: 4b433508ebb295c05dd3d03daf27f7bb
-    sha256: b57c59cf5abb06d407b3a79017b990ca5bfb10c15a10c62fc29e113f2b12d9a9
+    md5: 81bffd56a1dee786e084ca8d7bafb86d
+    sha256: dbe0796fba7ccdc4a6934010e92a78c6c06a35fe3975e08c617e99a2151b926a
   category: main
   optional: false
 - name: pango
-  version: 1.56.4
+  version: 1.58.0
   manager: conda
   platform: win-64
   dependencies:
     cairo: '>=1.18.4,<2.0a0'
-    fontconfig: '>=2.17.1,<3.0a0'
+    fontconfig: '>=2.18.2,<3.0a0'
     fonts-conda-ecosystem: ''
     fribidi: '>=1.0.16,<2.0a0'
-    harfbuzz: '>=13.2.1'
-    libexpat: '>=2.7.4,<3.0a0'
-    libfreetype: '>=2.14.2'
-    libfreetype6: '>=2.14.2'
-    libglib: '>=2.86.4,<3.0a0'
-    libpng: '>=1.6.55,<1.7.0a0'
+    libexpat: '>=2.8.1,<3.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libglib: '>=2.88.2,<3.0a0'
+    libharfbuzz: '>=14.2.1'
+    libpng: '>=1.6.58,<1.7.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/pango-1.56.4-h13911b6_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/pango-1.58.0-h13911b6_0.conda
   hash:
-    md5: 1f1cf3772ba7d4eef989e4679ddf97f7
-    sha256: 3d4e6e541e633f6fd22fc2c1d79ad5ec39503dea3ba04fc3e01d5be904ec7cea
+    md5: d706348be7393bbd156fc15ce1345587
+    sha256: c3124d2129e4df6b1fb170078f7400d94d844a4ffe951485dff36276ab60c616
   category: main
   optional: false
 - name: pcre2
@@ -6149,45 +6166,45 @@ package:
   category: main
   optional: false
 - name: pip
-  version: 26.1.2
+  version: '26.2'
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10,<3.13.0a0'
     setuptools: ''
     wheel: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-26.1.2-pyh8b19718_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-26.2-pyh8b19718_0.conda
   hash:
-    md5: 511fbc2c63d2c73650ad1755e4d357ba
-    sha256: 29b7d75bf81ad11645a8e320b369abdc90a92b93f2a9178e853d9dddf82e5106
+    md5: 2e8a3ed3e7935bd5e1729b6b27ed3f4e
+    sha256: bbbd59ac670c9d9882270cbd0744b2cc48e901af4b7067a509b2cb8c1552f175
   category: main
   optional: false
 - name: pip
-  version: 26.1.2
+  version: '26.2'
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10,<3.13.0a0'
     setuptools: ''
     wheel: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-26.1.2-pyh8b19718_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-26.2-pyh8b19718_0.conda
   hash:
-    md5: 511fbc2c63d2c73650ad1755e4d357ba
-    sha256: 29b7d75bf81ad11645a8e320b369abdc90a92b93f2a9178e853d9dddf82e5106
+    md5: 2e8a3ed3e7935bd5e1729b6b27ed3f4e
+    sha256: bbbd59ac670c9d9882270cbd0744b2cc48e901af4b7067a509b2cb8c1552f175
   category: main
   optional: false
 - name: pip
-  version: 26.1.2
+  version: '26.2'
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.10,<3.13.0a0'
     setuptools: ''
     wheel: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-26.1.2-pyh8b19718_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-26.2-pyh8b19718_0.conda
   hash:
-    md5: 511fbc2c63d2c73650ad1755e4d357ba
-    sha256: 29b7d75bf81ad11645a8e320b369abdc90a92b93f2a9178e853d9dddf82e5106
+    md5: 2e8a3ed3e7935bd5e1729b6b27ed3f4e
+    sha256: bbbd59ac670c9d9882270cbd0744b2cc48e901af4b7067a509b2cb8c1552f175
   category: main
   optional: false
 - name: pixman
@@ -6323,7 +6340,6 @@ package:
     libzlib: '>=1.3.1,<2.0a0'
     ncurses: '>=6.5,<7.0a0'
     openssl: '>=3.5.5,<4.0a0'
-    pip: ''
     readline: '>=8.3,<9.0a0'
     tk: '>=8.6.13,<8.7.0a0'
     tzdata: ''
@@ -6347,7 +6363,6 @@ package:
     libzlib: '>=1.3.1,<2.0a0'
     ncurses: '>=6.5,<7.0a0'
     openssl: '>=3.5.5,<4.0a0'
-    pip: ''
     readline: '>=8.3,<9.0a0'
     tk: '>=8.6.13,<8.7.0a0'
     tzdata: ''
@@ -6369,7 +6384,6 @@ package:
     libsqlite: '>=3.51.2,<4.0a0'
     libzlib: '>=1.3.1,<2.0a0'
     openssl: '>=3.5.5,<4.0a0'
-    pip: ''
     tk: '>=8.6.13,<8.7.0a0'
     tzdata: ''
     ucrt: '>=10.0.20348.0'
@@ -6543,6 +6557,51 @@ package:
   hash:
     md5: a8d735f3faf356a24acf9eea0a940a0f
     sha256: c0f0552a879e18282799431c7d2769b269839ac3b3735082e754df3c6fa0728d
+  category: main
+  optional: false
+- name: qt6-serialport
+  version: 6.11.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
+    libudev1: '>=257.13'
+    qt6-main: 6.11.1.*,>=6.11.1,<6.12.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/qt6-serialport-6.11.1-hf9e10ad_0.conda
+  hash:
+    md5: 8b51f2809f173257726b8f7c6875b4fb
+    sha256: 6765734ed7837b9c1b9ba80d2602d1d4eb24960d6702035b5c72a6cf1b8050c6
+  category: main
+  optional: false
+- name: qt6-serialport
+  version: 6.11.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=12.0'
+    libcxx: '>=19'
+    qt6-main: 6.11.1.*,>=6.11.1,<6.12.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/qt6-serialport-6.11.1-hc2b3133_0.conda
+  hash:
+    md5: b3aa2cdaa6c1045f38436c3c3c4065be
+    sha256: 6b8cf98eb56703612b1b435686f6cd827e7cf8d72ad7391c1f98ee66fa9e3bf9
+  category: main
+  optional: false
+- name: qt6-serialport
+  version: 6.11.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    qt6-main: 6.11.1.*,>=6.11.1,<6.12.0a0
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.3,<15'
+    vc14_runtime: '>=14.44.35208'
+  url: https://conda.anaconda.org/conda-forge/win-64/qt6-serialport-6.11.1-he453025_0.conda
+  hash:
+    md5: ebc47a137364b91ef536de15288e3fc9
+    sha256: cea7cea662e921468b26a359a704164c9ef9f209cb66943b54662f59dc9bbc37
   category: main
   optional: false
 - name: rav1e
@@ -6827,7 +6886,7 @@ package:
   category: main
   optional: false
 - name: shaderc
-  version: '2026.2'
+  version: '2026.3'
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -6835,10 +6894,10 @@ package:
     glslang: '>=16,<17.0a0'
     libcxx: '>=19'
     spirv-tools: '>=2026,<2027.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/shaderc-2026.2-hf31e910_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/shaderc-2026.3-h565cd3f_0.conda
   hash:
-    md5: 6e50dd641e624d5921f25a82aea39ae9
-    sha256: 97870b15002b9e78a169681655a148049cd1763d4062114155268e84b3ef8793
+    md5: dcba860d2b44c4bd7101e5d6cdef7639
+    sha256: 124051bbe2f7daa875f1612363a7b17f5aa8dbbd61ef18b9de64eef2733cd6ed
   category: main
   optional: false
 - name: shaderc
@@ -6954,16 +7013,16 @@ package:
   category: main
   optional: false
 - name: svt-av1
-  version: 4.0.1
+  version: 4.2.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-4.0.1-h0cb729a_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-4.2.0-h0cb729a_0.conda
   hash:
-    md5: 8badc3bf16b62272aa2458f138223821
-    sha256: bdef3c1c4d2a396ad4f7dc64c5e9a02d4c5a21ff93ed07a33e49574de5d2d18d
+    md5: 7d697f995ff16231780ae534ea0d5266
+    sha256: 182f692ddbcab92bf0992dcf853e8f82d626bcccf0f0dcf7aac995924b7fe796
   category: main
   optional: false
 - name: svt-av1
@@ -7114,48 +7173,48 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    vc14_runtime: '>=14.51.36231'
-  url: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_39.conda
+    vc14_runtime: '>=14.51.36247'
+  url: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-ha367084_41.conda
   hash:
-    md5: 2eacea63f545b97342da520df6854276
-    sha256: 17693b60cb54f80c60275f003f3bfc1b128af56dbfd65c4fae37c64eeb755ce1
+    md5: aa805b5522c2a98fa286e551a1f48546
+    sha256: 35444c55a92e2f7f7ba26bc70f81e56e52344f7d064c0fd4b40a46a58517b79c
   category: main
   optional: false
 - name: vc14_runtime
-  version: 14.51.36231
+  version: 14.51.36247
   manager: conda
   platform: win-64
   dependencies:
     ucrt: '>=10.0.20348.0'
-    vcomp14: 14.51.36231
-  url: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_39.conda
+    vcomp14: 14.51.36247
+  url: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36247-habf1de7_41.conda
   hash:
-    md5: 06a5bf5a1ca16cce0df6eaa91fc42bc2
-    sha256: 8153ed849c92e891eacac0f2f8d7ecb79f9b5fd7f7917fbb896f252a60a40390
+    md5: ac5333bb3d429361f23adf704cc49a78
+    sha256: 4e4cb599cdc41bf2109d1464c127b5bcbddf548ce3e322e612afb691338b48f8
   category: main
   optional: false
 - name: vcomp14
-  version: 14.51.36231
+  version: 14.51.36247
   manager: conda
   platform: win-64
   dependencies:
     ucrt: '>=10.0.20348.0'
-  url: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_39.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36247-habf1de7_41.conda
   hash:
-    md5: 8b53a83fda40ec679e4d63fa32fae989
-    sha256: 07fb14713c4bc62e2533a2e23a363abfb0e65650681fba0ae4c840e2219350f3
+    md5: 350bb67a5c8e5f1c53347ac544ab6600
+    sha256: 731e043390c9457299484d39e427221fc868a9249540a498a5a4f6456c7744d1
   category: main
   optional: false
 - name: vs2015_runtime
-  version: 14.51.36231
+  version: 14.51.36247
   manager: conda
   platform: win-64
   dependencies:
-    vc14_runtime: '>=14.51.36231'
-  url: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.51.36231-h84cd919_39.conda
+    vc14_runtime: '>=14.51.36247'
+  url: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.51.36247-h633cb9f_41.conda
   hash:
-    md5: 2ccc63d7b7d066a814ed9f99072832d7
-    sha256: 6de6c2cf008fc2dce61060b583f2d8494c83883106952b201381b6b0505f03d7
+    md5: 21504569fa34b5d3a67760219e3ff1cc
+    sha256: ee0ae67c96b80b9fdb50c3f617c6329dbcdf1562d0267604f6c0e24f494431d6
   category: main
   optional: false
 - name: wayland
@@ -7230,7 +7289,7 @@ package:
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/x264-1%21164.3095-h166bdaf_2.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
   hash:
     md5: 6c99772d483f566d59e25037fea2c4b1
     sha256: 175315eb3d6ea1f64a6ce470be00fa2ee59980108f246d3072ab8b977cb048a5
@@ -7241,7 +7300,7 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/x264-1%21164.3095-h57fd34a_2.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/x264-1!164.3095-h57fd34a_2.tar.bz2
   hash:
     md5: b1f6dccde5d3a1f911960b6e567113ff
     sha256: debdf60bbcfa6a60201b12a1d53f36736821db281a28223a09e0685edcce105a
@@ -7254,7 +7313,7 @@ package:
   dependencies:
     vc: '>=14.1,<15'
     vs2015_runtime: '>=14.16.27033'
-  url: https://conda.anaconda.org/conda-forge/win-64/x264-1%21164.3095-h8ffe710_2.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/win-64/x264-1!164.3095-h8ffe710_2.tar.bz2
   hash:
     md5: 19e39905184459760ccb8cf5c75f148b
     sha256: 97166b318f8c68ffe4d50b2f4bd36e415219eeaef233e7d41c54244dc6108249
@@ -7652,10 +7711,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.3,<15'
     vc14_runtime: '>=14.44.35208'
-  url: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.2-hfd05255_3.conda
   hash:
-    md5: 5187ecf958be3c39110fe691cbd6873e
-    sha256: ef408f85f664a4b9c9dac3cb2e36154d9baa15a88984ea800e11060e0f2394a1
+    md5: 945092a9bc1d0f250f7d5ecf51ecd471
+    sha256: 5a0b55df66ff07b4342e04967cef69f8bf348f6a0fb1cc1eca741c7b015dfe77
   category: main
   optional: false
 - name: zstd

--- a/packaging/conda-virtual-packages.yml
+++ b/packaging/conda-virtual-packages.yml
@@ -1,0 +1,29 @@
+# Virtual packages conda-lock should assume when solving the lock file
+# (RELEASING.md step 3). These mirror conda-lock's built-in defaults
+# (site-packages/conda_lock/default-virtual-packages.yaml) for the three
+# platforms we lock, with ONE change: __osx is raised from 11.0 to 12.0.
+#
+# Why: qt6-serialport (and possibly other Qt 6.11 packages) requires
+# __osx >= 12.0, so conda-lock's default of 11.0 makes the osx-arm64 solve
+# fail with "nothing provides __osx >= 12.0". macOS 12.0 is already the
+# app's real minimum - CMAKE_OSX_DEPLOYMENT_TARGET in CMakeLists.txt and
+# LSMinimumSystemVersion in packaging/macos/Info.plist.in - so the solver
+# should assume it too. Keep all three in step.
+subdirs:
+  linux-64:
+    packages:
+      __unix: "0"
+      __linux: "5.10"
+      __archspec: "1 x86_64"
+      __glibc: "2.28"
+      __cuda: "11.4"
+  osx-arm64:
+    packages:
+      __unix: "0"
+      __archspec: "1 arm64"
+      __osx: "12.0"
+  win-64:
+    packages:
+      __win: "0"
+      __archspec: "1 x86_64"
+      __cuda: "11.4"


### PR DESCRIPTION
Release-prep for v2.0.0, per RELEASING.md steps 2–3. After this merges, the release is cut by tagging `v2.0.0` on master (step 4).

## What's here

- **Changelog finalized** — the `[Unreleased]` header becomes `[2.0.0] — 2026-07-31`, so the release job's extracted notes carry the real version and date instead of "Unreleased". (Verified the `awk` extraction produces the section correctly with the new header.)
- **`conda-lock.yml` regenerated** — the lock predated `qt6-serialport=6.11` being added to `environment.yml` for the commutator, so the release's dependency snapshot was stale. The new lock pins `qt6-serialport 6.11.1` (with `qt6-main 6.11.1`, `libopencv 4.13.0`) on win-64, linux-64, and osx-arm64; other packages picked up patch-level bumps since July 23, which is the point of re-locking at release time.
- **New `packaging/conda-virtual-packages.yml`** (+ RELEASING.md command update) — regenerating the lock failed on osx-arm64: `qt6-serialport` requires `__osx >= 12.0` and conda-lock's default simulated macOS is 11.0. The spec mirrors conda-lock's defaults with `__osx` raised to 12.0 — already the app's true minimum (`CMAKE_OSX_DEPLOYMENT_TARGET` / `LSMinimumSystemVersion`). Without this file, RELEASING.md step 3 is not reproducible.
- **`check-version` rc fix** — the workflow documents that a `v2.0.0-rc1` tag publishes as a prerelease, but the guard compared the full tag (`2.0.0-rc1`) against the CMake version (`2.0.0`), which can never match since `project(VERSION)` only accepts numerics. Pre-release tags are now compared on their numeric part only; exact-match behavior for normal tags is unchanged.

## Not needed (already in place)

- `CMakeLists.txt` is already at `2.0.0`, so the tag guard will pass.
- Master CI is green on all three platforms as of PR #131's merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFED97LVqUze521U9N7PYB