### PR TITLE
README: add the macOS install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,23 @@ sudo udevadm control --reload-rules && sudo udevadm trigger   # then re-plug the
 ```
 
 > **Note on the Linux build.** The Miniscope is driven directly via **libuvc** on Linux (the kernel `uvcvideo` driver caches UVC control reads, so it can't return the live frame counter or BNO head-orientation data). The DeepLabCut-Live behavior tracker is **not** included in the AppImage. To build from source (and to enable the tracker with `-DUSE_PYTHON=ON`), see [`BUILD_LINUX.md`](BUILD_LINUX.md).
+
+## Installation (macOS, Apple Silicon)
+
+A **DMG** is published on the [Releases Page](https://github.com/Aharoni-Lab/Miniscope-DAQ-QT-Software/releases): `Miniscope-DAQ-<version>-macOS-arm64.dmg`. It is fully self-contained (Qt, OpenCV, and libusb are bundled). Open the DMG and drag **MiniscopeDAQ** into Applications (or anywhere else).
+
+**First launch.** The app is ad-hoc signed, not notarized, so macOS quarantines it on download and refuses to open it ("cannot verify the developer" or "is damaged" — both are the same quarantine flag). On macOS 15 and newer there is no click-through: the right-click → Open bypass is gone and "Open Anyway" in Privacy & Security requires an admin password. Clearing the flag from Terminal works for everyone and needs no admin rights:
+
+```bash
+# Point this at wherever you put the app (/Applications, ~/Applications, ...):
+xattr -dr com.apple.quarantine /Applications/MiniscopeDAQ.app
+
+# Verify - this MUST print nothing:
+xattr -r -l /Applications/MiniscopeDAQ.app | grep quarantine
+```
+
+Then open the app normally. This is a one-time step: once the flag is gone it stays gone, and every later launch just works.
+
+**First run** asks where to keep your user-config files and your recordings (defaulting to `~/Documents/Miniscope/…`), the same as on Linux and Windows.
+
+> **Note on the macOS build.** Miniscopes stream through a native AVFoundation/IOKit backend pinned to the scope's USB identity, so hot-plugging other cameras (or iPhone Continuity Camera) can't steal a Miniscope's slot mid-session. The DeepLabCut-Live behavior tracker is **not** included in the DMG. To build from source, and for the full first-launch/quarantine details, see [`BUILD_MACOS.md`](BUILD_MACOS.md).


### PR DESCRIPTION
v2.0.0 ships a DMG, but the README's installation docs stopped at Linux — a macOS user landing on the Releases page had no instructions. This adds an **Installation (macOS, Apple Silicon)** section matching the Windows/Linux ones:

- Download + drag-install from the DMG.
- The one-time quarantine clearing via `xattr -dr com.apple.quarantine` with a verification command — including the macOS 15+ reality that there is no GUI bypass for non-admin users (right-click → Open is gone; "Open Anyway" wants an admin password). Condensed from the bench-verified walkthrough in `BUILD_MACOS.md`.
- First-run data paths (`~/Documents/Miniscope`), matching the Linux section.
- A note on the AVFoundation/IOKit capture backend and the DeepLabCut-Live exclusion, mirroring the Linux note, with a pointer to `BUILD_MACOS.md`.

Docs-only; no code or release-artifact changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFED97LVqUze521U9N7PYB