### PR TITLE
Publish release metadata to the miniscope.org wiki on each tag

### DIFF
--- a/.github/workflows/sync-to-wiki.yml
+++ b/.github/workflows/sync-to-wiki.yml
@@ -1,0 +1,45 @@
+# Publish this repo's wiki.yml metadata to the miniscope.org wiki on every
+# release tag, via labki-org/wiki-repo-bridge (same setup as miniscope/MiniXL).
+# Each tag writes an immutable Release page under
+# "Miniscope DAQ QT software/Release/<version>"; the top-level project page is
+# human-curated and never rewritten.
+#
+# Secrets: WIKI_REPO_BOT_USER / WIKI_REPO_BOT_PASSWORD must hold a miniscope.org
+# bot account (Special:BotPasswords) with edit rights.
+name: Sync to wiki
+
+on:
+  # Run automatically when a release tag is pushed
+  push:
+    tags: ['v*']
+
+  # Manual runs from the Actions tab: retro-sync an existing tag (e.g. the
+  # v2.0.0 that predates this workflow) or test with a dry run.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Tag to sync (defaults to the workflow's ref).
+        required: false
+        type: string
+      dry_run:
+        description: Plan and print only, don't write to the wiki.
+        required: false
+        type: boolean
+        default: true
+      changelog:
+        description: Optional changelog text for the Release page.
+        required: false
+        type: string
+
+jobs:
+  sync:
+    uses: labki-org/wiki-repo-bridge/.github/workflows/sync.yml@main
+    with:
+      wikis: |
+        https://miniscope.org/api.php
+      tag: ${{ inputs.tag }}
+      dry_run: ${{ inputs.dry_run || false }}
+      changelog: ${{ inputs.changelog || '' }}
+    secrets:
+      WIKI_REPO_BOT_USER: ${{ secrets.WIKI_REPO_BOT_USER }}
+      WIKI_REPO_BOT_PASSWORD: ${{ secrets.WIKI_REPO_BOT_PASSWORD }}

--- a/wiki.yml
+++ b/wiki.yml
@@ -1,0 +1,33 @@
+# Project metadata synced to the miniscope.org wiki by wiki-repo-bridge
+# (https://github.com/labki-org/wiki-repo-bridge) on every release tag - see
+# .github/workflows/sync-to-wiki.yml. Each tag writes an immutable
+# "Miniscope DAQ QT software/Release/<version>" page (with this repo's README
+# snapshotted onto it); the top-level project page already exists on the wiki
+# and is human-curated, so the bridge never rewrites it.
+#
+# `name` must stay exactly "Miniscope DAQ QT software": it anchors the whole
+# wiki page tree to https://miniscope.org/wiki/Miniscope_DAQ_QT_software.
+
+kind: project
+name: Miniscope DAQ QT software
+description: |
+  Neural and behavior control and recording software for the UCLA Miniscope
+  Project. Desktop application (Windows, Linux, macOS) for streaming,
+  viewing, and recording Miniscope and behavior-camera data, with live
+  device control, head-orientation tracking, and Open Ephys commutator
+  support. In maintenance: it will be superseded long-term by the
+  miniscope-io SDK.
+
+project_status: Maintained
+repository_url: https://github.com/Aharoni-Lab/Miniscope-DAQ-QT-Software
+license: GPL-3.0
+responsible_party: Aharoni Lab
+
+features:
+  - Multi-camera acquisition — Miniscopes and behavior cameras in one session
+  - Live device control (LED, focus, gain) with per-config window layouts
+  - Lossless (GREY/FFV1) and lossy recording codecs per device
+  - DAQ hardware frame-counter logging for post-hoc frame-drop detection
+  - BNO head-orientation streaming and Open Ephys commutator control
+  - JSON user configs with schema validation and an in-app form editor
+  - Packaged releases: Windows installer/zip, Linux AppImage, macOS DMG


### PR DESCRIPTION
Wires this repo into [labki-org/wiki-repo-bridge](https://github.com/labki-org/wiki-repo-bridge), mirroring the working setup in [miniscope/MiniXL](https://github.com/miniscope/MiniXL): a root `wiki.yml` project declaration plus a thin workflow that calls the bridge's reusable sync on every `v*` tag.

## What a tag sync writes

Verified with a dry run against the live wiki (schema fetched from miniscope.org, `plan_sync` on this branch's tree):

- **`Miniscope DAQ QT software/Release/<version>`** — a new immutable Release page per tag: version, date, tag, artifact URL pinned to the tag, changelog, and this repo's README converted to wikitext and snapshotted.
- **`Miniscope DAQ QT software`** — the existing project page is *bootstrap-only*: the bridge writes it only when it doesn't exist. It exists (and is human-curated), so the bridge will never touch it. `wiki.yml`'s `name` must stay exactly `Miniscope DAQ QT software` since it anchors the page tree.

Validation against miniscope.org's installed SemanticSchemas schema (2 categories, 26 properties) passes with no issues.

## Manual runs

`workflow_dispatch` accepts a `tag` (to retro-sync tags that predate this workflow — v2.0.0), a `dry_run` flag (**default true**, so a manual run is safe by default), and optional `changelog` text for the Release page.

## Before the first live run

The repo (or org) needs two Actions secrets holding a miniscope.org bot account (`Special:BotPasswords`) with edit rights:

- `WIKI_REPO_BOT_USER`
- `WIKI_REPO_BOT_PASSWORD`

## Follow-up after merge

1. Add the secrets above.
2. Actions → "Sync to wiki" → Run workflow with `tag=v2.0.0` and `dry_run=true`; check the log.
3. Re-run with `dry_run=false` and `changelog=Release notes: https://github.com/Aharoni-Lab/Miniscope-DAQ-QT-Software/releases/tag/v2.0.0` to publish the v2.0.0 Release page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFED97LVqUze521U9N7PYB