### PR TITLE
Wiki sync: read the WIKI_REPO_MINISCOPE_BOT_* secret names

### DIFF
--- a/.github/workflows/sync-to-wiki.yml
+++ b/.github/workflows/sync-to-wiki.yml
@@ -4,8 +4,9 @@
 # "Miniscope DAQ QT software/Release/<version>"; the top-level project page is
 # human-curated and never rewritten.
 #
-# Secrets: WIKI_REPO_BOT_USER / WIKI_REPO_BOT_PASSWORD must hold a miniscope.org
-# bot account (Special:BotPasswords) with edit rights.
+# Secrets: WIKI_REPO_MINISCOPE_BOT_USER / WIKI_REPO_MINISCOPE_BOT_PASSWORD must
+# hold a miniscope.org bot account (Special:BotPasswords) with edit rights —
+# the same secret names miniscope/MiniXL uses for its miniscope.org credentials.
 name: Sync to wiki
 
 on:
@@ -41,5 +42,5 @@ jobs:
       dry_run: ${{ inputs.dry_run || false }}
       changelog: ${{ inputs.changelog || '' }}
     secrets:
-      WIKI_REPO_BOT_USER: ${{ secrets.WIKI_REPO_BOT_USER }}
-      WIKI_REPO_BOT_PASSWORD: ${{ secrets.WIKI_REPO_BOT_PASSWORD }}
+      WIKI_REPO_BOT_USER: ${{ secrets.WIKI_REPO_MINISCOPE_BOT_USER }}
+      WIKI_REPO_BOT_PASSWORD: ${{ secrets.WIKI_REPO_MINISCOPE_BOT_PASSWORD }}


### PR DESCRIPTION
The Actions secrets were added as `WIKI_REPO_MINISCOPE_BOT_USER` / `WIKI_REPO_MINISCOPE_BOT_PASSWORD` (matching miniscope/MiniXL's naming for its miniscope.org credential pair), but the workflow mapped the generic `WIKI_REPO_BOT_*` names into the reusable sync — so the first dry-run dispatch failed with "credentials for slot 'default' are not set" before contacting the wiki. This points the mapping at the actual secret names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFED97LVqUze521U9N7PYB